### PR TITLE
Add `make` option to generate automated doc, some polishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *.log
 **/.DS_Store
 .dars/
+.docs/
 .vscode/

--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,12 @@ headers-check:
 .PHONY: headers-update
 headers-update:
 	./scripts/dade-copyright-headers.py update
+
+DAML_SRC:=$(shell find src/main/daml -name '*.daml')
+
+.PHONY: doc
+doc: $(DAML_SRC)
+	daml damlc docs --format html \
+    --exclude-instances=HasField,HasImplementation,HasMethod,HasFromInterface,HasToInterface \
+    --drop-orphan-instances \
+    --output .docs $(DAML_SRC)

--- a/src/main/daml/Daml/Finance/Common/Date/DayCount.daml
+++ b/src/main/daml/Daml/Finance/Common/Date/DayCount.daml
@@ -34,8 +34,7 @@ calcDcf Act360 f t = calcDcfAct360 f t
 calcDcf Act365_Fixed f t = calcDcfAct365Fixed f t
 calcDcf Basis_30360 f t = calcDcf30360 f t
 calcDcf Basis_30360_ICMA f t = calcDcf30360Icma f t
-calcDcf Basis_30E3360 f t = calcDcf30E360 False f t
-  -- ^ this corresponds to 30E/360 without the maturity date adjustment
+calcDcf Basis_30E3360 f t = calcDcf30E360 False f t -- this corresponds to 30E/360 without the maturity date adjustment
 calcDcf Basis_30E360 f t = error "This calculation requires the knowledge of the maturity date of the product. Please, use `calcDcf30E360 instead`."
 
 -- | HIDE

--- a/src/main/daml/Daml/Finance/Interface/Asset/Account.daml
+++ b/src/main/daml/Daml/Finance/Interface/Asset/Account.daml
@@ -3,6 +3,7 @@
 
 {-# LANGUAGE AllowAmbiguousTypes #-}
 
+-- | We recommend to import this module qualified.
 module Daml.Finance.Interface.Asset.Account where
 
 import Daml.Finance.Interface.Asset.Factory.Holding qualified as Holding (F)
@@ -13,13 +14,29 @@ import Daml.Finance.Interface.Common.Disclosure qualified as Disclosure (GetView
 import Daml.Finance.Interface.Common.Types (Observers)
 import Daml.Finance.Interface.Common.Util (exerciseInterfaceByKeyHelper, flattenObservers)
 
+-- | Type synonym for `Account`.
 type I = Account
+
+-- | Type synonym for `AccountKey`.
 type K = AccountKey
+
+-- | Type synonym for `Reference`. This type is currently used as a work-around given the lack of interface keys.
 type R = Reference
+
+-- | Type synonym for `View`.
 type V = View
 
--- | Exercise interface by key
-exerciseInterfaceByKey : forall t2 d r. (HasExercise t2 d r) => K -> Party -> d -> Update r
+-- | Exercise interface by key.
+-- This method can be used to exercise a choice on an `Account` given its `AccountKey`.
+-- Requires as input the `AccountKey`, the actor fetching the account and the choice arguments. For example:
+-- ```
+-- exerciseInterfaceByKey @Account.I accountKey actor Account.Debit with holdingCid
+-- ```
+exerciseInterfaceByKey : forall t2 d r. (HasExercise t2 d r)
+  => K          -- ^ The account key.
+  -> Party      -- ^ The actor fetching the account.
+  -> d          -- ^ The choice arguments.
+  -> Update r
 exerciseInterfaceByKey k actor arg = exerciseInterfaceByKeyHelper @R @t2 k (GetCid with viewer = actor) arg
 
 -- | View for `Account`.
@@ -35,12 +52,11 @@ data View = View
       -- ^ Associated holding factory.
   deriving (Eq, Ord, Show)
 
--- | Convert the account's 'View' to its key
+-- | Convert the account's 'View' to its key.
 toKey : View -> AccountKey
 toKey v = AccountKey with custodian = v.custodian; owner = v.owner; id = v.id
 
--- | An interface which respresents an established relationship between multiple parties
--- and/or a specific grouping of assets.
+-- | An interface which represents an established relationship between a provider and an owner.
 interface Account where
   asDisclosure : Disclosure.I
     -- ^ Conversion to `Disclosure` interface.
@@ -87,7 +103,8 @@ instance HasToInterface I Disclosure.I where _toInterface = asDisclosure
 class (Implementation t) => HasImplementation t
 instance HasImplementation I
 
--- | This template is used to key an Account contract. It allows for looking up this contract
+-- | HIDE
+-- This template is used to key an Account contract. It allows for looking up this contract
 -- by key then acquiring the Account contract by fetching its contract id on this contract.
 -- As updates are made to an Account, this Reference contract is required to be kept in sync.
 template Reference
@@ -112,32 +129,34 @@ template Reference
       do
         pure cid
 
-    -- | HIDE
-    -- Only to be called from the interface implementation.
     choice SetCid : ContractId Reference
+      -- ^ Set the account cid. This choice should be called only from `Account` implementations.
       with
         newCid : ContractId Account
+          -- ^ The account cid.
       controller accountView.custodian, accountView.owner
       do
         create this with cid = newCid
 
-    -- | HIDE
-    -- Only to be called from the interface implementation.
     choice SetObservers : ContractId Reference
+      -- ^ Set observers. This choice should be called only from `Account` implementations.
       with
         newObservers : Observers
+          -- ^ The new observers.
       controller accountView.custodian, accountView.owner
       do
         create this with observers = newObservers
 
--- | Create Reference for the account
+-- | HIDE
+-- Create Reference for the account
 createReference : Party -> ContractId Account -> Update (ContractId Reference)
 createReference actor cid = do
   accountView <- exercise cid GetView with viewer = actor
   disclosureView <- exercise (toInterfaceContractId @Disclosure.I cid) Disclosure.GetView with viewer = actor
   create Reference with accountView; cid; observers = disclosureView.observers
 
--- | Helper function to update the acount reference once observers are added to the account.
+-- | HIDE
+-- Helper function to update the account reference once observers are added to the account.
 disclosureUpdateReference : Observers -> AccountKey -> ContractId Account -> Update (ContractId Disclosure.I)
 disclosureUpdateReference newObservers k iCid = do
   exerciseByKey @Reference k SetCid with newCid = iCid

--- a/src/main/daml/Daml/Finance/Interface/Asset/Factory/Account.daml
+++ b/src/main/daml/Daml/Finance/Interface/Asset/Factory/Account.daml
@@ -9,12 +9,14 @@ import Daml.Finance.Interface.Asset.Types (AccountKey(..))
 import Daml.Finance.Interface.Common.Disclosure qualified as Disclosure (I, Implementation)
 import Daml.Finance.Interface.Common.Types (Observers)
 
+-- | Type synonym for `Factory`.
 type F = Factory
 
 -- View of `Factory`.
 data View = View
   with
     provider : Party
+      -- ^ The provider of the `Factory`.
   deriving (Eq, Ord, Show)
 
 -- | Interface that allows implementing templates to create accounts.
@@ -28,10 +30,8 @@ interface Factory where
   removeImpl : Remove -> Update ()
     -- ^ Implementation of `Remove` choice.
 
-  -- | HIDE
-  -- Only to be called from interface implementations.
   nonconsuming choice Create : ContractId Account.I
-    -- ^ Creates a new account.
+    -- ^ Create a new account.
     with
       account : AccountKey
         -- ^ The account's key.
@@ -43,11 +43,11 @@ interface Factory where
     do
       createImpl this arg
 
-  -- | HIDE
-  -- Only to be called from interface implementations.
   nonconsuming choice Remove : ()
+    -- ^ Archive an account.
     with
       account : AccountKey
+        -- ^ The account's key.
     controller account.custodian, account.owner
       do
         removeImpl this arg

--- a/src/main/daml/Daml/Finance/Interface/Asset/Factory/Holding.daml
+++ b/src/main/daml/Daml/Finance/Interface/Asset/Factory/Holding.daml
@@ -8,12 +8,14 @@ import Daml.Finance.Interface.Asset.Types (AccountKey, InstrumentKey)
 import Daml.Finance.Interface.Common.Disclosure qualified as Disclosure (I, Implementation)
 import Daml.Finance.Interface.Common.Types (Observers, Parties)
 
+-- | Type synonym for `Factory`.
 type F = Factory
 
 -- View of `Factory`.
 data View = View
   with
     provider : Party
+      -- ^ The provider of the `Factory`.
   deriving (Eq, Ord, Show)
 
 -- | Holding factory contract used to create (credit) and archive (debit) holdings.
@@ -27,9 +29,8 @@ interface Factory where
   removeImpl : Remove -> Update ()
     -- ^ Implementation of `Remove` choice.
 
-  -- | HIDE
-  -- Only to be called from interface implementations.
   nonconsuming choice Create : ContractId Holding.I
+    -- ^ Create a holding on the instrument in the corresponding account.
     with
       instrument : InstrumentKey
         -- ^ The instrument of which units are held.
@@ -44,9 +45,8 @@ interface Factory where
         assertMsg "amount must be positive" $ amount > 0.0
         createImpl this arg
 
-  -- | HIDE
-  -- Only to be called from interface implementations.
   nonconsuming choice Remove : ()
+    -- ^ Archive a holding.
     with
       actors : Parties
         -- ^ The parties authorizing the removal.

--- a/src/main/daml/Daml/Finance/Interface/Asset/Fungible.daml
+++ b/src/main/daml/Daml/Finance/Interface/Asset/Fungible.daml
@@ -13,7 +13,10 @@ import Daml.Finance.Interface.Common.Disclosure qualified as Disclosure (I)
 import Daml.Finance.Interface.Common.Types (Parties)
 import Daml.Finance.Interface.Common.Util (verify)
 
+-- | Type synonym for `Fungible`.
 type I = Fungible
+
+-- | Type synonym for `View`.
 type V = View
 
 -- | View for `Fungible`.

--- a/src/main/daml/Daml/Finance/Interface/Asset/Holding.daml
+++ b/src/main/daml/Daml/Finance/Interface/Asset/Holding.daml
@@ -6,18 +6,21 @@ module Daml.Finance.Interface.Asset.Holding where
 import Daml.Finance.Interface.Asset.Types (AccountKey, InstrumentKey)
 import Daml.Finance.Interface.Common.Disclosure qualified as Disclosure (I, Implementation)
 
+-- | Type synonym for `Holding`.
 type I = Holding
+
+-- | Type synonym for `View`.
 type V = View
 
 -- | View for `Holding`.
 data View = View
   with
     instrument : InstrumentKey
-      -- ^ Instrument being held
+      -- ^ Instrument being held.
     account : AccountKey
-      -- ^ Key of the account holding the assets
+      -- ^ Key of the account holding the assets.
     amount : Decimal
-      -- ^ Size of the holding
+      -- ^ Size of the holding.
   deriving (Eq, Ord, Show)
 
 -- | Base interface for a holding.

--- a/src/main/daml/Daml/Finance/Interface/Asset/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Interface/Asset/Instrument.daml
@@ -118,7 +118,7 @@ template Reference
       do
         create this with observers = newObservers
 
--- | Convert the instrument's View to its key
+-- | Convert the instrument's View to its key.
 toKey : View -> InstrumentKey
 toKey v = InstrumentKey with depository = v.depository; issuer = v.issuer; id = v.id
 
@@ -126,19 +126,19 @@ toKey v = InstrumentKey with depository = v.depository; issuer = v.issuer; id = 
 qty : Decimal -> InstrumentKey -> Quantity InstrumentKey Decimal
 qty amount instrument = Quantity with unit = instrument; amount
 
--- | Scale `Quantity` by the provided factor
+-- | Scale `Quantity` by the provided factor.
 scale : Decimal -> Quantity InstrumentKey Decimal -> Quantity InstrumentKey Decimal
 scale factor quantity = quantity with amount = quantity.amount * factor
 
 -- | HIDE
--- Create Reference for instrument
+-- Create Reference for instrument.
 createReference : Party -> ContractId Instrument -> Update (ContractId Reference)
 createReference actor cid = do
   instrumentView <- exercise cid GetView with viewer = actor
   disclosureView <- exercise (toInterfaceContractId @Disclosure.I cid) Disclosure.GetView with viewer = actor
   create Reference with instrumentView; cid; observers = disclosureView.observers
 
--- HIDE
+-- | HIDE
 -- Helper function to update the instrument reference once observers are added to the instrument.
 disclosureUpdateReference : Observers -> InstrumentKey -> ContractId Instrument -> Update (ContractId Disclosure.I)
 disclosureUpdateReference newObservers k iCid = do

--- a/src/main/daml/Daml/Finance/Interface/Asset/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Interface/Asset/Instrument.daml
@@ -10,14 +10,29 @@ import Daml.Finance.Interface.Common.Disclosure qualified as Disclosure (GetView
 import Daml.Finance.Interface.Common.Types (Observers)
 import Daml.Finance.Interface.Common.Util (exerciseInterfaceByKeyHelper, flattenObservers)
 
+-- | Type synonym for `Instrument`.
 type I = Instrument
+
+-- | Type synonym for `InstrumentKey`.
 type K = InstrumentKey
+
+-- | Type synonym for `Quantity`.
 type Q = Quantity InstrumentKey Decimal
+
+-- | Type synonym for `Reference`. This type is currently used as a work-around given the lack of interface keys.
 type R = Reference
+
+-- | Type synonym for `View`.
 type V = View
 
--- | Exercise interface by key
-exerciseInterfaceByKey : forall t2 d r. (HasExercise t2 d r) => InstrumentKey -> Party -> d -> Update r
+-- | Exercise interface by key.
+-- This method can be used to exercise a choice on an `Instrument` given its `InstrumentKey`.
+-- Requires as input the `InstrumentKey`, the actor fetching the instrument and the choice arguments. For example:
+exerciseInterfaceByKey : forall t2 d r. (HasExercise t2 d r)
+  => K          -- ^ The instrument key.
+  -> Party      -- ^ The actor fetching the instrument.
+  -> d          -- ^ The choice arguments.
+  -> Update r
 exerciseInterfaceByKey k actor arg = exerciseInterfaceByKeyHelper @R @t2 k (GetCid with viewer = actor) arg
 
 -- | View for `Instrument`.
@@ -58,7 +73,8 @@ instance HasToInterface I Disclosure.I where _toInterface = asDisclosure
 class (Implementation t) => HasImplementation t
 instance HasImplementation I
 
--- | This template is used to key an Instrument contract. It allows for looking up this contract
+-- | HIDE
+-- This template is used to key an Instrument contract. It allows for looking up this contract
 -- by key then acquiring the Instrument contract by fetching its contract id on this contract.
 -- As updates are made to an Instrument, this Reference contract is required to be kept in sync.
 template Reference
@@ -84,30 +100,23 @@ template Reference
       do
         pure cid
 
-    -- | HIDE
-    -- Only to be called from the interface implementation.
     choice SetCid : ContractId Reference
+      -- ^ Set the instrument cid. This choice should be called only from `Instrument` implementations.
       with
         newCid : ContractId Instrument
+          -- The instrument cid.
       controller instrumentView.depository, instrumentView.issuer
       do
         create this with cid = newCid
 
-    -- | HIDE
-    -- Only to be called from the interface implementation.
     choice SetObservers : ContractId Reference
+      -- ^ Set observers. This choice should be called only from `Instrument` implementations.
       with
         newObservers : Observers
+          -- ^ The new observers.
       controller instrumentView.depository, instrumentView.issuer
       do
         create this with observers = newObservers
-
--- | Create Reference for instrument
-createReference : Party -> ContractId Instrument -> Update (ContractId Reference)
-createReference actor cid = do
-  instrumentView <- exercise cid GetView with viewer = actor
-  disclosureView <- exercise (toInterfaceContractId @Disclosure.I cid) Disclosure.GetView with viewer = actor
-  create Reference with instrumentView; cid; observers = disclosureView.observers
 
 -- | Convert the instrument's View to its key
 toKey : View -> InstrumentKey
@@ -121,7 +130,16 @@ qty amount instrument = Quantity with unit = instrument; amount
 scale : Decimal -> Quantity InstrumentKey Decimal -> Quantity InstrumentKey Decimal
 scale factor quantity = quantity with amount = quantity.amount * factor
 
--- | Helper function to update the instrument reference once observers are added to the instrument.
+-- | HIDE
+-- Create Reference for instrument
+createReference : Party -> ContractId Instrument -> Update (ContractId Reference)
+createReference actor cid = do
+  instrumentView <- exercise cid GetView with viewer = actor
+  disclosureView <- exercise (toInterfaceContractId @Disclosure.I cid) Disclosure.GetView with viewer = actor
+  create Reference with instrumentView; cid; observers = disclosureView.observers
+
+-- HIDE
+-- Helper function to update the instrument reference once observers are added to the instrument.
 disclosureUpdateReference : Observers -> InstrumentKey -> ContractId Instrument -> Update (ContractId Disclosure.I)
 disclosureUpdateReference newObservers k iCid = do
   exerciseByKey @Reference k SetCid with newCid = iCid

--- a/src/main/daml/Daml/Finance/Interface/Asset/Lockable.daml
+++ b/src/main/daml/Daml/Finance/Interface/Asset/Lockable.daml
@@ -11,7 +11,10 @@ import Daml.Finance.Interface.Common.Disclosure qualified as Disclosure (I)
 import Daml.Finance.Interface.Common.Types (Parties)
 import Daml.Finance.Interface.Common.Util (verify)
 
+-- | Type synonym for `Lockable`.
 type I = Lockable
+
+-- | Type synonym for `View`.
 type V = View
 
 -- | Type of lock held.

--- a/src/main/daml/Daml/Finance/Interface/Common/Disclosure.daml
+++ b/src/main/daml/Daml/Finance/Interface/Common/Disclosure.daml
@@ -10,6 +10,7 @@ import DA.Traversable qualified as T (mapA)
 import Daml.Finance.Interface.Common.Types (Observers, Parties)
 import Prelude hiding (null)
 
+-- | Type synonym for `Disclosure`.
 type I = Disclosure
 
 -- | View for `Disclosure`.
@@ -69,7 +70,7 @@ interface Disclosure where
 
   nonconsuming choice RemoveObservers : Optional (ContractId Disclosure)
     -- ^ Remove an observer context from the existing observers.
-    -- Any party can undisclose itself. None is returned iff no update is needed.
+    -- Any party can undisclose itself. None is returned if no update is needed.
     with
       observersToRemove : (Text, Parties)
         -- ^ Observer context to remove.

--- a/src/main/daml/Daml/Finance/Interface/Common/Util.daml
+++ b/src/main/daml/Daml/Finance/Interface/Common/Util.daml
@@ -6,7 +6,6 @@
 module Daml.Finance.Interface.Common.Util
   ( exerciseInterfaceByKeyHelper
   , fetchInterfaceByKey
-  , fetchThenExerciseInterfaceByKey
   , flattenObservers
   , verify
   ) where
@@ -22,13 +21,8 @@ fetchInterfaceByKey k = do
   d <- snd <$> fetchByKey @t k
   fetch $ coerceContractId d.cid
 
--- | Fetch then exercise (similar to exerciseInterfaceByKey but with different authorization)
-fetchThenExerciseInterfaceByKey : forall t k i c r. (HasFetchByKey t k, HasField "cid" t (ContractId i), Choice i c r, HasExercise i c r) => k -> c -> Update r
-fetchThenExerciseInterfaceByKey k choiceData = do
-  d <- snd <$> fetchByKey @t k
-  exercise d.cid choiceData
-
--- | Utility for exercising interface by key
+-- | HIDE
+-- Utility function for exercising interface by key.
 exerciseInterfaceByKeyHelper : forall t1 t2 t k c d r. (HasExerciseByKey t1 k c (ContractId t), HasExercise t2 d r) => k -> c -> d -> Update r
 exerciseInterfaceByKeyHelper k arg1 arg2 = do
   cid : ContractId t <- exerciseByKey @t1 k arg1
@@ -39,7 +33,10 @@ exerciseInterfaceByKeyHelper k arg1 arg2 = do
 verify : CanAssert m => Bool -> Text -> m ()
 verify = flip assertMsg
 
--- | Flatten observers
+-- | Flattens observers into a `Set Party` for usage in template definitions. For example:
+-- ```
+-- observer $ flattenObservers observers
+-- ```
 flattenObservers : Observers -> Parties
 flattenObservers (observers : Observers) =
   S.fromList $ concatMap (\t -> concatMap S.toList (S.toList t._2)) (M.toList observers)


### PR DESCRIPTION
This is not yet included in the Ci, but I wanted to try how it looks like. 

Changes:
- hide some functions involving account and instrument references
- add comment to type synonyms (if you agree this makes sense I will do it across the library, otherwise will remove it)
- removed one unused function

There are a couple of quirks when generating doc for interfaces, which we should raise:
- interface methods don't seem to be displayed nicely (**bold** is not taken into account)
- interface methods are also duplicated as functions
- Plenty of extra type-classes are displayed (and the fact that we use `I` for all interfaces makes things confusing)

It is an open point where this docs should be hosted and how it gets integrated with the SDK doc. What currently happens is the following:
- doc for the standard library is generated using `daml damlc docs` and exported to some json format
- the output json is used in the Sphinx doc build, which is then used to produce [https://docs.daml.com/](https://docs.daml.com/)

One option could be:
- as part of our release, we produce the doc in json format
- this gets downloaded from the main doc build in the daml repo

As an alternative:
- we copy over the styling and host on a separate website on our side --> this would ensure that the doc gets updated whenever we release Daml Finance (also if there is no SDK release) 