### PR TITLE
Make transfer use Credit

### DIFF
--- a/src/main/daml/Daml/Finance/Asset/Fungible.daml
+++ b/src/main/daml/Daml/Finance/Asset/Fungible.daml
@@ -5,13 +5,12 @@ module Daml.Finance.Asset.Fungible where
 
 import DA.Action (foldlA)
 import DA.Assert ((===))
-import DA.Map qualified as M
 import DA.Set (delete, insert, null, singleton)
-import Daml.Finance.Interface.Asset.Account qualified as Account (R, view)
+import Daml.Finance.Interface.Asset.Account qualified as Account (Credit(..), I, R, exerciseInterfaceByKey, view)
 import Daml.Finance.Interface.Asset.Factory.Holding qualified as HoldingFactory (Create(..), F, HasImplementation(..), Remove(..), View(..))
 import Daml.Finance.Interface.Asset.Fungible qualified as Fungible (HasImplementation, I, Merge(..), Split(..), SplitResult(..), View(..))
 import Daml.Finance.Interface.Asset.Holding qualified as Holding (I, View(..))
-import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (K)
+import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (K, qty)
 import Daml.Finance.Interface.Asset.Lockable qualified as Lockable (Acquire(..), I, Lock(..), LockType(..), Release(..), View(..))
 import Daml.Finance.Interface.Asset.Transferable qualified as Transferable (I, Transfer(..), View(..))
 import Daml.Finance.Interface.Asset.Types (AccountKey(..))
@@ -81,12 +80,19 @@ template Fungible
       asLockable = toInterface @Lockable.I this
       view = Transferable.View ()
       transferImpl Transferable.Transfer{newOwnerAccount} = do
+        -- Account sanity checks
         newAccount <- fetchInterfaceByKey @Account.R newOwnerAccount
         let view = Account.view newAccount
         view.owner === newOwnerAccount.owner
         view.custodian === account.custodian
-        toInterfaceContractId <$> create this with
-          account = (this.account with owner = newOwnerAccount.owner; id = view.id); observers = M.empty
+        -- Create new holding via Credit
+        newHoldingCid <- coerceContractId <$> Account.exerciseInterfaceByKey @Account.I newOwnerAccount newOwnerAccount.owner Account.Credit
+          with
+            quantity = Instrument.qty amount instrument
+        -- Holding sanity checks. This prevents a holding from changing type during a `Transfer` (from e.g., `NonFungible` to `Fungible`)
+        newHolding <- fetch newHoldingCid
+        assertMsg "Sent holding type does not correspond to receiving account holding type" $ interfaceTypeRep newHolding == templateTypeRep @Fungible
+        pure newHoldingCid
 
     implements Fungible.I where
       asTransferable = toInterface @Transferable.I this

--- a/src/main/daml/Daml/Finance/Asset/NonFungible.daml
+++ b/src/main/daml/Daml/Finance/Asset/NonFungible.daml
@@ -4,13 +4,12 @@
 module Daml.Finance.Asset.NonFungible where
 
 import DA.Assert ((===))
-import DA.Map qualified as M
 import DA.Set (delete, insert, null, singleton)
-import Daml.Finance.Interface.Asset.Account qualified as Account (R, view)
+import Daml.Finance.Interface.Asset.Account qualified as Account (Credit(..), I, R, exerciseInterfaceByKey, view)
 import Daml.Finance.Interface.Asset.Factory.Holding qualified as HoldingFactory (Create(..), F, HasImplementation(..), Remove(..), View(..))
 import Daml.Finance.Interface.Asset.Transferable qualified as NonFungible (HasImplementation)
 import Daml.Finance.Interface.Asset.Holding qualified as Holding (I, View(..))
-import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (K)
+import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (K, qty)
 import Daml.Finance.Interface.Asset.Lockable qualified as Lockable (Acquire(..), I, Lock(..), LockType(..), Release(..), View(..))
 import Daml.Finance.Interface.Asset.Transferable qualified as Transferable (I, Transfer(..), View(..))
 import Daml.Finance.Interface.Asset.Types (AccountKey(..))
@@ -80,12 +79,19 @@ template NonFungible
       asLockable = toInterface @Lockable.I this
       view = Transferable.View ()
       transferImpl Transferable.Transfer{newOwnerAccount} = do
+        -- Account sanity checks
         newAccount <- fetchInterfaceByKey @Account.R newOwnerAccount
         let view = Account.view newAccount
         view.owner === newOwnerAccount.owner
         view.custodian === account.custodian
-        toInterfaceContractId <$> create this with
-          account = (this.account with owner = newOwnerAccount.owner; id = view.id); observers = M.empty
+        -- Create new holding via Credit
+        newHoldingCid <- coerceContractId <$> Account.exerciseInterfaceByKey @Account.I newOwnerAccount newOwnerAccount.owner Account.Credit
+          with
+            quantity = Instrument.qty amount instrument
+        -- Holding sanity checks. This prevents a holding from changing type during a `Transfer` (from e.g., `NonFungible` to `Fungible`)
+        newHolding <- fetch newHoldingCid
+        assertMsg "Sent holding type does not correspond to receiving account holding type" $ interfaceTypeRep newHolding == templateTypeRep @NonFungible
+        pure newHoldingCid
 
 instance HoldingFactory.HasImplementation Factory
 -- | Implementation of the corresponding Holding Factory.

--- a/src/test/daml/Daml/Finance/Asset/Test/Common.daml
+++ b/src/test/daml/Daml/Finance/Asset/Test/Common.daml
@@ -3,7 +3,7 @@
 
 module Daml.Finance.Asset.Test.Common where
 
-import DA.Map qualified as M (Map, empty)
+import DA.Map qualified as M (Map)
 import Daml.Finance.Asset.Test.Util.Account qualified as Account (createAccount, credit, createFactory, credit)
 import Daml.Finance.Asset.Test.Util.Instrument (originate)
 import Daml.Finance.Interface.Asset.Factory.Holding qualified as Holding (F)
@@ -25,6 +25,8 @@ data TestParties = TestParties
       -- ^ Locker of the holding.
     locker2 : Party
       -- ^ Additional locker of the holding.
+    publicParty : Party
+      -- ^ The public party. Every party can readAs the public party.
 
 data TestInitialState = TestInitialState
   with
@@ -40,7 +42,7 @@ data TestInitialState = TestInitialState
 setupParties : Script TestParties
 setupParties = do
   -- Create parties
-  [custodian, issuer, investor, locker, locker2] <- createParties ["Custodian", "Issuer", "Investor", "Locker", "locker2"]
+  [custodian, issuer, investor, locker, locker2, publicParty] <- createParties ["Custodian", "Issuer", "Investor", "Locker", "Locker2", "PublicParty"]
   pure TestParties{..}
 
 setupInitialState : (HasToInterface a Holding.F, HasSignatory a, HasObserver a, HasEnsure a, HasAgreement a, HasCreate a, HasFetch a, HasArchive a, HasTemplateTypeRep a, HasToAnyTemplate a, HasFromAnyTemplate a, DA.Internal.Record.HasField "observers" a (M.Map k v), DA.Internal.Record.HasField "provider" a Party) => TestParties -> a -> Script TestInitialState
@@ -50,8 +52,7 @@ setupInitialState (tp : TestParties) (factory : a) = do
   -- Account and holding factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory custodian []
 
-  holdingFactoryCid <- toInterfaceContractId <$> submitMulti [custodian] [] do
-    createCmd factory with provider = custodian; observers = M.empty
+  holdingFactoryCid <- toInterfaceContractId <$> submitMulti [custodian] [] do createCmd factory
 
   -- Create account
   [issuerAccount, investorAccount] <- mapA (Account.createAccount [] accountFactoryCid holdingFactoryCid [] custodian) [issuer, investor]

--- a/src/test/daml/Daml/Finance/Asset/Test/Common.daml
+++ b/src/test/daml/Daml/Finance/Asset/Test/Common.daml
@@ -12,7 +12,7 @@ import Daml.Finance.Interface.Asset.Types
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Script
 
--- Parties involved in the test script
+-- | Parties involved in the test script.
 data TestParties = TestParties
   with
     custodian : Party
@@ -28,6 +28,7 @@ data TestParties = TestParties
     publicParty : Party
       -- ^ The public party. Every party can readAs the public party.
 
+-- | Initial test state.
 data TestInitialState = TestInitialState
   with
     investorAccount : AccountKey
@@ -39,12 +40,14 @@ data TestInitialState = TestInitialState
     issuerHoldingCid : ContractId Holding.I
       -- ^ Initial holding of the issuer.
 
+-- | Setup test parties.
 setupParties : Script TestParties
 setupParties = do
   -- Create parties
   [custodian, issuer, investor, locker, locker2, publicParty] <- createParties ["Custodian", "Issuer", "Investor", "Locker", "Locker2", "PublicParty"]
   pure TestParties{..}
 
+-- | Setup test initial state.
 setupInitialState : (HasToInterface a Holding.F, HasSignatory a, HasObserver a, HasEnsure a, HasAgreement a, HasCreate a, HasFetch a, HasArchive a, HasTemplateTypeRep a, HasToAnyTemplate a, HasFromAnyTemplate a, DA.Internal.Record.HasField "observers" a (M.Map k v), DA.Internal.Record.HasField "provider" a Party) => TestParties -> a -> Script TestInitialState
 setupInitialState (tp : TestParties) (factory : a) = do
   let TestParties{..} = tp

--- a/src/test/daml/Daml/Finance/Asset/Test/Fungible.daml
+++ b/src/test/daml/Daml/Finance/Asset/Test/Fungible.daml
@@ -3,7 +3,7 @@
 
 module Daml.Finance.Asset.Test.Fungible where
 
-import DA.Map qualified as M (empty)
+import DA.Map qualified as M (fromList)
 import DA.Set (singleton)
 import Daml.Finance.Asset.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Asset.Test.Common (TestInitialState(..), TestParties(..), setupInitialState, setupParties)
@@ -18,10 +18,10 @@ import Daml.Script
 run : Script ()
 run = script do
   -- Create parties
-  tp@TestParties{custodian; issuer; investor; locker; locker2} <- setupParties
+  tp@TestParties{custodian; issuer; investor; locker; locker2; publicParty} <- setupParties
 
   -- Initialize state with `Fungible.Factory`
-  TestInitialState {investorAccount; issuerAccount; issuerHoldingCid} <- setupInitialState tp (Fungible.Factory with provider = custodian; observers = M.empty)
+  TestInitialState {investorAccount; issuerAccount; issuerHoldingCid} <- setupInitialState tp (Fungible.Factory with provider = custodian; observers = M.fromList [("PublicParty", singleton $ singleton publicParty)])
 
   -- Lock asset
   lockableCid <- submitMulti [issuer, locker] [] do exerciseCmd (coerceContractId issuerHoldingCid : ContractId Lockable.I) Lockable.Acquire with newLocker = singleton locker; context = "Test Lock"; lockType = Lockable.Semaphore
@@ -53,7 +53,7 @@ run = script do
   fungibleCid <- submitMulti [issuer, investor] [] do exerciseCmd restCid Fungible.Merge with fungibleCids = [splitCid1, splitCid2]
 
   -- Transfer
-  transferableCid <- submitMulti [issuer, investor] [] do exerciseCmd (coerceContractId fungibleCid : ContractId Transferable.I) Transferable.Transfer with newOwnerAccount = investorAccount
+  transferableCid <- submitMulti [issuer, investor] [publicParty] do exerciseCmd (coerceContractId fungibleCid : ContractId Transferable.I) Transferable.Transfer with newOwnerAccount = investorAccount
 
   -- Assert state
   Holding.verifyOwnerOfHolding [(investor, transferableCid)]

--- a/src/test/daml/Daml/Finance/Asset/Test/NoCrossTransfer.daml
+++ b/src/test/daml/Daml/Finance/Asset/Test/NoCrossTransfer.daml
@@ -1,0 +1,43 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Daml.Finance.Asset.Test.NoCrossTransfer where
+
+import DA.Map qualified as M (fromList)
+import DA.Set (singleton)
+import Daml.Finance.Asset.Fungible qualified as Fungible (Factory(..))
+import Daml.Finance.Asset.NonFungible qualified as NonFungible (Factory(..))
+import Daml.Finance.Asset.Test.Common (TestInitialState(..), TestParties(..), setupInitialState, setupParties)
+import Daml.Finance.Asset.Test.Util.Account qualified as Account (createFactory)
+import Daml.Finance.Interface.Asset.Factory.Account qualified as Account (Create(..), F)
+import Daml.Finance.Interface.Asset.Transferable qualified as Transferable (I, Transfer(..))
+import Daml.Finance.Interface.Asset.Types (AccountKey(..))
+import Daml.Script
+
+-- | Verify that I cannot transfer a non-fungible holding to a fungible account.
+run : Script ()
+run = script do
+  -- Create parties
+  tp@TestParties{custodian; issuer; investor; locker; locker2; publicParty} <- setupParties
+
+  -- Initialize state with `NonFungible.Factory`
+  let pp = M.fromList [("PublicParty", singleton $ singleton publicParty)]
+  TestInitialState {issuerAccount; issuerHoldingCid} <- setupInitialState tp $ NonFungible.Factory with provider = custodian; observers = pp
+
+  -- Create investor account for fungible holdings
+  accountFactoryCid <- toInterfaceContractId @Account.F <$> Account.createFactory custodian []
+  holdingFactoryCid <- toInterfaceContractId <$> submit custodian do createCmd Fungible.Factory with provider = custodian; observers = pp
+  let
+    id = show investor <> "@" <> show custodian <> " - Fungible"
+    investorAccount = AccountKey with custodian; owner = investor; id
+  submitMulti [custodian, investor] [] do
+    exerciseCmd accountFactoryCid Account.Create
+      with
+        account = investorAccount
+        holdingFactoryCid
+        observers = M.fromList [("Issuer", singleton $ singleton issuer)]
+
+  -- Attempt to transfer a non-fungible holding to a fungible holding.
+  submitMultiMustFail [issuer, investor] [publicParty] do exerciseCmd (coerceContractId issuerHoldingCid : ContractId Transferable.I) Transferable.Transfer with newOwnerAccount = investorAccount
+
+  pure ()

--- a/src/test/daml/Daml/Finance/Asset/Test/NonFungible.daml
+++ b/src/test/daml/Daml/Finance/Asset/Test/NonFungible.daml
@@ -3,7 +3,7 @@
 
 module Daml.Finance.Asset.Test.NonFungible where
 
-import DA.Map qualified as M (empty)
+import DA.Map qualified as M (fromList)
 import DA.Set (singleton)
 import Daml.Finance.Asset.NonFungible qualified as NonFungible (Factory(..))
 import Daml.Finance.Asset.Test.Common (TestInitialState(..), TestParties(..), setupInitialState, setupParties)
@@ -18,10 +18,10 @@ import Daml.Script
 run : Script ()
 run = script do
   -- Create parties
-  tp@TestParties{custodian; issuer; investor; locker; locker2} <- setupParties
+  tp@TestParties{custodian; issuer; investor; locker; locker2; publicParty} <- setupParties
 
   -- Initialize state with `NonFungible.Factory`
-  TestInitialState {investorAccount; issuerAccount; issuerHoldingCid} <- setupInitialState tp (NonFungible.Factory with provider = custodian; observers = M.empty)
+  TestInitialState {investorAccount; issuerAccount; issuerHoldingCid} <- setupInitialState tp (NonFungible.Factory with provider = custodian; observers = M.fromList [("PublicParty", singleton $ singleton publicParty)])
 
   -- Cannot split
   submitMultiMustFail [issuer, investor] [] do exerciseCmd (coerceContractId issuerHoldingCid : ContractId Fungible.I) Fungible.Split with amounts = [100.0]
@@ -39,7 +39,7 @@ run = script do
   lockableCid <- submitMulti [locker] [] do exerciseCmd lockableCid Lockable.Release with context = "Test Lock"
 
   -- Transfer
-  transferableCid <- submitMulti [issuer, investor] [] do exerciseCmd (coerceContractId lockableCid : ContractId Transferable.I) Transferable.Transfer with newOwnerAccount = investorAccount
+  transferableCid <- submitMulti [issuer, investor] [publicParty] do exerciseCmd (coerceContractId lockableCid : ContractId Transferable.I) Transferable.Transfer with newOwnerAccount = investorAccount
 
   -- Assert state
   Holding.verifyOwnerOfHolding [(investor, transferableCid)]

--- a/src/test/daml/Daml/Finance/Bond/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Bond/Test/Util.daml
@@ -114,7 +114,7 @@ lifecycleAndVerifyCouponEffectsAndSettlement readAs today bondInstrument settler
     exerciseCmd custodianCashInstructionCid Instruction.Approve with receiverAccount = investorAccount
 
   -- Settle container
-  [investorCashTransferableCid] <- submitMulti [settler] [] do exerciseCmd result.containerCid Settleable.Settle
+  [investorCashTransferableCid] <- submitMulti [settler] readAs do exerciseCmd result.containerCid Settleable.Settle
 
   -- Assert state
   verifyOwnerOfHolding [(investor, investorBondHoldingCid), (investor, toInterfaceContractId investorCashTransferableCid)]
@@ -163,7 +163,7 @@ lifecycleAndVerifyRedemptionEffectsAndSettlement readAs today bondInstrument set
 
   -- Settle container
   [investorCouponTransferableCid, investorRedemptionTransferableCid] <-
-    submitMulti [settler] [] do exerciseCmd result.containerCid Settleable.Settle
+    submitMulti [settler] readAs do exerciseCmd result.containerCid Settleable.Settle
 
   -- Assert state
   verifyOwnerOfHolding [(investor, investorCouponTransferableCid), (investor, investorRedemptionTransferableCid)]

--- a/src/test/daml/Daml/Finance/Bond/Test/ZeroCoupon.daml
+++ b/src/test/daml/Daml/Finance/Bond/Test/ZeroCoupon.daml
@@ -63,7 +63,7 @@ lifecycleAndVerifyRedemptionEffectsAndSettlement readAs today bondInstrument set
 
   -- Settle container
   [investorRedemptionTransferableCid] <-
-    submitMulti [settler] [] do exerciseCmd result.containerCid Settleable.Settle
+    submitMulti [settler] readAs do exerciseCmd result.containerCid Settleable.Settle
 
   -- Assert state
   Holding.verifyOwnerOfHolding [(investor, investorRedemptionTransferableCid)]

--- a/src/test/daml/Daml/Finance/Derivative/Test/CallableBond.daml
+++ b/src/test/daml/Daml/Finance/Derivative/Test/CallableBond.daml
@@ -44,8 +44,6 @@ data TestParties = TestParties
       -- ^ Owner of the bond holding. Chooses to exercise the right of the call bond.
     settler : Party
       -- ^ Triggers the settlement of fully allocated settlement instructions.
-    provider : Party
-      -- ^ Acts as provider of account and holding factory.
     publicParty : Party
       -- ^ The public party. Every party can readAs the public party.
 
@@ -68,10 +66,10 @@ run = script do
   TestParties{..} <- setupParties
 
   -- Account and holding factory
-  let pp = [("factoryProvider", singleton $ singleton publicParty)]
-  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory provider pp
-  holdingFactoryCid <- toInterfaceContractId <$> submitMulti [provider] [] do
-    createCmd Fungible.Factory with provider; observers = M.fromList pp
+  let pp = [("PublicParty", singleton $ singleton publicParty)]
+  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
+  holdingFactoryCid <- toInterfaceContractId <$> submit bank do
+    createCmd Fungible.Factory with provider = bank; observers = M.fromList pp
 
   -- Create accounts
   [bankAccount, investorAccount] <- mapA (Account.createAccount [publicParty] accountFactoryCid holdingFactoryCid [] bank) [bank, investor]
@@ -167,7 +165,7 @@ run = script do
   bankCashInstructionPrincipalCid <- submitMulti [investor] [] do exerciseCmd bankCashInstructionPrincipalCid Instruction.Approve with receiverAccount = investorAccount
 
   -- Settle container
-  [investorCashTransferableCouponCid, investorCashTransferablePrincipalCid] <- submitMulti [settler] [] do exerciseCmd result.containerCid Settleable.Settle
+  [investorCashTransferableCouponCid, investorCashTransferablePrincipalCid] <- submitMulti [settler] [publicParty] do exerciseCmd result.containerCid Settleable.Settle
 
   -- Assert state
   Some investorCoupon <- queryContractId @Fungible.T investor $ coerceContractId investorCashTransferableCouponCid
@@ -181,6 +179,6 @@ run = script do
 
 setupParties : Script TestParties
 setupParties = do
-  [bank, issuer, centralBank, investor, settler, provider, publicParty] <-
-    createParties ["Bank", "issuer", "Central Bank", "Investor", "Settler", "Provider", "PublicParty"]
-  pure $ TestParties with bank; issuer; centralBank; investor; settler; provider; publicParty
+  [bank, issuer, centralBank, investor, settler, publicParty] <-
+    createParties ["Bank", "issuer", "Central Bank", "Investor", "Settler", "PublicParty"]
+  pure $ TestParties with bank; issuer; centralBank; investor; settler; publicParty

--- a/src/test/daml/Daml/Finance/Derivative/Test/EuropeanOption.daml
+++ b/src/test/daml/Daml/Finance/Derivative/Test/EuropeanOption.daml
@@ -48,8 +48,6 @@ data TestParties = TestParties
       -- ^ Owner of the option holding. Chooses to not exercise the right of the call option.
     settler : Party
       -- ^ Triggers the settlement of fully allocated settlement instructions.
-    provider : Party
-      -- ^ Acts as provider of account and holding factory.
     publicParty : Party
       -- ^ The public party. Every party can readAs the public party.
 
@@ -71,10 +69,10 @@ run = script do
   TestParties{..} <- setupParties
 
   -- Account and holding factory
-  let pp = [("factoryProvider", singleton $ singleton publicParty)]
-  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory provider pp
-  holdingFactoryCid <- toInterfaceContractId <$> submitMulti [provider] [] do
-    createCmd Fungible.Factory with provider; observers = M.fromList pp
+  let pp = [("PublicParty", singleton $ singleton publicParty)]
+  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
+  holdingFactoryCid <- toInterfaceContractId <$> submit bank do
+    createCmd Fungible.Factory with provider = bank; observers = M.fromList pp
 
   -- Create accounts
   [bankAccount, investor1Account, investor2Account] <- mapA (Account.createAccount [publicParty] accountFactoryCid holdingFactoryCid [] bank) [bank, investor1, investor2]
@@ -189,7 +187,7 @@ run = script do
   bankCashInstructionCid <- submitMulti [investor1] [] do exerciseCmd bankCashInstructionCid Instruction.Approve with receiverAccount = investor1Account
 
   -- Settle container
-  [investorCashTransferableCid] <- submitMulti [settler] [] do exerciseCmd result.containerCid Settleable.Settle
+  [investorCashTransferableCid] <- submitMulti [settler] [publicParty] do exerciseCmd result.containerCid Settleable.Settle
 
   -- Assert state
   Some investorCash <- queryContractId @Fungible.T investor1 $ coerceContractId investorCashTransferableCid
@@ -248,6 +246,6 @@ run = script do
 
 setupParties : Script TestParties
 setupParties = do
-  [bank, broker, centralBank, investor1, investor2, settler, provider, publicParty] <-
-    createParties ["Bank", "Broker", "Central Bank", "Investor 1", "Investor 2", "Settler", "Provider", "PublicParty"]
-  pure $ TestParties with bank; broker; centralBank; investor1; investor2; settler; provider; publicParty
+  [bank, broker, centralBank, investor1, investor2, settler, publicParty] <-
+    createParties ["Bank", "Broker", "Central Bank", "Investor 1", "Investor 2", "Settler", "PublicParty"]
+  pure $ TestParties with bank; broker; centralBank; investor1; investor2; settler; publicParty

--- a/src/test/daml/Daml/Finance/Derivative/Test/ForwardCash.daml
+++ b/src/test/daml/Daml/Finance/Derivative/Test/ForwardCash.daml
@@ -37,8 +37,6 @@ data TestParties = TestParties
       -- ^ Owner of the equity forward holding.
     settler : Party
       -- ^ Triggers the settlement of fully allocated settlement instructions.
-    provider : Party
-      -- ^ Acts as provider of account and holding factory.
     publicParty : Party
       -- ^ The public party. Every party can readAs the public party.
 
@@ -49,16 +47,16 @@ run = script do
 
   -- Account and holding factory
   let pp = [("factoryProvider", singleton $ singleton publicParty)]
-  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory provider pp
-  holdingFactoryCid <- toInterfaceContractId <$> submitMulti [provider] [] do
-    createCmd Fungible.Factory with provider; observers = M.fromList pp
+  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
+  holdingFactoryCid <- toInterfaceContractId <$> submit bank do
+    createCmd Fungible.Factory with provider = bank; observers = M.fromList pp
 
   -- Create accounts
   [bankOwnAccount, investorAccount] <- mapA (Account.createAccount [publicParty] accountFactoryCid holdingFactoryCid [] bank) [bank, investor]
 
   -- Distribute cash
   now <- getTime
-  let obs = [("public party", singleton $ singleton publicParty)]
+  let obs = [("PublicParty", singleton $ singleton publicParty)]
   cashInstrument <- Instrument.originate centralBank centralBank "USD" obs now
   bankCashTransferableCid <- Account.credit [publicParty] cashInstrument 50_000.0 bankOwnAccount
 
@@ -113,7 +111,7 @@ run = script do
   bankCashInstructionCid <- submitMulti [investor] [] do exerciseCmd bankCashInstructionCid Instruction.Approve with receiverAccount = investorAccount
 
   -- Settle container
-  [investorCashTransferableCid] <- submitMulti [settler] [] do exerciseCmd result.containerCid Settleable.Settle
+  [investorCashTransferableCid] <- submitMulti [settler] [publicParty] do exerciseCmd result.containerCid Settleable.Settle
 
   -- Assert state
   Holding.verifyOwnerOfHolding [(investor, investorCashTransferableCid)]
@@ -122,6 +120,6 @@ run = script do
 
 setupParties : Script TestParties
 setupParties = do
-  [bank, broker, centralBank, investor, settler, provider, publicParty] <-
-    createParties ["Bank", "Broker", "Central Bank", "Investor", "Settler", "Provider", "PublicParty"]
-  pure $ TestParties with bank; broker; centralBank; investor; settler; provider; publicParty
+  [bank, broker, centralBank, investor, settler, publicParty] <-
+    createParties ["Bank", "Broker", "Central Bank", "Investor", "Settler", "PublicParty"]
+  pure $ TestParties with bank; broker; centralBank; investor; settler; publicParty

--- a/src/test/daml/Daml/Finance/Derivative/Test/ForwardPhysical.daml
+++ b/src/test/daml/Daml/Finance/Derivative/Test/ForwardPhysical.daml
@@ -39,8 +39,6 @@ data TestParties = TestParties
       -- ^ Owner of the equity forward holding.
     settler : Party
       -- ^ Triggers the settlement of fully allocated settlement instructions.
-    provider : Party
-      -- ^ Acts as provider of account and holding factory.
     publicParty : Party
       -- ^ The public party. Every party can readAs the public party.
 
@@ -50,10 +48,10 @@ run = script do
   TestParties{..} <- setupParties
 
   -- Account and holding factory
-  let pp = [("factoryProvider", singleton $ singleton publicParty)]
-  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory provider pp
-  holdingFactoryCid <- toInterfaceContractId <$> submitMulti [provider] [] do
-    createCmd Fungible.Factory with provider; observers = M.fromList pp
+  let pp = [("PublicParty", singleton $ singleton publicParty)]
+  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
+  holdingFactoryCid <- toInterfaceContractId <$> submit bank do
+    createCmd Fungible.Factory with provider = bank; observers = M.fromList pp
 
   -- Create accounts
   [bankOwnAccount, investorAccount] <- mapA (Account.createAccount [publicParty] accountFactoryCid holdingFactoryCid [] bank) [bank, investor]
@@ -116,7 +114,7 @@ run = script do
 
   -- Settle container
   [bankCashTransferableCid, investorEquityTransferableCid] <-
-    submitMulti [settler] [] do exerciseCmd result.containerCid Settleable.Settle
+    submitMulti [settler] [publicParty] do exerciseCmd result.containerCid Settleable.Settle
 
   -- Assert state
   Holding.verifyOwnerOfHolding [(bank, bankCashTransferableCid), (investor, investorEquityTransferableCid)]
@@ -125,6 +123,6 @@ run = script do
 
 setupParties : Script TestParties
 setupParties = do
-  [bank, broker, centralBank, equityIssuer, investor, settler, provider, publicParty] <-
-    createParties ["Bank", "Broker", "Central Bank", "Equity Issuer", "Investor", "Settler", "Provider", "PublicParty"]
-  pure $ TestParties with bank; broker; centralBank; equityIssuer; investor; settler; provider; publicParty
+  [bank, broker, centralBank, equityIssuer, investor, settler, publicParty] <-
+    createParties ["Bank", "Broker", "Central Bank", "Equity Issuer", "Investor", "Settler", "PublicParty"]
+  pure $ TestParties with bank; broker; centralBank; equityIssuer; investor; settler; publicParty

--- a/src/test/daml/Daml/Finance/Derivative/Test/Intermediated/BondCoupon.daml
+++ b/src/test/daml/Daml/Finance/Derivative/Test/Intermediated/BondCoupon.daml
@@ -11,7 +11,7 @@ import DA.Foldable qualified as F (forA_)
 import DA.Map qualified as M (empty, fromList)
 import DA.Set (empty, fromList, singleton)
 import Daml.Finance.Asset.Fungible qualified as Fungible (Factory(..))
-import Daml.Finance.Asset.Test.Util.Account qualified as Account (createAccount, createFactory, credit)
+import Daml.Finance.Asset.Test.Util.Account qualified as Account (createAccount, createFactory, credit, submitExerciseInterfaceByKeyCmd)
 import Daml.Finance.Asset.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
 import Daml.Finance.Asset.Test.Util.Instrument qualified as BaseInstrument (originate, submitExerciseInterfaceByKeyCmd)
 import Daml.Finance.Derivative.Test.Util (originateDerivative, mapClaimToUTCTime)
@@ -20,6 +20,7 @@ import Daml.Finance.Interface.Asset.Holding qualified as Holding (I)
 import Daml.Finance.Interface.Asset.Instrument qualified as BaseInstrument (GetCid(..), R)
 import Daml.Finance.Interface.Asset.Transferable qualified as Transferable (I, Transfer(..))
 import Daml.Finance.Interface.Asset.Util (getAmount, getInstrument, getOwner)
+import Daml.Finance.Interface.Common.Disclosure qualified as Disclosure (I, AddObservers(..))
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (SetProvider(..), GetView(..), I)
 import Daml.Finance.Interface.Lifecycle.Lifecyclable qualified as Lifecyclable (I, Lifecycle(..))
 import Daml.Finance.Interface.Lifecycle.SettlementRule qualified as SettlementRule (Claim(..))
@@ -74,36 +75,35 @@ data TestParties = TestParties
       -- ^ Owner of the bond holding.
     settler : Party
       -- ^ Triggers the settlement of fully allocated settlement instructions.
-    provider : Party
-      -- ^ Acts as provider of account and holding factory.
     publicParty : Party
       -- ^ The public party. Every party can readAs the public party.
 
--- Penultimate coupon payment on a bond showing creation of new instrument version
+-- | Setup a set of accounts.
+setupAccounts : Party -> Party -> [Party] -> Script [Account.K]
+setupAccounts custodian publicParty owners = do
+  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory custodian []
+  holdingFactoryCid <- toInterfaceContractId <$> submit custodian do
+    createCmd Fungible.Factory with provider= custodian; observers = M.fromList [("PublicParty", singleton $ singleton publicParty)]
+  forA owners $ Account.createAccount [] accountFactoryCid holdingFactoryCid [] custodian
+
+-- | Penultimate coupon payment on a bond showing creation of new instrument version.
 run : Script ()
 run = script do
   TestParties{..} <- setupParties
 
-  -- Account and holding factory
-  let pp = [("factoryProvider", singleton $ singleton publicParty)]
-  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory provider pp
-  holdingFactoryCid <- toInterfaceContractId <$> submitMulti [provider] [] do
-    createCmd Fungible.Factory with provider; observers = M.fromList pp
-
   -- Setup security accounts
-  [csdOwnSecurityAccount, investorSecurityAccount] <- mapA (Account.createAccount [publicParty] accountFactoryCid holdingFactoryCid [] csd) [csd, investor]
-  csdAccountAtIssuer <- Account.createAccount [publicParty] accountFactoryCid holdingFactoryCid [] issuer csd
+  [csdOwnSecurityAccount, investorSecurityAccount] <- setupAccounts csd publicParty [csd, investor]
+  [csdAccountAtIssuer] <- setupAccounts issuer publicParty [csd]
 
   -- Setup cash accounts at central bank
-  [issuerCashAccount, bankCashAccount] <- mapA (Account.createAccount [publicParty] accountFactoryCid holdingFactoryCid [] centralBank) [issuer, bank]
-  csdCashAccount <- Account.createAccount [publicParty] accountFactoryCid holdingFactoryCid [("Issuer", singleton $ singleton issuer)] centralBank csd
+  [issuerCashAccount, bankCashAccount, csdCashAccount] <- setupAccounts centralBank publicParty [issuer, bank, csd]
 
   -- Setup Issuer's cash account at Bank
-  [investorCashAccount, bankOwnCashAccount] <- mapA (Account.createAccount [publicParty] accountFactoryCid holdingFactoryCid [] bank) [investor, bank]
+  [investorCashAccount, bankOwnCashAccount] <- setupAccounts bank publicParty [investor, bank]
 
   -- Distribute central-bank cash
   now <- getTime
-  let obs = [("public party", singleton $ singleton publicParty)]
+  let obs = [("PublicParty", singleton $ singleton publicParty)]
   cashInstrument <- BaseInstrument.originate centralBank centralBank "USD" obs now
   issuerCashTransferableCid <- Account.credit [publicParty] cashInstrument 20_000.0 issuerCashAccount
 
@@ -132,6 +132,10 @@ run = script do
   (derivativeLifecyclableCid2, [effectCid]) <- BaseInstrument.submitExerciseInterfaceByKeyCmd @Lifecyclable.I [issuer] [] derivativeInstrument Lifecyclable.Lifecycle with settler; eventCid = clockEventCid; observableCids = []; ruleName = "Time"; clockCid
 
   -- setup settlement contract between issuer and CSD
+  -- Setup settlement contract between issuer and CSD
+  -- In order for the workflow to be successful, we need to disclose the CSD's cash account to the Issuer.
+  Account.submitExerciseInterfaceByKeyCmd @Disclosure.I [csd] [] csdCashAccount Disclosure.AddObservers with disclosers = singleton csd; observersToAdd = ("Issuer", singleton issuer)
+
   settle1Cid <- submitMulti [csd, issuer] [] do
     createCmd EffectSettlementService
       with
@@ -197,7 +201,7 @@ run = script do
     exerciseCmd bankCashInstructionCid Instruction.Approve with receiverAccount = investorCashAccount
 
   -- Settle container
-  [bankCashTransferableCid, investorCashTransferableCid] <- submitMulti [settler] [] do exerciseCmd result.containerCid Settleable.Settle
+  [bankCashTransferableCid, investorCashTransferableCid] <- submitMulti [settler] [publicParty] do exerciseCmd result.containerCid Settleable.Settle
 
   -- Assert state
   Holding.verifyOwnerOfHolding
@@ -210,8 +214,8 @@ run = script do
 
 setupParties : Script TestParties
 setupParties = do
-  [bank, centralBank, csd, issuer, investor, settler, provider, publicParty] <- createParties ["Bank", "CentralBank", "CSD", "Issuer", "Investor", "Settler", "Provider", "PublicParty"]
-  pure $ TestParties with bank; centralBank; csd; issuer; investor; settler; provider; publicParty
+  [bank, centralBank, csd, issuer, investor, settler, publicParty] <- createParties ["Bank", "CentralBank", "CSD", "Issuer", "Investor", "Settler", "PublicParty"]
+  pure $ TestParties with bank; centralBank; csd; issuer; investor; settler; publicParty
 
 -- | Service template that allows to claim an effect and settle the corresponding transactions atomically.
 template EffectSettlementService

--- a/src/test/daml/Daml/Finance/Equity/Test/CashDividend.daml
+++ b/src/test/daml/Daml/Finance/Equity/Test/CashDividend.daml
@@ -29,24 +29,23 @@ import Daml.Script
 run : Script ()
 run = script do
   -- Create parties
-  [cb, depository, bank, issuer, investor, settler, provider, publicParty] <-
-    createParties ["CentralBank", "CSD", "Bank", "Issuer", "Investor", "Settler", "Provider", "PublicParty"]
+  [cb, depository, bank, issuer, investor, settler, publicParty] <-
+    createParties ["CentralBank", "CSD", "Bank", "Issuer", "Investor", "Settler", "PublicParty"]
 
   -- Account and holding factory
-  let pp = [("factoryProvider", singleton $ singleton publicParty)]
-  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory provider pp
-  holdingFactoryCid <- toInterfaceContractId <$> submitMulti [provider] [] do
-    createCmd Fungible.Factory with provider; observers = M.fromList pp
+  let pp = [("PublicParty", singleton $ singleton publicParty)]
+  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
+  holdingFactoryCid <- toInterfaceContractId <$> submit bank do
+    createCmd Fungible.Factory with provider = bank; observers = M.fromList pp
 
   -- Create accounts
   [bankAccount, investorAccount] <- mapA (Account.createAccount [publicParty] accountFactoryCid holdingFactoryCid [] bank) [bank, investor]
 
   -- Distribute assets
   now <- getTime
-  let obs = [("public party", singleton $ singleton publicParty)]
-  equityInstrument <- originateEquity depository issuer "AAPL" "0" obs now
+  equityInstrument <- originateEquity depository issuer "AAPL" "0" pp now
   investorEquityTransferableCid <- Account.credit [publicParty] equityInstrument 1_000.0 investorAccount
-  cashInstrument <- originate cb issuer "USD" obs now
+  cashInstrument <- originate cb issuer "USD" pp now
   bankCashTransferableCid <- Account.credit [publicParty] cashInstrument 2_000.0 bankAccount
 
   -- Originate new equity version
@@ -100,7 +99,7 @@ run = script do
   bankCashInstructionCid <- submitMulti [investor] [] do exerciseCmd bankCashInstructionCid Instruction.Approve with receiverAccount = investorAccount
 
   -- Settle container
-  [investorCashTransferableCid] <- submitMulti [settler] [] do exerciseCmd result.containerCid Settleable.Settle
+  [investorCashTransferableCid] <- submitMulti [settler] [publicParty] do exerciseCmd result.containerCid Settleable.Settle
 
   -- Assert state
   Holding.verifyOwnerOfHolding [(investor, investorEquityTransferableCid), (investor, coerceContractId investorCashTransferableCid)]

--- a/src/test/daml/Daml/Finance/Equity/Test/CashTakeover.daml
+++ b/src/test/daml/Daml/Finance/Equity/Test/CashTakeover.daml
@@ -29,24 +29,23 @@ import Daml.Script
 run : Script ()
 run = script do
   -- Create parties
-  [cb, depository, bank, issuer, buyer, investor, settler, provider, publicParty] <-
-    createParties ["CentralBank", "CSD", "Bank", "Issuer", "Buyer", "Investor", "Settler", "Provider", "PublicParty"]
+  [cb, depository, bank, issuer, buyer, investor, settler, publicParty] <-
+    createParties ["CentralBank", "CSD", "Bank", "Issuer", "Buyer", "Investor", "Settler", "PublicParty"]
 
   -- Account and holding factory
-  let pp = [("factoryProvider", singleton $ singleton publicParty)]
-  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory provider pp
-  holdingFactoryCid <- toInterfaceContractId <$> submitMulti [provider] [] do
-    createCmd Fungible.Factory with provider; observers = M.fromList pp
+  let pp = [("PublicParty", singleton $ singleton publicParty)]
+  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
+  holdingFactoryCid <- toInterfaceContractId <$> submit bank do
+    createCmd Fungible.Factory with provider = bank; observers = M.fromList pp
 
   -- Create accounts
   [bankAccount, investorAccount] <- mapA (Account.createAccount [publicParty] accountFactoryCid holdingFactoryCid [] bank) [bank, investor]
 
   -- Distribute assets
   now <- getTime
-  let obs = [("public party", singleton $ singleton publicParty)]
-  equityInstrument <- originateEquity depository issuer "AAPL" "0" obs now
+  equityInstrument <- originateEquity depository issuer "AAPL" "0" pp now
   investorEquityTransferableCid <- Account.credit [publicParty] equityInstrument 1_000.0 investorAccount
-  cashInstrument <- originate cb issuer "USD" obs now
+  cashInstrument <- originate cb issuer "USD" pp now
   bankCashTransferableCid <- Account.credit [publicParty] cashInstrument 50_000.0 bankAccount
 
   -- Create takeover
@@ -95,7 +94,7 @@ run = script do
   bankCashInstructionCid <- submitMulti [investor] [] do exerciseCmd bankCashInstructionCid Instruction.Approve with receiverAccount = investorAccount
 
   -- Settle container
-  [investorCashTransferableCid] <- submitMulti [settler] [] do exerciseCmd result.containerCid Settleable.Settle
+  [investorCashTransferableCid] <- submitMulti [settler] [publicParty] do exerciseCmd result.containerCid Settleable.Settle
 
   -- Assert state
   Holding.verifyOwnerOfHolding [(investor, investorCashTransferableCid)]

--- a/src/test/daml/Daml/Finance/Equity/Test/Merger.daml
+++ b/src/test/daml/Daml/Finance/Equity/Test/Merger.daml
@@ -28,24 +28,23 @@ import Daml.Script
 run : Script ()
 run = script do
   -- Create parties
-  [depository, bank, issuer1, issuer2, issuer3, investor, settler, provider, publicParty] <-
-    createParties ["CSD", "Bank", "Issuer1", "Issuer2", "Issuer3", "Investor", "Settler", "Provider", "PublicParty"]
+  [depository, bank, issuer1, issuer2, issuer3, investor, settler, publicParty] <-
+    createParties ["CSD", "Bank", "Issuer1", "Issuer2", "Issuer3", "Investor", "Settler", "PublicParty"]
 
   -- Account and holding factory
-  let pp = [("factoryProvider", singleton $ singleton publicParty)]
-  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory provider pp
-  holdingFactoryCid <- toInterfaceContractId <$> submitMulti [provider] [] do
-    createCmd Fungible.Factory with provider; observers = M.fromList pp
+  let pp = [("PublicParty", singleton $ singleton publicParty)]
+  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
+  holdingFactoryCid <- toInterfaceContractId <$> submit bank do
+    createCmd Fungible.Factory with provider = bank; observers = M.fromList pp
 
   -- Create accounts
   [bankAccount, investorAccount] <- mapA (Account.createAccount [publicParty] accountFactoryCid holdingFactoryCid [] bank) [bank, investor]
 
   -- Distribute assets
   now <- getTime
-  let obs = [("public party", singleton $ singleton publicParty)]
-  mergingInstrument <- originateEquity depository issuer1 "ABC" "0" obs now
+  mergingInstrument <- originateEquity depository issuer1 "ABC" "0" pp now
   investorEquityCid <- Account.credit [publicParty] mergingInstrument 2_000.0 investorAccount
-  emergingInstrument <- originateEquity depository issuer2 "XYZ" "0" obs now
+  emergingInstrument <- originateEquity depository issuer2 "XYZ" "0" pp now
   bankEquityCid <- Account.credit [publicParty] emergingInstrument 1_000.0 bankAccount
 
   -- Create merger
@@ -95,7 +94,7 @@ run = script do
   bankEquityInstructionCid <- submitMulti [investor] [] do exerciseCmd bankEquityInstructionCid Instruction.Approve with receiverAccount = investorAccount
 
   -- Settle container
-  [investorEquityCid] <- submitMulti [settler] [] do exerciseCmd result.containerCid Settleable.Settle
+  [investorEquityCid] <- submitMulti [settler] [publicParty] do exerciseCmd result.containerCid Settleable.Settle
 
   -- Assert state
   Holding.verifyOwnerOfHolding [(investor, investorEquityCid)]

--- a/src/test/daml/Daml/Finance/Equity/Test/ShareDividend.daml
+++ b/src/test/daml/Daml/Finance/Equity/Test/ShareDividend.daml
@@ -28,22 +28,21 @@ import Daml.Script
 run : Script ()
 run = script do
   -- Create parties
-  [depository, bank, issuer, investor, settler, provider, publicParty] <-
-    createParties ["CSD", "Bank", "Issuer", "Investor", "Settler", "Provider", "PublicParty"]
+  [depository, bank, issuer, investor, settler, publicParty] <-
+    createParties ["CSD", "Bank", "Issuer", "Investor", "Settler", "PublicParty"]
 
   -- Account and holding factory
-  let pp = [("factoryProvider", singleton $ singleton publicParty)]
-  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory provider pp
-  holdingFactoryCid <- toInterfaceContractId <$> submitMulti [provider] [] do
-    createCmd Fungible.Factory with provider; observers = M.fromList pp
+  let pp = [("PublicParty", singleton $ singleton publicParty)]
+  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
+  holdingFactoryCid <- toInterfaceContractId <$> submit bank do
+    createCmd Fungible.Factory with provider = bank; observers = M.fromList pp
 
   -- Create accounts
   [bankAccount, investorAccount] <- mapA (Account.createAccount [publicParty] accountFactoryCid holdingFactoryCid [] bank) [bank, investor]
 
   -- Distribute assets
   now <- getTime
-  let obs = [("public party", singleton $ singleton publicParty)]
-  equityInstrument <- originateEquity depository issuer "AAPL" "0" obs now
+  equityInstrument <- originateEquity depository issuer "AAPL" "0" pp now
   investorEquityTransferableCid <- Account.credit [publicParty] equityInstrument 1_000.0 investorAccount
 
   -- Originate new equity version
@@ -99,7 +98,7 @@ run = script do
   issuerEquityInstructionCid <- submitMulti [investor] [] do exerciseCmd bankEquityInstructionCid Instruction.Approve with receiverAccount = investorAccount
 
   -- Settle container
-  [investorEquityTransferableCid2] <- submitMulti [settler] [] do fmap coerceContractId <$> exerciseCmd result.containerCid Settleable.Settle
+  [investorEquityTransferableCid2] <- submitMulti [settler] [publicParty] do fmap coerceContractId <$> exerciseCmd result.containerCid Settleable.Settle
 
   -- Assert state
   Holding.verifyOwnerOfHolding [(investor, investorEquityTransferableCid1), (investor, investorEquityTransferableCid2)]

--- a/src/test/daml/Daml/Finance/Equity/Test/ShareTakeover.daml
+++ b/src/test/daml/Daml/Finance/Equity/Test/ShareTakeover.daml
@@ -28,24 +28,23 @@ import Daml.Script
 run : Script ()
 run = script do
   -- Create parties
-  [depository, bank, issuer, buyer, investor, settler, provider, publicParty] <-
-    createParties ["CSD", "Bank", "Issuer", "Buyer", "Investor", "Settler", "Provider", "PublicParty"]
+  [depository, bank, issuer, buyer, investor, settler, publicParty] <-
+    createParties ["CSD", "Bank", "Issuer", "Buyer", "Investor", "Settler", "PublicParty"]
 
   -- Account and holding factory
-  let pp = [("factoryProvider", singleton $ singleton publicParty)]
-  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory provider pp
-  holdingFactoryCid <- toInterfaceContractId <$> submitMulti [provider] [] do
-    createCmd Fungible.Factory with provider; observers = M.fromList pp
+  let pp = [("PublicParty", singleton $ singleton publicParty)]
+  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
+  holdingFactoryCid <- toInterfaceContractId <$> submit bank do
+    createCmd Fungible.Factory with provider = bank; observers = M.fromList pp
 
   -- Create accounts
   [bankAccount, investorAccount] <- mapA (Account.createAccount [publicParty] accountFactoryCid holdingFactoryCid [] bank) [bank, investor]
 
   -- Distribute assets
   now <- getTime
-  let obs = [("public party", singleton $ singleton publicParty)]
-  issuerEquityInstrument <- originateEquity depository issuer "ABC" "0" obs now
+  issuerEquityInstrument <- originateEquity depository issuer "ABC" "0" pp now
   investorEquityTransferableCid <- Account.credit [publicParty] issuerEquityInstrument 1_000.0 investorAccount
-  buyerEquityInstrument <- originateEquity depository buyer "XYZ" "0" obs now
+  buyerEquityInstrument <- originateEquity depository buyer "XYZ" "0" pp now
   bankEquityTransferableCid <- Account.credit [publicParty] buyerEquityInstrument 5_000.0 bankAccount
 
   -- Create takeover
@@ -94,7 +93,7 @@ run = script do
   bankEquityInstructionCid <- submitMulti [investor] [] do exerciseCmd bankEquityInstructionCid Instruction.Approve with receiverAccount = investorAccount
 
   -- Settle container
-  [investorEquityTransferableCid] <- submitMulti [settler] [] do exerciseCmd result.containerCid Settleable.Settle
+  [investorEquityTransferableCid] <- submitMulti [settler] [publicParty] do exerciseCmd result.containerCid Settleable.Settle
 
   -- Assert state
   Holding.verifyOwnerOfHolding [(investor, investorEquityTransferableCid)]

--- a/src/test/daml/Daml/Finance/Settlement/Test/BatchWithRoute.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/BatchWithRoute.daml
@@ -3,7 +3,7 @@
 
 module Daml.Finance.Settlement.Test.BatchWithRoute where
 
-import DA.Map qualified as M (empty, fromList)
+import DA.Map qualified as M (fromList)
 import DA.Set (empty, singleton)
 import Daml.Finance.Asset.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Asset.Test.Util.Account qualified as Account (createAccount, createFactory, credit)
@@ -31,6 +31,8 @@ data TestParties = TestParties
       -- ^ Depository of the equity instrument. Custodian of the equity holdings of Bank 1 and Issuer.
     issuer : Party
       -- ^ Issuer of the equity instrument. Receives cash in exchange for units of equity.
+    publicParty : Party
+      -- ^ The public party. Every party can readAs the public party.
 
 -- | DvP via settlement chain and instructions.
 -- Bank transfers cash to Issuer in exchange for an equity instrument (detained by issuer at depository).
@@ -53,21 +55,22 @@ run = script do
   TestParties{..} <- setupParties
 
   -- Setup security accounts
+  let pp = [("PublicParty", singleton $ singleton publicParty)]
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory depository []
   holdingFactoryCid <- toInterfaceContractId <$> submitMulti [depository] [] do
-    createCmd Fungible.Factory with provider = depository; observers = M.empty
+    createCmd Fungible.Factory with provider = depository; observers = M.fromList pp
   [bank1SecurityAccount, issuerSecurityAccount] <- mapA (Account.createAccount [] accountFactoryCid holdingFactoryCid [] depository) [bank1, issuer]
 
   -- Setup cash accounts at CB
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory cb []
   holdingFactoryCid <- toInterfaceContractId <$> submitMulti [cb] [] do
-    createCmd Fungible.Factory with provider = cb; observers = M.empty
+    createCmd Fungible.Factory with provider = cb; observers = M.fromList pp
   [bank1CashAccount, bank2CashAccount] <- mapA (Account.createAccount [] accountFactoryCid holdingFactoryCid [] cb) [bank1, bank2]
 
   -- Setup cash accounts at Bank 2
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank2 []
   holdingFactoryCid <- toInterfaceContractId <$> submitMulti [bank2] [] do
-    createCmd Fungible.Factory with provider = bank2; observers = M.empty
+    createCmd Fungible.Factory with provider = bank2; observers = M.fromList pp
   [bank2OwnCashAccount, issuerCashAccount] <- mapA (Account.createAccount [] accountFactoryCid holdingFactoryCid [] bank2) [bank2, issuer]
 
   -- Distribute assets
@@ -113,7 +116,7 @@ run = script do
 
   -- Settle container
   [equityTransferableCid, bank2CashTransferableCid, issuerCashTransferableCid] <-
-    submitMulti [bank1] [] do exerciseCmd containerSettleableCid Settleable.Settle
+    submitMulti [bank1] [publicParty] do exerciseCmd containerSettleableCid Settleable.Settle
 
   -- Assert state
   Holding.verifyOwnerOfHolding [(bank1, equityTransferableCid), (bank2, bank2CashTransferableCid), (issuer, issuerCashTransferableCid)]
@@ -122,5 +125,5 @@ run = script do
 
 setupParties : Script TestParties
 setupParties = do
-  [cb, depository, bank1, bank2, issuer] <- createParties ["CentralBank", "CSD", "Bank 1", "Bank 2", "Issuer"]
-  pure TestParties with cb, depository, bank1, bank2, issuer
+  [cb, depository, bank1, bank2, issuer, publicParty] <- createParties ["CentralBank", "CSD", "Bank 1", "Bank 2", "Issuer", "PublicParty"]
+  pure TestParties with cb, depository, bank1, bank2, issuer, publicParty

--- a/src/test/daml/Daml/Finance/Settlement/Test/Intermediated.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Intermediated.daml
@@ -3,7 +3,7 @@
 
 module Daml.Finance.Settlement.Test.Intermediated where
 
-import DA.Map qualified as M (empty)
+import DA.Map qualified as M (fromList)
 import DA.Set (empty, singleton)
 import Daml.Finance.Asset.Fungible qualified as Fungible (Factory(..), T)
 import Daml.Finance.Asset.Test.Util.Account qualified as Account (createAccount, createFactory, credit, submitExerciseInterfaceByKeyCmd)
@@ -61,9 +61,10 @@ run useDelegatee = script do
   TestParties{..} <- setupParties
 
   -- Account and holding factory
+  let pp = [("PublicParty", singleton $ singleton publicParty)]
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory publicParty []
   holdingFactoryCid <- toInterfaceContractId <$> submitMulti [publicParty] [] do
-    createCmd Fungible.Factory with provider = publicParty; observers = M.empty
+    createCmd Fungible.Factory with provider = publicParty; observers = M.fromList pp
 
   -- Create accounts
   let
@@ -158,7 +159,7 @@ run useDelegatee = script do
   custodian2InstructionCid <- submitMulti [alice] [] do exerciseCmd custodian2InstructionCid Instruction.Approve with receiverAccount = aliceDepoAccount
 
   -- Settle container
-  [bank1CashCid, bank2CashCid, bobCashCid, custodian1AssetCid, custodian2AssetCid, aliceAssetCid] <- submitMulti [agent] [] do exerciseCmd containerSettleableCid Settleable.Settle
+  [bank1CashCid, bank2CashCid, bobCashCid, custodian1AssetCid, custodian2AssetCid, aliceAssetCid] <- submitMulti [agent] [publicParty] do exerciseCmd containerSettleableCid Settleable.Settle
 
   -- Assert state
   Holding.verifyOwnerOfHolding [(bank1, bank1CashCid), (bank2, bank2CashCid), (bob, bobCashCid), (custodian1, custodian1AssetCid), (custodian2, custodian2AssetCid), (alice, aliceAssetCid)]

--- a/src/test/daml/Daml/Finance/Settlement/Test/Transfer.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Transfer.daml
@@ -3,7 +3,7 @@
 
 module Daml.Finance.Settlement.Test.Transfer where
 
-import DA.Map qualified as M (empty)
+import DA.Map qualified as M (fromList)
 import DA.Set (empty, singleton)
 import Daml.Finance.Asset.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Asset.Test.Util.Account qualified as Account (credit, createAccount, createFactory)
@@ -41,10 +41,10 @@ run = script do
 
   -- Account and holding factory
   let
-    pp = [("factoryProvider", singleton $ singleton publicParty)]
+    pp = [("PublicParty", singleton $ singleton publicParty)]
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory provider pp
   holdingFactoryCid <- toInterfaceContractId <$> submitMulti [publicParty] [] do
-    createCmd Fungible.Factory with provider = publicParty; observers = M.empty
+    createCmd Fungible.Factory with provider = publicParty; observers = M.fromList pp
 
   -- Create accounts
   [senderAccount, receiverAccount] <- mapA (Account.createAccount [publicParty] accountFactoryCid holdingFactoryCid [] bank) [sender, receiver]
@@ -69,7 +69,7 @@ run = script do
   cashInstructionCid <- submitMulti [receiver] [publicParty] do exerciseCmd cashInstructionCid Instruction.Approve with receiverAccount
 
   -- Settle transfer
-  [cashHoldingCid] <- submitMulti [bank] [] do exerciseCmd cashTransferCid Settleable.Settle
+  [cashHoldingCid] <- submitMulti [bank] [publicParty] do exerciseCmd cashTransferCid Settleable.Settle
 
   -- Assert state
   Holding.verifyOwnerOfHolding [(receiver, cashHoldingCid)]


### PR DESCRIPTION
Addresses https://github.com/DACH-NY/daml-finance/issues/262

This forces holdings allocated to a specific account to have the same type.

It relies on a public party mechanism to disclose the holding factory.

Open questions:
- we need one holding factory per custodian, so maybe it makes sense to introduce a `HoldingFactoryFactory`
- upgrade scenario for holdings does look a bit more complex now
- are we happy with the public party disclosure mechanism?
- given that we are coupling accounts and holdings, should we introduce 1 account implementation per holding type instead of relying on holding factories?

Upgrade scenario for holdings:
- introduce V2 holding
- for each V1 holding factory, introduce V2 holding Factory
- for each account referencing the V1 factory, create new account referencing V2 factory
- replace each V1 holding with a V2 holding at the new account

