### PR TITLE
Fix batch id generation in lifecycle settlement rule

### DIFF
--- a/src/main/daml/Daml/Finance/Interface/Asset/Types.daml
+++ b/src/main/daml/Daml/Finance/Interface/Asset/Types.daml
@@ -11,7 +11,10 @@ data Id = Id
       -- ^ A textual label.
     version : Text
       -- ^ A textual version.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord)
+
+instance Show Id where
+  show id = id.label <> "@" <> id.version
 
 -- | A unique key for Accounts.
 data AccountKey = AccountKey

--- a/src/main/daml/Daml/Finance/Lifecycle/SettlementRule.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/SettlementRule.daml
@@ -5,6 +5,7 @@ module Daml.Finance.Lifecycle.SettlementRule where
 
 import DA.Foldable (forA_)
 import DA.Set (fromList, member)
+import DA.Text (sha256)
 import Daml.Finance.Interface.Asset.Account qualified as Account (exerciseInterfaceByKey, Debit(..), Credit(..), I)
 import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (qty)
 import Daml.Finance.Interface.Asset.Util (getAccount, getAmount, getCustodian, getInstrument, getOwner)
@@ -85,7 +86,8 @@ template Rule
         newInstrumentHoldingCids <- fmap sequence . mapA updateInstrumentHolding $ zip holdings holdingCids
 
         -- Generate settlement instructions for other instruments
-        (settleableCid, instructionCids) <- exercise instructableCid Instructable.Instruct with instructors = fromList [custodian, owner] ;settler; id = effectView.id; steps
+        let id = sha256 $ effectView.id <> partyToText custodian <> partyToText owner
+        (settleableCid, instructionCids) <- exercise instructableCid Instructable.Instruct with instructors = fromList [custodian, owner]; settler; id; steps
         pure SettlementRule.ClaimResult with
           newInstrumentHoldingCids
           containerCid = settleableCid


### PR DESCRIPTION
Adresses https://github.com/DACH-NY/daml-finance/issues/187

It's not actually the effect id that needs to be unique. Rather we need to generate a unique batch id for settlement in the lifecycle rule, so that instruction ids don't clash when claiming multiple times for different owners.

The stop-gap solution for now is to hash the effect id together with the custodian and the owner. This still breaks down if for some reason one would split a holding and claim each of the resulting ones separately, or if one claims holdings on the same instruments from different accounts.

A proper solution would probably be to take a random id from external, see https://github.com/DACH-NY/daml-finance/issues/283 .
