### PR TITLE
Fix character escaping in docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,8 @@ doc: $(DAML_SRC)
     --exclude-instances=HasField,HasImplementation,HasMethod,HasFromInterface,HasToInterface \
     --drop-orphan-instances \
     --output .docs $(DAML_SRC)
+
+.PHONY: docjson
+docjson: $(DAML_SRC)
+	daml damlc docs --output=.docs/daml-finance.json --package-name=daml-finance --format Json \
+    $(DAML_SRC)

--- a/src/main/daml/Daml/Finance/Asset/NonTransferable.daml
+++ b/src/main/daml/Daml/Finance/Asset/NonTransferable.daml
@@ -20,7 +20,7 @@ type T = NonTransferable
 
 instance Holding.HasImplementation T
 -- | Implementation of a non-transferable holding.
--- `NonTransferable` implements the interface `Lockable.I` (which requires Holding.I`, and
+-- `NonTransferable` implements the interface `Lockable.I` (which requires `Holding.I`, and
 -- `Disclosure.I` to be implemented as well).
 template NonTransferable
   with

--- a/src/main/daml/Daml/Finance/Common/Date/Calendar.daml
+++ b/src/main/daml/Daml/Finance/Common/Date/Calendar.daml
@@ -32,7 +32,7 @@ data HolidayCalendarData = HolidayCalendarData
       -- ^ A list of dates defining holidays.
   deriving (Eq, Show)
 
--- | Merge multiple holiday calendars into a single one. `id`s are concatenated by `,`.
+-- | Merge multiple holiday calendars into a single one. `id`\s are concatenated by `,`.
 merge : [HolidayCalendarData] -> HolidayCalendarData
 merge [] = HolidayCalendarData with id = "Empty"; holidays = []; weekend = []
 merge cals = foldl1

--- a/src/main/daml/Daml/Finance/Derivative/Election.daml
+++ b/src/main/daml/Daml/Finance/Derivative/Election.daml
@@ -59,8 +59,8 @@ template Election
         toInterfaceContractId <$> create this with observers = newObservers
       archiveImpl self = archive (coerceContractId self : ContractId Election)
 
--- | Helper contract to delegate the right to create `Election`s referencing a specific `Instrument`.
--- The provider delegates the ability to create `Election`s to any party that has visibility on the `ElectionFactory` contract. In order to create the `Election`, a valid `Holding` must be presented which identifies the choice controller as either the owner or the custodian to the `Holding`.
+-- | Helper contract to delegate the right to create `Election`\s referencing a specific `Instrument`.
+-- The provider delegates the ability to create `Election`\s to any party that has visibility on the `ElectionFactory` contract. In order to create the `Election`, a valid `Holding` must be presented which identifies the choice controller as either the owner or the custodian to the `Holding`.
 template ElectionFactory
   with
     provider : Party

--- a/src/main/daml/Daml/Finance/Derivative/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Derivative/Instrument.daml
@@ -30,8 +30,9 @@ type T = Instrument
 
 instance Instrument.HasImplementation T
 instance Election.ExercisableHasImplementation T
+
 -- | An instrument representing a generic derivative, modelled using the Contingent Claims library.
--- | The responsibility for processing lifecycle events as well as elections is delegated to the issuer, who is hence responsible for providing the correct `Observable`s.
+-- The responsibility for processing lifecycle events as well as elections is delegated to the issuer, who is hence responsible for providing the correct `Observable`\s.
 template Instrument
   with
     depository : Party

--- a/src/main/daml/Daml/Finance/Interface/Asset/Types.daml
+++ b/src/main/daml/Daml/Finance/Interface/Asset/Types.daml
@@ -10,10 +10,10 @@ data Id = Id
     label : Text
       -- ^ A textual label.
     version : Text
-      -- ^ A textual verison.
+      -- ^ A textual version.
   deriving (Eq, Ord, Show)
 
--- | A unique key for Accounts
+-- | A unique key for Accounts.
 data AccountKey = AccountKey
   with
     custodian : Party

--- a/src/main/daml/Daml/Finance/Interface/Derivative/Util/Claims.daml
+++ b/src/main/daml/Daml/Finance/Interface/Derivative/Util/Claims.daml
@@ -25,11 +25,11 @@ isZero' = all $ CC.isZero . (.claim)
 -- | Maps the time parameter in a `Claim` to `Time`. As `Time` is generally understood to express UTC time, we recommend mapping to UTC time.
 toTime : HasUTCTimeConversion t => Claim t x a o -> Claim Time x a o
 toTime =
-  let contraMap _ = error "Inverse mapping from `Time` is not provided" -- currently the contramap from `Time` back to `a` is not used, because `Observation`s do not depend on time explicitly
+  let contraMap _ = error "Inverse mapping from `Time` is not provided" -- currently the contramap from `Time` back to `a` is not used, because `Observation`\s do not depend on time explicitly
   in mapParams contraMap toUTCTime identity identity identity
 
 -- | Maps the time parameter in a `Claim` to `Time`. As `Time` is generally understood to express UTC time, we recommend mapping to UTC time.
 toTime' : (t -> Time) -> Claim t x a o -> Claim Time x a o
 toTime' forwardMap c =
-  let contraMap _ = error "Inverse mapping from `Time` is not provided" -- currently the contramap from `Time` back to `a` is not used, because `Observation`s do not depend on time explicitly
+  let contraMap _ = error "Inverse mapping from `Time` is not provided" -- currently the contramap from `Time` back to `a` is not used, because `Observation`\s do not depend on time explicitly
   in mapParams contraMap forwardMap identity identity identity c

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Effect.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Effect.daml
@@ -53,7 +53,7 @@ interface Effect where
       calculateImpl this arg self
 
   choice SetProvider : ContractId Effect
-    -- ^ Set the provider of the effect. The provider has visibility on all sub-transactions triggered by `Claim`ing an effect.
+    -- ^ Set the provider of the effect. The provider has visibility on all sub-transactions triggered by `Claim`\ing an effect.
     with
       newProvider : Party
         -- ^ The new provider.

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/SettlementRule.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/SettlementRule.daml
@@ -25,7 +25,7 @@ data ClaimResult = ClaimResult
       -- ^ Settlement instructions to settle all effect consequences other than consuming / upgrading the target instrument.
   deriving (Eq, Show)
 
--- | Interface for contracts that allow holders to claim an `Effect` and generate `SettlementInstruction`s.
+-- | Interface for contracts that allow holders to claim an `Effect` and generate `SettlementInstruction`\s.
 interface SettlementRule where
   view : View
     -- ^ Acquire the default interface view.

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Instructable.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Instructable.daml
@@ -37,7 +37,7 @@ interface Instructable where
       pure $ view this
 
   nonconsuming choice Instruct : (ContractId Settleable.I, [ContractId Instruction.I])
-    --  ^ Generate settlement instructions. It returns the `Instruction`s as well as a container to batch-settle them.
+    --  ^ Generate settlement instructions. It returns the `Instruction`\s as well as a container to batch-settle them.
     with
       instructors : Parties
         -- ^ Parties requesting to instruct a settlement.

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Settleable.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Settleable.daml
@@ -18,7 +18,7 @@ data View = View
       -- ^ Settlement steps.
   deriving (Eq, Show)
 
--- | An interface for atomically settling `Transferable`s.
+-- | An interface for atomically settling `Transferable`\s.
 interface Settleable where
   view : View
     -- ^ Acquire the default interface view.

--- a/src/main/daml/Daml/Finance/Lifecycle/SettlementRule.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/SettlementRule.daml
@@ -28,7 +28,7 @@ template Rule
     claimers : Parties
       -- ^ Parties granted the ability to claim an effect.
     instructableCid : ContractId Instructable.I
-      -- ^ Instructable contract used to generate the `Settleable` and `Instruction`s.
+      -- ^ Instructable contract used to generate the `Settleable` and `Instruction`\s.
     instrumentLabel : Text
       -- ^ The textual identifier of the target instrument.
     settler : Party

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -29,17 +29,17 @@ import Daml.Finance.Settlement.Instruction (Instruction(..))
 type T = Batch
 
 instance Settleable.HasImplementation T
--- | Allows to atomically settle a set of settlement `Step`s.
+-- | Allows to atomically settle a set of settlement `Step`\s.
 template Batch
   with
     requestors : Parties
-      -- ^ Parties requesting the settlement
+      -- ^ Parties requesting the settlement.
     settler : Party
-      -- ^ Party triggering the settlement
+      -- ^ Party triggering the settlement.
     id : Text
-      -- ^ A textual identifier
+      -- ^ A textual identifier.
     stepsWithInstructionId : [(Step, Text)]
-      -- ^ The settlement `Step`s and the identifiers of the corresponding `Instruction`s
+      -- ^ The settlement `Step`\s and the identifiers of the corresponding `Instruction`\s.
   where
     signatory requestors
     observer settler
@@ -74,7 +74,7 @@ template Batch
         pure l
 
 -- | Factory template that implements the `Instructable` interface and is used to create a settlement batch.
--- A batch is made of a set of `Instruction`s, as well as a container template used to atomically settle them.
+-- A batch is made of a set of `Instruction`\s, as well as a container template used to atomically settle them.
 template BatchFactory
   with
     provider : Party
@@ -98,7 +98,7 @@ template BatchFactory
         pure (settleableCid, instructionCids)
 
 -- | Factory template that implements the `Instructable` interface and is used to create a settlement batch.
--- A batch is made of a set of `Instruction`s, as well as a container template used to atomically settle them.
+-- A batch is made of a set of `Instruction`\s, as well as a container template used to atomically settle them.
 -- For each instrument to settle as part of the batch, a hierarchy of intermediaries is specified in `paths`. This hierarchy is used to generate settlement instructions.
 template BatchFactoryWithIntermediaries
   with


### PR DESCRIPTION
This is related to point 1 in https://github.com/DACH-NY/daml-finance/issues/269.

Additionally, add `make` option to generate documentation in json format