### PR TITLE
Add observers to `Instructable`, introduce flexible controller

### DIFF
--- a/src/main/daml/Daml/Finance/Interface/Settlement/Instructable.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Instructable.daml
@@ -14,8 +14,10 @@ type V = View
 -- | View for `Instructable`.
 data View = View
   with
-    requestors : Parties
-      -- ^ Party requesting to instruct a settlement.
+    provider : Party
+      -- ^ Party providing the facility to create settlement instructions.
+    observers : Parties
+      -- ^ Observers.
   deriving (Eq, Ord, Show)
 
 -- | An interface used to generate settlement instructions.
@@ -37,13 +39,15 @@ interface Instructable where
   nonconsuming choice Instruct : (ContractId Settleable.I, [ContractId Instruction.I])
     --  ^ Generate settlement instructions. It returns the `Instruction`s as well as a container to batch-settle them.
     with
+      instructors : Parties
+        -- ^ Parties requesting to instruct a settlement.
       settler : Party
-        -- ^ Party to instruct the settlement.
+        -- ^ Party that triggers the final settlement.
       id : Text
         -- ^ A textual identifier.
       steps : [Step]
-        -- ^ Settlement steps to execute.
-    controller (view this).requestors
+        -- ^ Settlement steps to instruct.
+    controller instructors
     do
       instructImpl this arg
 

--- a/src/main/daml/Daml/Finance/Lifecycle/SettlementRule.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/SettlementRule.daml
@@ -4,7 +4,7 @@
 module Daml.Finance.Lifecycle.SettlementRule where
 
 import DA.Foldable (forA_)
-import DA.Set (member)
+import DA.Set (fromList, member)
 import Daml.Finance.Interface.Asset.Account qualified as Account (exerciseInterfaceByKey, Debit(..), Credit(..), I)
 import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (qty)
 import Daml.Finance.Interface.Asset.Util (getAccount, getAmount, getCustodian, getInstrument, getOwner)
@@ -85,7 +85,7 @@ template Rule
         newInstrumentHoldingCids <- fmap sequence . mapA updateInstrumentHolding $ zip holdings holdingCids
 
         -- Generate settlement instructions for other instruments
-        (settleableCid, instructionCids) <- exercise instructableCid Instructable.Instruct with settler; id = effectView.id; steps
+        (settleableCid, instructionCids) <- exercise instructableCid Instructable.Instruct with instructors = fromList [custodian, owner] ;settler; id = effectView.id; steps
         pure SettlementRule.ClaimResult with
           newInstrumentHoldingCids
           containerCid = settleableCid

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -77,21 +77,24 @@ template Batch
 -- A batch is made of a set of `Instruction`s, as well as a container template used to atomically settle them.
 template BatchFactory
   with
-    requestors : Parties
-      -- ^ Party requesting the settlement
+    provider : Party
+      -- ^ Party providing the facility to create settlement instructions.
+    observers : Parties
+      -- ^ Observers.
   where
-    signatory requestors
+    signatory provider
+    observer observers
 
     implements Instructable.I where
-      view = Instructable.View with requestors
-      instructImpl Instructable.Instruct{settler; id; steps} = do
+      view = Instructable.View with provider; observers
+      instructImpl Instructable.Instruct{instructors; settler; id; steps} = do
         let
           createInstruction step index = let idUsed = id <> "-" <> show index in
-            Instruction with requestors; signed = empty; settler; step; allocation = None; account = None; id = idUsed; observers = M.fromList [(idUsed, singleton $ singleton settler)]
+            Instruction with requestors = instructors; signed = empty; settler; step; allocation = None; account = None; id = idUsed; observers = M.fromList [(idUsed, singleton $ singleton settler)]
           instructions = mapWithIndex createInstruction steps
           instructionIds = map (.id) instructions
         instructionCids <- mapA (fmap toInterfaceContractId . create) instructions
-        settleableCid <- toInterfaceContractId <$> create Batch with requestors; settler; id; stepsWithInstructionId = zip steps instructionIds
+        settleableCid <- toInterfaceContractId <$> create Batch with requestors = instructors; settler; id; stepsWithInstructionId = zip steps instructionIds
         pure (settleableCid, instructionCids)
 
 -- | Factory template that implements the `Instructable` interface and is used to create a settlement batch.
@@ -99,16 +102,19 @@ template BatchFactory
 -- For each instrument to settle as part of the batch, a hierarchy of intermediaries is specified in `paths`. This hierarchy is used to generate settlement instructions.
 template BatchFactoryWithIntermediaries
   with
-    requestors : Parties
-      -- ^ Parties requesting the settlement.
+    provider : Party
+      -- ^ Party providing the facility to create settlement instructions.
+    observers : Parties
+      -- ^ Observers.
     paths : M.Map Text Path
       -- ^ Hierarchical paths used to settle holding transfers. A path is specified for each instrument label.
   where
-    signatory requestors
+    signatory provider
+    observer observers
 
     implements Instructable.I where
-      view = Instructable.View with requestors
-      instructImpl Instructable.Instruct{settler; id; steps} = do
+      view = Instructable.View with provider; observers
+      instructImpl Instructable.Instruct{instructors; settler; id; steps} = do
         let
           -- Group steps by instrument. For each group, lookup corresponding paths and expand steps according to the corresponding settlement route.
           groupedSteps = mconcat $ fromSomeNote "Could not find path or route." $ mapA (\steps -> do
@@ -118,11 +124,11 @@ template BatchFactoryWithIntermediaries
             ) $ groupOn (.quantity.unit) steps
           -- For each step, generate instructions and ids.
           createInstruction step index = let idUsed = id <> "-" <> show index in
-            Instruction with requestors; signed = empty; settler; step; allocation = None; account = None; id = idUsed; observers = M.fromList [(idUsed, singleton $ singleton settler)]
+            Instruction with requestors = instructors; signed = empty; settler; step; allocation = None; account = None; id = idUsed; observers = M.fromList [(idUsed, singleton $ singleton settler)]
           instructions = mapWithIndex createInstruction groupedSteps
           instructionIds = map (.id) instructions
         instructionCids <- mapA (fmap toInterfaceContractId . create) instructions
-        settleableCid <- toInterfaceContractId <$> create Batch with requestors; settler; id; stepsWithInstructionId = zip groupedSteps instructionIds
+        settleableCid <- toInterfaceContractId <$> create Batch with requestors = instructors; settler; id; stepsWithInstructionId = zip groupedSteps instructionIds
         pure (settleableCid, instructionCids)
 
 -- | Data type that describes a hierarchical account structure between two parties for holdings on an instrument.

--- a/src/test/daml/Daml/Finance/Bond/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Bond/Test/Util.daml
@@ -4,7 +4,7 @@
 module Daml.Finance.Bond.Test.Util where
 
 import DA.Map qualified as M
-import DA.Set (Set, singleton)
+import DA.Set (Set, empty, singleton)
 import Daml.Finance.Asset.Test.Util.Holding (verifyOwnerOfHolding)
 import Daml.Finance.Asset.Test.Util.Instrument (createReference)
 import Daml.Finance.Asset.Test.Util.Instrument qualified as Instrument (submitExerciseInterfaceByKeyCmd)
@@ -83,7 +83,7 @@ lifecycleAndVerifyCouponEffectsAndSettlement readAs today bondInstrument settler
     Instrument.toKey <$> exerciseCmd @Instrument.I (coerceContractId bondLifecyclableCid) Instrument.GetView with viewer = issuer
 
   -- Create settlement factory
-  factoryCid <- submitMulti [investor] [] do createCmd BatchFactory with requestors = singleton investor
+  factoryCid <- submitMulti [investor] [] do createCmd BatchFactory with provider = investor; observers = empty
 
   -- Claim effect
   settlementRuleCid <- submitMulti [custodian, investor] [] do
@@ -129,7 +129,7 @@ lifecycleAndVerifyRedemptionEffectsAndSettlement readAs today bondInstrument set
     Instrument.toKey <$> exerciseCmd @Instrument.I (coerceContractId bondLifecyclableCid) Instrument.GetView with viewer = issuer
 
   -- Create settlement factory
-  factoryCid <- submitMulti [investor] [] do createCmd BatchFactory with requestors = singleton investor
+  factoryCid <- submitMulti [investor] [] do createCmd BatchFactory with provider = investor; observers = empty
 
   -- Claim effect
   settlementRuleCid <- submitMulti [custodian, investor] [] do

--- a/src/test/daml/Daml/Finance/Bond/Test/ZeroCoupon.daml
+++ b/src/test/daml/Daml/Finance/Bond/Test/ZeroCoupon.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Bond.Test.ZeroCoupon where
 
 import DA.Date
 import DA.Map qualified as M (fromList)
-import DA.Set (Set, singleton)
+import DA.Set (Set, empty, singleton)
 import Daml.Finance.Asset.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Asset.Test.Util.Account qualified as Account (createAccount, createFactory, credit)
 import Daml.Finance.Asset.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
@@ -32,7 +32,7 @@ lifecycleAndVerifyRedemptionEffectsAndSettlement readAs today bondInstrument set
   let newBondInstrumentKey = Instrument.getKey newBondInstrument
 
   -- Create settlement factory
-  factoryCid <- submitMulti [investor] [] do createCmd BatchFactory with requestors = singleton investor
+  factoryCid <- submitMulti [investor] [] do createCmd BatchFactory with provider = investor; observers = empty
 
   -- Claim effect
   settlementRuleCid <- submitMulti [custodian, investor] [] do

--- a/src/test/daml/Daml/Finance/Derivative/Test/CallableBond.daml
+++ b/src/test/daml/Daml/Finance/Derivative/Test/CallableBond.daml
@@ -8,7 +8,7 @@ import ContingentClaims.Observation (Observation(..))
 import DA.Assert ((===))
 import DA.Date as D (Month(..), date)
 import DA.Map qualified as M (empty, fromList)
-import DA.Set (singleton)
+import DA.Set (empty, singleton)
 import DA.Time (time)
 import Daml.Finance.Asset.Fungible qualified as Fungible (Factory(..), T)
 import Daml.Finance.Asset.Test.Util.Account qualified as Account (createAccount, createFactory, credit)
@@ -136,7 +136,7 @@ run = script do
         observableCids = []
 
   -- Create settlement factory
-  factoryCid <- submitMulti [bank] [] do createCmd BatchFactory with requestors = singleton bank
+  factoryCid <- submitMulti [bank] [] do createCmd BatchFactory with provider = bank; observers = empty
 
   settlementRuleCid <- submitMulti [bank, investor] [] do
     createCmd Rule

--- a/src/test/daml/Daml/Finance/Derivative/Test/EuropeanOption.daml
+++ b/src/test/daml/Daml/Finance/Derivative/Test/EuropeanOption.daml
@@ -9,7 +9,7 @@ import ContingentClaims.Observation (Observation(..))
 import DA.Assert ((===))
 import DA.Date (addDays,  toDateUTC)
 import DA.Map qualified as M (empty, fromList)
-import DA.Set (singleton)
+import DA.Set (empty, singleton)
 import Daml.Finance.Asset.Fungible qualified as Fungible (Factory(..), T)
 import Daml.Finance.Asset.Test.Util.Account qualified as Account (createAccount, createFactory, credit)
 import Daml.Finance.Asset.Test.Util.Instrument qualified as Instrument (originate)
@@ -149,7 +149,7 @@ run = script do
         observableCids = [observableCid]
 
   -- Create settlement factory
-  factoryCid <- submitMulti [investor1] [] do createCmd BatchFactory with requestors = singleton investor1
+  factoryCid <- submitMulti [investor1] [] do createCmd BatchFactory with provider = investor1; observers = empty
 
   -- Claim effect
   settlementRuleCid <- submitMulti [bank, investor1] [] do
@@ -215,7 +215,7 @@ run = script do
         observableCids = [observableCid]
 
   -- Create settlement factory
-  factoryCid <- submitMulti [investor2] [] do createCmd BatchFactory with requestors = singleton investor2
+  factoryCid <- submitMulti [investor2] [] do createCmd BatchFactory with provider = investor2; observers = empty
 
   settlementRuleCid <- submitMulti [bank, investor2] [] do
     createCmd Rule

--- a/src/test/daml/Daml/Finance/Derivative/Test/ForwardCash.daml
+++ b/src/test/daml/Daml/Finance/Derivative/Test/ForwardCash.daml
@@ -7,7 +7,7 @@ import ContingentClaims.Claim (Inequality(..), one, scale, when)
 import ContingentClaims.Observation (Observation(..))
 import DA.Date (addDays, toDateUTC)
 import DA.Map qualified as M (empty, fromList)
-import DA.Set (singleton)
+import DA.Set (empty, singleton)
 import Daml.Finance.Asset.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Asset.Test.Util.Account qualified as Account (createAccount, createFactory, credit)
 import Daml.Finance.Asset.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
@@ -84,7 +84,7 @@ run = script do
   (_, [effectCid]) <- Instrument.submitExerciseInterfaceByKeyCmd @Lifecyclable.I [broker] [] derivativeInstrument Lifecyclable.Lifecycle with settler; eventCid = clockEventCid; observableCids = [observableCid]; ruleName = "Time"; clockCid
 
   -- Create settlement factory
-  factoryCid <- submitMulti [investor] [] do createCmd BatchFactory with requestors = singleton investor
+  factoryCid <- submitMulti [investor] [] do createCmd BatchFactory with provider = investor; observers = empty
 
   -- Claim effect
   settlementRuleCid <- submitMulti [bank, investor] [] do

--- a/src/test/daml/Daml/Finance/Derivative/Test/ForwardPhysical.daml
+++ b/src/test/daml/Daml/Finance/Derivative/Test/ForwardPhysical.daml
@@ -7,7 +7,7 @@ import ContingentClaims.Claim (Inequality(..), and, give, one, scale, when)
 import ContingentClaims.Observation (Observation(..))
 import DA.Date (addDays, toDateUTC)
 import DA.Map qualified as M (empty, fromList)
-import DA.Set (singleton)
+import DA.Set (empty, singleton)
 import Daml.Finance.Asset.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Asset.Test.Util.Account qualified as Account (createAccount, createFactory, credit)
 import Daml.Finance.Asset.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
@@ -84,7 +84,7 @@ run = script do
   (_, [effectCid]) <- Instrument.submitExerciseInterfaceByKeyCmd @Lifecyclable.I [broker] [] derivativeInstrument Lifecyclable.Lifecycle with settler; eventCid = clockEventCid; observableCids = []; ruleName = "Time"; clockCid
 
   -- Create settlement factory
-  factoryCid <- submitMulti [investor] [] do createCmd BatchFactory with requestors = singleton investor
+  factoryCid <- submitMulti [investor] [] do createCmd BatchFactory with provider = investor; observers = empty
 
   -- Claim effect
   settlementRuleCid <- submitMulti [bank, investor] [] do

--- a/src/test/daml/Daml/Finance/Derivative/Test/Intermediated/BondCoupon.daml
+++ b/src/test/daml/Daml/Finance/Derivative/Test/Intermediated/BondCoupon.daml
@@ -9,7 +9,7 @@ import DA.Assert ((===))
 import DA.Date (addDays, toDateUTC)
 import DA.Foldable qualified as F (forA_)
 import DA.Map qualified as M (empty, fromList)
-import DA.Set (fromList, singleton)
+import DA.Set (empty, fromList, singleton)
 import Daml.Finance.Asset.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Asset.Test.Util.Account qualified as Account (createAccount, createFactory, credit)
 import Daml.Finance.Asset.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
@@ -158,11 +158,12 @@ run = script do
       [ ( "USD" , Path with senderPath = [csd, centralBank]; receiverPath = [investor, bank, centralBank])
       ]
 
-  factoryCid <- submitMulti [csd, investor] [] do
+  factoryCid <- submit csd do
     createCmd BatchFactoryWithIntermediaries
       with
-        requestors = fromList [csd, investor]
+        provider = csd
         paths = M.fromList routes
+        observers = fromList [investor]
 
   settlementRuleCid <- submitMulti [csd, investor] [] do
     createCmd Rule
@@ -272,7 +273,7 @@ template EffectSettlementService
           pure (hCid, h)
 
         -- 1. csd claims effect against issuer
-        factoryCid <- create BatchFactory with requestors = singleton csd
+        factoryCid <- create BatchFactory with provider = csd; observers = empty
 
         settlementRuleCid <- create Rule
           with
@@ -290,6 +291,8 @@ template EffectSettlementService
 
         archive factoryCid
         archive settlementRuleCid
+
+        -- TODO : use settlement instruction instead of direct transfer, or at least make sure it gets archived
 
         steps <- fmap ((.step) . Instruction.view) <$> mapA fetch result.instructionCids
 

--- a/src/test/daml/Daml/Finance/Equity/Test/CashDividend.daml
+++ b/src/test/daml/Daml/Finance/Equity/Test/CashDividend.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Equity.Test.CashDividend where
 
 import DA.Date (toDateUTC)
 import DA.Map qualified as M (empty, fromList)
-import DA.Set (singleton)
+import DA.Set (empty, singleton)
 import Daml.Finance.Asset.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Asset.Test.Util.Account qualified as Account (createAccount, createFactory, credit)
 import Daml.Finance.Asset.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
@@ -70,7 +70,7 @@ run = script do
   (_, [effectCid]) <- submitMulti [issuer] [] do exerciseCmd lifecyclableCid Lifecyclable.Lifecycle with ruleName = "Dividend"; settler; observableCids = []; eventCid; clockCid
 
   -- Create settlement factory and rule to claim effects
-  factoryCid <- submitMulti [investor] [] do createCmd BatchFactory with requestors = singleton investor
+  factoryCid <- submitMulti [investor] [] do createCmd BatchFactory with provider = investor; observers = empty
 
   settlementRuleCid <- submitMulti [bank, investor] [] do
     createCmd Rule

--- a/src/test/daml/Daml/Finance/Equity/Test/CashTakeover.daml
+++ b/src/test/daml/Daml/Finance/Equity/Test/CashTakeover.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Equity.Test.CashTakeover where
 
 import DA.Date (toDateUTC)
 import DA.Map qualified as M (empty, fromList)
-import DA.Set (singleton)
+import DA.Set (empty, singleton)
 import Daml.Finance.Asset.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Asset.Test.Util.Account qualified as Account (createAccount, createFactory, credit)
 import Daml.Finance.Asset.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
@@ -66,7 +66,7 @@ run = script do
   (_, [effectCid]) <- submitMulti [buyer] [] do exerciseCmd lifecyclableCid Lifecyclable.Lifecycle with ruleName = "Takeover"; settler; eventCid; observableCids = []; clockCid
 
   -- Create settlement factory
-  factoryCid <- submitMulti [investor] [] do createCmd BatchFactory with requestors = singleton investor
+  factoryCid <- submitMulti [investor] [] do createCmd BatchFactory with provider = investor; observers = empty
 
   -- Claim effect
   ruleCid <- submitMulti [bank, investor] [] do

--- a/src/test/daml/Daml/Finance/Equity/Test/Merger.daml
+++ b/src/test/daml/Daml/Finance/Equity/Test/Merger.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Equity.Test.Merger where
 
 import DA.Date (toDateUTC)
 import DA.Map qualified as M (empty, fromList)
-import DA.Set (singleton)
+import DA.Set (empty, singleton)
 import Daml.Finance.Asset.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Asset.Test.Util.Account qualified as Account (createAccount, createFactory, credit)
 import Daml.Finance.Asset.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
@@ -66,7 +66,7 @@ run = script do
   (_, [effectCid]) <- submitMulti [issuer3] [] do exerciseCmd lifecyclableCid Lifecyclable.Lifecycle with ruleName = "Merger"; settler; eventCid; observableCids = []; clockCid
 
   -- Create settlement factory
-  factoryCid <- submitMulti [investor] [] do createCmd BatchFactory with requestors = singleton investor
+  factoryCid <- submitMulti [investor] [] do createCmd BatchFactory with provider = investor; observers = empty
 
   -- Claim effect
   settlementRuleCid <- submitMulti [bank, investor] [] do

--- a/src/test/daml/Daml/Finance/Equity/Test/ShareDividend.daml
+++ b/src/test/daml/Daml/Finance/Equity/Test/ShareDividend.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Equity.Test.ShareDividend where
 
 import DA.Date (toDateUTC)
 import DA.Map qualified as M (empty, fromList)
-import DA.Set (singleton)
+import DA.Set (empty, singleton)
 import Daml.Finance.Asset.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Asset.Test.Util.Account qualified as Account (createAccount, createFactory, credit)
 import Daml.Finance.Asset.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
@@ -66,7 +66,7 @@ run = script do
   (_, [effectCid]) <- submitMulti [issuer] [] do exerciseCmd lifecyclableCid Lifecyclable.Lifecycle with ruleName = "Dividend"; settler; eventCid; observableCids = []; clockCid
 
   -- Create settlement factory
-  factoryCid <- submitMulti [investor] [] do createCmd BatchFactory with requestors = singleton investor
+  factoryCid <- submitMulti [investor] [] do createCmd BatchFactory with provider = investor; observers = empty
 
   -- Claim effect
   settlementRuleCid <- submitMulti [bank, investor] [] do

--- a/src/test/daml/Daml/Finance/Equity/Test/ShareTakeover.daml
+++ b/src/test/daml/Daml/Finance/Equity/Test/ShareTakeover.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Equity.Test.ShareTakeover where
 
 import DA.Date (toDateUTC)
 import DA.Map qualified as M (empty, fromList)
-import DA.Set (singleton)
+import DA.Set (empty, singleton)
 import Daml.Finance.Asset.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Asset.Test.Util.Account qualified as Account (createAccount, createFactory, credit)
 import Daml.Finance.Asset.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
@@ -65,7 +65,7 @@ run = script do
   (_, [effectCid]) <- submitMulti [buyer] [] do exerciseCmd lifecyclableCid Lifecyclable.Lifecycle with ruleName = "Takeover"; settler; eventCid; observableCids = []; clockCid
 
   -- Create settlement factory
-  factoryCid <- submitMulti [investor] [] do createCmd BatchFactory with requestors = singleton investor
+  factoryCid <- submitMulti [investor] [] do createCmd BatchFactory with provider = investor; observers = empty
 
   -- Claim effect
   settlementRuleCid <- submitMulti [bank, investor] [] do

--- a/src/test/daml/Daml/Finance/Settlement/Test/Batch.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Batch.daml
@@ -4,7 +4,7 @@
 module Daml.Finance.Settlement.Test.Batch where
 
 import DA.Map qualified as M (empty)
-import DA.Set (singleton)
+import DA.Set (empty, singleton)
 import Daml.Finance.Asset.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Asset.Test.Util.Account qualified as Account (createAccount, createFactory, credit)
 import Daml.Finance.Asset.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
@@ -57,9 +57,9 @@ run = script do
       [ Step with sender = issuer; receiver = bank; quantity = (Instrument.qty 1_000.0 equityInstrument)
       , Step with sender = bank; receiver = issuer; quantity = (Instrument.qty 200_000.0 cashInstrument)
       ]
-  instructableCid <- submitMulti [bank] [] do createCmd BatchFactory with requestors = singleton bank
+  instructableCid <- submitMulti [bank] [] do createCmd BatchFactory with provider = bank; observers = empty
   (containerSettleableCid, [equityInstructionCid, cashInstructionCid]) <-
-    submitMulti [bank] [] do exerciseCmd instructableCid Instructable.Instruct with settler = bank; id = "DVP"; steps
+    submitMulti [bank] [] do exerciseCmd instructableCid Instructable.Instruct with instructors = singleton bank; settler = bank; id = "DVP"; steps
 
   -- Allocate instructions
   equityInstructionCid <- submitMulti [issuer] [] do exerciseCmd equityInstructionCid Instruction.Allocate with transferableCid = equityTransferableCid

--- a/src/test/daml/Daml/Finance/Settlement/Test/BatchWithRoute.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/BatchWithRoute.daml
@@ -4,7 +4,7 @@
 module Daml.Finance.Settlement.Test.BatchWithRoute where
 
 import DA.Map qualified as M (empty, fromList)
-import DA.Set (singleton)
+import DA.Set (empty, singleton)
 import Daml.Finance.Asset.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Asset.Test.Util.Account qualified as Account (createAccount, createFactory, credit)
 import Daml.Finance.Asset.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
@@ -88,8 +88,9 @@ run = script do
   instructableCid <- submitMulti [bank1] [] do
     createCmd BatchFactoryWithIntermediaries
       with
-        requestors = singleton bank1
+        provider = bank1
         paths = M.fromList routes
+        observers = empty
 
   -- Instruct settlement
   let
@@ -98,7 +99,7 @@ run = script do
       , Step with sender = bank1; receiver = issuer; quantity = (Instrument.qty 200_000.0 cashInstrument)
       ]
   (containerSettleableCid, [equityInstructionCid, cashInstruction1Cid, cashInstruction2Cid]) <-
-    submitMulti [bank1] [] do exerciseCmd instructableCid Instructable.Instruct with settler = bank1; id = "DVP"; steps
+    submitMulti [bank1] [] do exerciseCmd instructableCid Instructable.Instruct with instructors = singleton bank1; settler = bank1; id = "DVP"; steps
 
   -- Allocate instructions
   equityInstructionCid <- submitMulti [issuer] [] do exerciseCmd equityInstructionCid Instruction.Allocate with transferableCid = equityTransferableCid

--- a/src/test/daml/Daml/Finance/Settlement/Test/Intermediated.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Intermediated.daml
@@ -4,7 +4,7 @@
 module Daml.Finance.Settlement.Test.Intermediated where
 
 import DA.Map qualified as M (empty)
-import DA.Set (singleton)
+import DA.Set (empty, singleton)
 import Daml.Finance.Asset.Fungible qualified as Fungible (Factory(..), T)
 import Daml.Finance.Asset.Test.Util.Account qualified as Account (createAccount, createFactory, credit, submitExerciseInterfaceByKeyCmd)
 import Daml.Finance.Asset.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
@@ -114,9 +114,9 @@ run useDelegatee = script do
       , Step with sender = custodian1; receiver = custodian2; quantity = assetQuantity
       , Step with sender = custodian2; receiver = alice; quantity = assetQuantity
       ]
-  factoryCid <- submitMulti [agent] [] do createCmd BatchFactory with requestors = singleton agent
+  factoryCid <- submitMulti [agent] [] do createCmd BatchFactory with provider = agent; observers = empty
   (containerSettleableCid, [aliceInstructionCid, bank1InstructionCid, bank2InstructionCid, bobInstructionCid, custodian1InstructionCid, custodian2InstructionCid]) <-
-    submitMulti [agent] [] do exerciseCmd factoryCid Instructable.Instruct with settler = agent; id = "CROSSPAYMENT"; steps
+    submitMulti [agent] [] do exerciseCmd factoryCid Instructable.Instruct with instructors = singleton agent; settler = agent; id = "CROSSPAYMENT"; steps
 
   -- Allocate instructions
   aliceInstructionCid <-

--- a/src/test/daml/Daml/Finance/Settlement/Test/Transfer.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Transfer.daml
@@ -4,7 +4,7 @@
 module Daml.Finance.Settlement.Test.Transfer where
 
 import DA.Map qualified as M (empty)
-import DA.Set (singleton)
+import DA.Set (empty, singleton)
 import Daml.Finance.Asset.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Asset.Test.Util.Account qualified as Account (credit, createAccount, createFactory)
 import Daml.Finance.Asset.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
@@ -56,11 +56,11 @@ run = script do
   cashTransferableCid <- Account.credit [publicParty] cashInstrument 200_000.0 senderAccount
 
   -- Create transfer factory
-  factoryCid <- submitMulti [bank] [] do createCmd BatchFactory with requestors = singleton bank
+  factoryCid <- submitMulti [bank] [] do createCmd BatchFactory with provider = bank; observers = empty
 
   -- Instruct transfer
   let step = Step with sender; receiver; quantity = (Instrument.qty 200_000.0 cashInstrument)
-  (cashTransferCid, [cashInstructionCid]) <- submitMulti [bank] [] do exerciseCmd factoryCid Instructable.Instruct with settler = bank; id = "TFER"; steps = [step]
+  (cashTransferCid, [cashInstructionCid]) <- submitMulti [bank] [] do exerciseCmd factoryCid Instructable.Instruct with instructors = singleton bank; settler = bank; id = "TFER"; steps = [step]
 
   -- Allocate instruction
   cashInstructionCid <- submitMulti [sender] [publicParty] do exerciseCmd cashInstructionCid Instruction.Allocate with transferableCid = coerceContractId cashTransferableCid


### PR DESCRIPTION
Also
- rename requestors to provider
- change from Parties to Party

Motivation:
- we want to have as few Batch Factories as possible, given that this contract needs to be created directly at ledger initialisation (unless we want to introduce a factory's factory). Adding observers + flexible controllers allows us to use a public party mechanism, which reduces the number of contracts that we need.
- This came out while trying to port some CBDC sandbox code to the new library

The flexible controllers are now signatories of the batch + instructions. 

The previous scenario can be reproduced with the new version (by setting observers = empty).

I will need to think a bit better how this works in the case of `BatchFactoryWithIntermediaries` as we generally do not want to give a public party visibility on the entire account hierarchy. 

I did not implement `Disclosure` as I think the factory contracts are meant to be quite stable, but we could reconsider that.