### PR TITLE
Add instrument factories

### DIFF
--- a/package/main/daml/Daml.Finance.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Bond/daml.yaml
@@ -12,6 +12,7 @@ data-dependencies:
   - ../../../../lib/contingent-claims-3.0.0.20220721.1.dar
   - ../Daml.Finance.Common/.daml/dist/daml-finance-common-0.1.1.dar
   - ../Daml.Finance.Interface.Asset/.daml/dist/daml-finance-interface-asset-0.1.1.dar
+  - ../Daml.Finance.Interface.Bond/.daml/dist/daml-finance-interface-bond-0.1.1.dar
   - ../Daml.Finance.Interface.Common/.daml/dist/daml-finance-interface-common-0.1.1.dar
   - ../Daml.Finance.Interface.Derivative/.daml/dist/daml-finance-interface-derivative-0.1.1.dar
   - ../Daml.Finance.Interface.Lifecycle/.daml/dist/daml-finance-interface-lifecycle-0.1.1.dar

--- a/package/main/daml/Daml.Finance.Interface.Bond/README.md
+++ b/package/main/daml/Daml.Finance.Interface.Bond/README.md
@@ -1,0 +1,3 @@
+# Daml.Finance.Interface.Bond
+
+This package contains interface definitions used to model different types of bonds.

--- a/package/main/daml/Daml.Finance.Interface.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Bond/daml.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+sdk-version: 2.4.0-snapshot.20220703.10163.0.89b068ec
+name: daml-finance-interface-bond
+source: daml
+version: 0.1.1
+dependencies:
+  - daml-prim
+  - daml-stdlib
+data-dependencies:
+  - ../Daml.Finance.Common/.daml/dist/daml-finance-common-0.1.1.dar
+  - ../Daml.Finance.Interface.Asset/.daml/dist/daml-finance-interface-asset-0.1.1.dar
+  - ../Daml.Finance.Interface.Common/.daml/dist/daml-finance-interface-common-0.1.1.dar
+build-options:
+  - --target=1.dev

--- a/package/main/daml/Daml.Finance.Interface.Bond/daml/Daml/Finance/Interface/Bond
+++ b/package/main/daml/Daml.Finance.Interface.Bond/daml/Daml/Finance/Interface/Bond
@@ -1,0 +1,1 @@
+../../../../../../../../src/main/daml/Daml/Finance/Interface/Bond

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,6 +2,10 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# TODO: Need to build this first as the bond interface package depends on the date type definitions.
+# These should be moved into Interface.Common (see https://github.com/DACH-NY/daml-finance/issues/288)
+DAML_PROJECT=../package/main/daml/Daml.Finance.Common daml build
+
 # Build Interfaces
 DAML_PROJECT=../package/main/daml/Daml.Finance.Interface.Common daml build
 DAML_PROJECT=../package/main/daml/Daml.Finance.Interface.Asset daml build
@@ -9,9 +13,9 @@ DAML_PROJECT=../package/main/daml/Daml.Finance.Interface.Settlement daml build
 DAML_PROJECT=../package/main/daml/Daml.Finance.Interface.Lifecycle daml build
 DAML_PROJECT=../package/main/daml/Daml.Finance.Interface.Derivative daml build
 DAML_PROJECT=../package/main/daml/Daml.Finance.Interface.Equity daml build
+DAML_PROJECT=../package/main/daml/Daml.Finance.Interface.Bond daml build
 
 # Build Implementations
-DAML_PROJECT=../package/main/daml/Daml.Finance.Common daml build
 DAML_PROJECT=../package/main/daml/Daml.Finance.Asset daml build
 DAML_PROJECT=../package/main/daml/Daml.Finance.Settlement daml build
 DAML_PROJECT=../package/main/daml/Daml.Finance.Lifecycle daml build

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -4,6 +4,7 @@
 # Clean
 daml clean --project-root ../package/main/daml/Daml.Finance.Interface.Common
 daml clean --project-root ../package/main/daml/Daml.Finance.Interface.Asset
+daml clean --project-root ../package/main/daml/Daml.Finance.Interface.Bond
 daml clean --project-root ../package/main/daml/Daml.Finance.Interface.Equity
 daml clean --project-root ../package/main/daml/Daml.Finance.Interface.Settlement
 daml clean --project-root ../package/main/daml/Daml.Finance.Interface.Lifecycle

--- a/src/main/daml/Daml/Finance/Asset/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Asset/Instrument.daml
@@ -4,7 +4,8 @@
 module Daml.Finance.Asset.Instrument where
 
 import DA.Set (singleton)
-import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (HasImplementation, I, View(..), disclosureUpdateReference)
+import Daml.Finance.Interface.Asset.Factory.Instrument qualified as InstrumentFactory (Create(..), F, HasImplementation, Remove(..), View(..))
+import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (GetCid(..), HasImplementation, I, R, View(..), createReference, disclosureUpdateReference)
 import Daml.Finance.Interface.Asset.Types (Id(..), InstrumentKey(..))
 import Daml.Finance.Interface.Common.Disclosure qualified as Disclosure (I, SetObservers(..), View(..))
 import Daml.Finance.Interface.Common.Types (Observers)
@@ -44,17 +45,32 @@ template Instrument
         Instrument.disclosureUpdateReference newObservers instrumentKey cid
       archiveImpl self = archive (coerceContractId self : ContractId Instrument)
 
--- | Proposal template for instrument creation.
-template Request
+instance InstrumentFactory.HasImplementation Factory
+-- | Factory template for instrument creation.
+template Factory
   with
-    instrument : Instrument
-      -- ^ The proposed instrument.
+    provider : Party
+      -- ^ The factory's provider.
+    observers : Observers
+      -- ^ The factory's observers.
   where
-    signatory instrument.issuer
-    observer instrument.depository
+    signatory provider
+    observer flattenObservers observers
 
-    choice Accept : ContractId Instrument
-      -- ^ Creates the proposed instrument.
-      controller instrument.depository
-      do
-        create instrument
+    implements InstrumentFactory.F where
+      asDisclosure = toInterface @Disclosure.I this
+      view = InstrumentFactory.View with provider
+      createImpl InstrumentFactory.Create{instrument; validAsOf; observers} = do
+        cid <- toInterfaceContractId <$> create Instrument with depository = instrument.depository; issuer = instrument.issuer; id = instrument.id; validAsOf; observers
+        Instrument.createReference instrument.depository cid
+        pure cid
+      removeImpl InstrumentFactory.Remove{instrument}  = do
+        (refCid, ref) <- fetchByKey @Instrument.R instrument
+        instrumentCid <- exercise refCid Instrument.GetCid with viewer = instrument.depository
+        archive $ fromInterfaceContractId @Instrument instrumentCid
+        archive refCid
+
+    implements Disclosure.I where
+      view = Disclosure.View with disclosureControllers = singleton $ singleton provider; observers
+      setObserversImpl Disclosure.SetObservers{newObservers} = toInterfaceContractId <$> create this with observers = newObservers
+      archiveImpl self = archive (coerceContractId self : ContractId Instrument)

--- a/src/main/daml/Daml/Finance/Bond/FixedRate.daml
+++ b/src/main/daml/Daml/Finance/Bond/FixedRate.daml
@@ -5,11 +5,12 @@ module Daml.Finance.Bond.FixedRate where
 
 import DA.Set (singleton)
 import Daml.Finance.Bond.Util
-import Daml.Finance.Common.Date.Calendar
-import Daml.Finance.Common.Date.DayCount
-import Daml.Finance.Common.Date.RollConvention
-import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (HasImplementation, I, K, View(..), disclosureUpdateReference)
+import Daml.Finance.Common.Date.Calendar (BusinessDayConventionEnum)
+import Daml.Finance.Common.Date.DayCount (DayCountConventionEnum)
+import Daml.Finance.Common.Date.RollConvention (PeriodEnum)
+import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (GetCid(..), HasImplementation, I, K, R, View(..), createReference, disclosureUpdateReference)
 import Daml.Finance.Interface.Asset.Types (Id(..), InstrumentKey(..))
+import Daml.Finance.Interface.Bond.FixedRate qualified as FixedRate (Create(..), Factory, HasImplementation, Remove(..), View(..))
 import Daml.Finance.Interface.Common.Disclosure qualified as Disclosure (I, SetObservers(..), View(..))
 import Daml.Finance.Interface.Common.Types (Observers)
 import Daml.Finance.Interface.Common.Util (flattenObservers)
@@ -17,13 +18,13 @@ import Daml.Finance.Interface.Derivative.HasClaims qualified as HasClaims (I, Vi
 import Daml.Finance.Interface.Lifecycle.Lifecyclable qualified as Lifecyclable (I, Lifecycle(..), View(..))
 import Prelude hiding (key)
 
-type T = FixedRateBond
+type T = Instrument
 
 instance Instrument.HasImplementation T
 
 -- | This template models a fixed rate bond.
 -- It pays a fixed coupon rate at the end of every coupon period.
-template FixedRateBond
+template Instrument
   with
     depository : Party
       -- ^ The depository of the instrument.
@@ -89,4 +90,51 @@ template FixedRateBond
       setObserversImpl Disclosure.SetObservers{newObservers} = do
         cid <- toInterfaceContractId <$> create this with observers = newObservers
         Instrument.disclosureUpdateReference newObservers instrumentKey cid
-      archiveImpl self = archive (coerceContractId self : ContractId FixedRateBond)
+      archiveImpl self = archive (coerceContractId self : ContractId Instrument)
+
+instance FixedRate.HasImplementation Factory
+-- | Factory template for instrument creation.
+template Factory
+  with
+    provider : Party
+      -- ^ The factory's provider.
+    observers : Observers
+      -- ^ The factory's observers.
+  where
+    signatory provider
+    observer flattenObservers observers
+
+    implements FixedRate.Factory where
+      asDisclosure = toInterface @Disclosure.I this
+      view = FixedRate.View with provider
+      createImpl FixedRate.Create{instrument; couponRate; issueDate; firstCouponDate; maturityDate; holidayCalendarIds; calendarDataProvider; dayCountConvention; businessDayConvention; couponPeriod; couponPeriodMultiplier; currency; lastEventTimestamp; observers} = do
+        cid <- toInterfaceContractId <$> create Instrument
+          with
+            depository = instrument.depository
+            issuer = instrument.issuer
+            id = instrument.id
+            couponRate
+            issueDate
+            firstCouponDate
+            maturityDate
+            holidayCalendarIds
+            calendarDataProvider
+            dayCountConvention
+            businessDayConvention
+            couponPeriod
+            couponPeriodMultiplier
+            currency
+            lastEventTimestamp
+            observers
+        Instrument.createReference instrument.depository cid
+        pure cid
+      removeImpl FixedRate.Remove{instrument}  = do
+        (refCid, ref) <- fetchByKey @Instrument.R instrument
+        instrumentCid <- exercise refCid Instrument.GetCid with viewer = instrument.depository
+        archive $ fromInterfaceContractId @Instrument instrumentCid
+        archive refCid
+
+    implements Disclosure.I where
+      view = Disclosure.View with disclosureControllers = singleton $ singleton provider; observers
+      setObserversImpl Disclosure.SetObservers{newObservers} = toInterfaceContractId <$> create this with observers = newObservers
+      archiveImpl self = archive (coerceContractId self : ContractId Instrument)

--- a/src/main/daml/Daml/Finance/Bond/FloatingRate.daml
+++ b/src/main/daml/Daml/Finance/Bond/FloatingRate.daml
@@ -5,11 +5,12 @@ module Daml.Finance.Bond.FloatingRate where
 
 import DA.Set (singleton)
 import Daml.Finance.Bond.Util
-import Daml.Finance.Common.Date.Calendar
-import Daml.Finance.Common.Date.DayCount
-import Daml.Finance.Common.Date.RollConvention
-import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (HasImplementation, I, K, View(..), disclosureUpdateReference)
+import Daml.Finance.Common.Date.Calendar (BusinessDayConventionEnum)
+import Daml.Finance.Common.Date.DayCount (DayCountConventionEnum)
+import Daml.Finance.Common.Date.RollConvention (PeriodEnum)
+import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (GetCid(..), HasImplementation, I, K, R, View(..), createReference, disclosureUpdateReference)
 import Daml.Finance.Interface.Asset.Types (Id(..), InstrumentKey(..))
+import Daml.Finance.Interface.Bond.FloatingRate qualified as FloatingRate (Create(..), Factory, HasImplementation, Remove(..), View(..))
 import Daml.Finance.Interface.Common.Disclosure qualified as Disclosure (I, SetObservers(..), View(..))
 import Daml.Finance.Interface.Common.Types (Observers)
 import Daml.Finance.Interface.Common.Util (flattenObservers)
@@ -17,14 +18,14 @@ import Daml.Finance.Interface.Derivative.HasClaims qualified as HasClaims (I, Vi
 import Daml.Finance.Interface.Lifecycle.Lifecyclable qualified as Lifecyclable (I, Lifecycle(..), View(..))
 import Prelude hiding (key)
 
-type T = FloatingRateBond
+type T = Instrument
 
 instance Instrument.HasImplementation T
 -- | This template models a floating rate bond.
 -- It pays a floating coupon rate at the end of every coupon period.
 -- This consists of a reference rate (observed at the beginning of the coupon period) plus a coupon spread.
 -- For example: 3M Euribor + 0.5%.
-template FloatingRateBond
+template Instrument
   with
     depository : Party
       -- ^ The depository of the instrument.
@@ -92,4 +93,52 @@ template FloatingRateBond
       setObserversImpl Disclosure.SetObservers{newObservers} = do
         cid <- toInterfaceContractId <$> create this with observers = newObservers
         Instrument.disclosureUpdateReference newObservers instrumentKey cid
-      archiveImpl self = archive (coerceContractId self : ContractId FloatingRateBond)
+      archiveImpl self = archive (coerceContractId self : ContractId Instrument)
+
+instance FloatingRate.HasImplementation Factory
+-- | Factory template for instrument creation.
+template Factory
+  with
+    provider : Party
+      -- ^ The factory's provider.
+    observers : Observers
+      -- ^ The factory's observers.
+  where
+    signatory provider
+    observer flattenObservers observers
+
+    implements FloatingRate.Factory where
+      asDisclosure = toInterface @Disclosure.I this
+      view = FloatingRate.View with provider
+      createImpl FloatingRate.Create{instrument; referenceRateId; couponSpread; issueDate; firstCouponDate; maturityDate; holidayCalendarIds; calendarDataProvider; dayCountConvention; businessDayConvention; couponPeriod; couponPeriodMultiplier; currency; lastEventTimestamp; observers} = do
+        cid <- toInterfaceContractId <$> create Instrument
+          with
+            depository = instrument.depository
+            issuer = instrument.issuer
+            id = instrument.id
+            referenceRateId
+            couponSpread
+            issueDate
+            firstCouponDate
+            maturityDate
+            holidayCalendarIds
+            calendarDataProvider
+            dayCountConvention
+            businessDayConvention
+            couponPeriod
+            couponPeriodMultiplier
+            currency
+            lastEventTimestamp
+            observers
+        Instrument.createReference instrument.depository cid
+        pure cid
+      removeImpl FloatingRate.Remove{instrument}  = do
+        (refCid, ref) <- fetchByKey @Instrument.R instrument
+        instrumentCid <- exercise refCid Instrument.GetCid with viewer = instrument.depository
+        archive $ fromInterfaceContractId @Instrument instrumentCid
+        archive refCid
+
+    implements Disclosure.I where
+      view = Disclosure.View with disclosureControllers = singleton $ singleton provider; observers
+      setObserversImpl Disclosure.SetObservers{newObservers} = toInterfaceContractId <$> create this with observers = newObservers
+      archiveImpl self = archive (coerceContractId self : ContractId Instrument)

--- a/src/main/daml/Daml/Finance/Bond/InflationLinked.daml
+++ b/src/main/daml/Daml/Finance/Bond/InflationLinked.daml
@@ -7,11 +7,12 @@ import ContingentClaims.Claim (Inequality(..), (<=), cond, one, scale, when)
 import ContingentClaims.Observation (Observation(..))
 import DA.Set (singleton)
 import Daml.Finance.Bond.Util
-import Daml.Finance.Common.Date.Calendar
-import Daml.Finance.Common.Date.DayCount
-import Daml.Finance.Common.Date.RollConvention
-import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (HasImplementation, I, K, View(..), disclosureUpdateReference)
+import Daml.Finance.Common.Date.Calendar (BusinessDayConventionEnum)
+import Daml.Finance.Common.Date.DayCount (DayCountConventionEnum, calcDcf)
+import Daml.Finance.Common.Date.RollConvention (PeriodEnum)
+import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (GetCid(..), HasImplementation, I, K, R, View(..), createReference, disclosureUpdateReference)
 import Daml.Finance.Interface.Asset.Types (Id(..), InstrumentKey(..))
+import Daml.Finance.Interface.Bond.InflationLinked qualified as InflationLinked (Create(..), Factory, HasImplementation, Remove(..), View(..))
 import Daml.Finance.Interface.Common.Disclosure qualified as Disclosure (I, SetObservers(..), View(..))
 import Daml.Finance.Interface.Common.Types (Observers)
 import Daml.Finance.Interface.Common.Util (flattenObservers)
@@ -19,7 +20,7 @@ import Daml.Finance.Interface.Derivative.HasClaims qualified as HasClaims (I, Vi
 import Daml.Finance.Interface.Lifecycle.Lifecyclable qualified as Lifecyclable (I, Lifecycle(..), View(..))
 import Prelude hiding ((<=), key, or)
 
-type T = InflationLinkedBond
+type T = Instrument
 
 instance Instrument.HasImplementation T
 
@@ -29,7 +30,7 @@ instance Instrument.HasImplementation T
 -- For example: 0.5% p.a coupon, CPI adjusted principal:
 -- At maturity, the greater of the adjusted principal and the original principal is redeemed.
 -- For clarity, this only applies to the redemption amount. The coupons are always calculated based on the adjusted principal.
-template InflationLinkedBond
+template Instrument
   with
     depository : Party
       -- ^ The depository of the instrument.
@@ -122,4 +123,53 @@ template InflationLinkedBond
       setObserversImpl Disclosure.SetObservers{newObservers} = do
         cid <- toInterfaceContractId <$> create this with observers = newObservers
         Instrument.disclosureUpdateReference newObservers instrumentKey cid
-      archiveImpl self = archive (coerceContractId self : ContractId InflationLinkedBond)
+      archiveImpl self = archive (coerceContractId self : ContractId Instrument)
+
+instance InflationLinked.HasImplementation Factory
+-- | Factory template for instrument creation.
+template Factory
+  with
+    provider : Party
+      -- ^ The factory's provider.
+    observers : Observers
+      -- ^ The factory's observers.
+  where
+    signatory provider
+    observer flattenObservers observers
+
+    implements InflationLinked.Factory where
+      asDisclosure = toInterface @Disclosure.I this
+      view = InflationLinked.View with provider
+      createImpl InflationLinked.Create{instrument; inflationIndexId; inflationIndexBaseValue; couponRate; issueDate; firstCouponDate; maturityDate; holidayCalendarIds; calendarDataProvider; dayCountConvention; businessDayConvention; couponPeriod; couponPeriodMultiplier; currency; lastEventTimestamp; observers} = do
+        cid <- toInterfaceContractId <$> create Instrument
+          with
+            depository = instrument.depository
+            issuer = instrument.issuer
+            id = instrument.id
+            inflationIndexId
+            inflationIndexBaseValue
+            couponRate
+            issueDate
+            firstCouponDate
+            maturityDate
+            holidayCalendarIds
+            calendarDataProvider
+            dayCountConvention
+            businessDayConvention
+            couponPeriod
+            couponPeriodMultiplier
+            currency
+            lastEventTimestamp
+            observers
+        Instrument.createReference instrument.depository cid
+        pure cid
+      removeImpl InflationLinked.Remove{instrument}  = do
+        (refCid, ref) <- fetchByKey @Instrument.R instrument
+        instrumentCid <- exercise refCid Instrument.GetCid with viewer = instrument.depository
+        archive $ fromInterfaceContractId @Instrument instrumentCid
+        archive refCid
+
+    implements Disclosure.I where
+      view = Disclosure.View with disclosureControllers = singleton $ singleton provider; observers
+      setObserversImpl Disclosure.SetObservers{newObservers} = toInterfaceContractId <$> create this with observers = newObservers
+      archiveImpl self = archive (coerceContractId self : ContractId Instrument)

--- a/src/main/daml/Daml/Finance/Bond/ZeroCoupon.daml
+++ b/src/main/daml/Daml/Finance/Bond/ZeroCoupon.daml
@@ -5,8 +5,9 @@ module Daml.Finance.Bond.ZeroCoupon where
 
 import DA.Set (singleton)
 import Daml.Finance.Bond.Util
-import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (HasImplementation, I, K, View(..), disclosureUpdateReference)
+import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (GetCid(..), HasImplementation, I, K, R, View(..), createReference, disclosureUpdateReference)
 import Daml.Finance.Interface.Asset.Types (Id(..), InstrumentKey(..))
+import Daml.Finance.Interface.Bond.ZeroCoupon qualified as ZeroCoupon (Create(..), Factory, HasImplementation, Remove(..), View(..))
 import Daml.Finance.Interface.Common.Disclosure qualified as Disclosure (I, SetObservers(..), View(..))
 import Daml.Finance.Interface.Common.Types (Observers)
 import Daml.Finance.Interface.Common.Util (flattenObservers)
@@ -14,12 +15,12 @@ import Daml.Finance.Interface.Derivative.HasClaims qualified as HasClaims (I, Vi
 import Daml.Finance.Interface.Lifecycle.Lifecyclable qualified as Lifecyclable (I, Lifecycle(..), View(..))
 import Prelude hiding (key)
 
-type T = ZeroCouponBond
+type T = Instrument
 
 instance Instrument.HasImplementation T
 -- | This template models a zero coupon bond.
 -- It does not pay any coupons, only the redemption amount at maturity.
-template ZeroCouponBond
+template Instrument
   with
     depository : Party
       -- ^ The depository of the instrument.
@@ -68,4 +69,35 @@ template ZeroCouponBond
       setObserversImpl Disclosure.SetObservers{newObservers} = do
         cid <- toInterfaceContractId <$> create this with observers = newObservers
         Instrument.disclosureUpdateReference newObservers instrumentKey cid
-      archiveImpl self = archive (coerceContractId self : ContractId ZeroCouponBond)
+      archiveImpl self = archive (coerceContractId self : ContractId Instrument)
+
+
+instance ZeroCoupon.HasImplementation Factory
+-- | Factory template for instrument creation.
+template Factory
+  with
+    provider : Party
+      -- ^ The factory's provider.
+    observers : Observers
+      -- ^ The factory's observers.
+  where
+    signatory provider
+    observer flattenObservers observers
+
+    implements ZeroCoupon.Factory where
+      asDisclosure = toInterface @Disclosure.I this
+      view = ZeroCoupon.View with provider
+      createImpl ZeroCoupon.Create{instrument; issueDate; maturityDate; currency; lastEventTimestamp; observers} = do
+        cid <- toInterfaceContractId <$> create Instrument with depository = instrument.depository; issuer = instrument.issuer; id = instrument.id; issueDate; maturityDate; currency; lastEventTimestamp; observers
+        Instrument.createReference instrument.depository cid
+        pure cid
+      removeImpl ZeroCoupon.Remove{instrument}  = do
+        (refCid, ref) <- fetchByKey @Instrument.R instrument
+        instrumentCid <- exercise refCid Instrument.GetCid with viewer = instrument.depository
+        archive $ fromInterfaceContractId @Instrument instrumentCid
+        archive refCid
+
+    implements Disclosure.I where
+      view = Disclosure.View with disclosureControllers = singleton $ singleton provider; observers
+      setObserversImpl Disclosure.SetObservers{newObservers} = toInterfaceContractId <$> create this with observers = newObservers
+      archiveImpl self = archive (coerceContractId self : ContractId Instrument)

--- a/src/main/daml/Daml/Finance/Derivative/Factory.daml
+++ b/src/main/daml/Daml/Finance/Derivative/Factory.daml
@@ -1,3 +1,6 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module Daml.Finance.Derivative.Factory where
 
 import Daml.Finance.Derivative.Instrument (Instrument(..))

--- a/src/main/daml/Daml/Finance/Derivative/Factory.daml
+++ b/src/main/daml/Daml/Finance/Derivative/Factory.daml
@@ -1,0 +1,41 @@
+module Daml.Finance.Derivative.Factory where
+
+import Daml.Finance.Derivative.Instrument (Instrument(..))
+import Daml.Finance.Interface.Derivative.Factory qualified as DerivativeFactory (Create(..), F, HasImplementation, Remove(..), View(..))
+import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (GetCid(..), R, createReference)
+import Daml.Finance.Interface.Common.Disclosure qualified as Disclosure (I, SetObservers(..), View(..))
+import Daml.Finance.Interface.Common.Types (Observers)
+import Daml.Finance.Interface.Common.Util (flattenObservers)
+import DA.Set (singleton)
+
+type F = Factory
+
+instance DerivativeFactory.HasImplementation Factory
+-- | Factory template for instrument creation.
+template Factory
+  with
+    provider : Party
+      -- ^ The factory's provider.
+    observers : Observers
+      -- ^ The factory's observers.
+  where
+    signatory provider
+    observer flattenObservers observers
+
+    implements DerivativeFactory.F where
+      asDisclosure = toInterface @Disclosure.I this
+      view = DerivativeFactory.View with provider
+      createImpl DerivativeFactory.Create{instrument; claims, acquisitionTime, lastEventTimestamp; observers} = do
+        cid <- toInterfaceContractId <$> create Instrument with depository = instrument.depository; issuer = instrument.issuer; id = instrument.id; claims; acquisitionTime; lastEventTimestamp; observers
+        Instrument.createReference instrument.depository cid
+        pure cid
+      removeImpl DerivativeFactory.Remove{instrument}  = do
+        (refCid, ref) <- fetchByKey @Instrument.R instrument
+        instrumentCid <- exercise refCid Instrument.GetCid with viewer = instrument.depository
+        archive $ fromInterfaceContractId @Instrument instrumentCid
+        archive refCid
+
+    implements Disclosure.I where
+      view = Disclosure.View with disclosureControllers = singleton $ singleton provider; observers
+      setObserversImpl Disclosure.SetObservers{newObservers} = toInterfaceContractId <$> create this with observers = newObservers
+      archiveImpl self = archive (coerceContractId self : ContractId Instrument)

--- a/src/main/daml/Daml/Finance/Equity/Factory.daml
+++ b/src/main/daml/Daml/Finance/Equity/Factory.daml
@@ -1,3 +1,6 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module Daml.Finance.Equity.Factory where
 
 import Daml.Finance.Equity.Instrument (Instrument(..))

--- a/src/main/daml/Daml/Finance/Equity/Factory.daml
+++ b/src/main/daml/Daml/Finance/Equity/Factory.daml
@@ -1,0 +1,41 @@
+module Daml.Finance.Equity.Factory where
+
+import Daml.Finance.Equity.Instrument (Instrument(..))
+import Daml.Finance.Interface.Equity.Factory qualified as EquityFactory (Create(..), F, HasImplementation, Remove(..), View(..))
+import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (GetCid(..), R, createReference)
+import Daml.Finance.Interface.Common.Disclosure qualified as Disclosure (I, SetObservers(..), View(..))
+import Daml.Finance.Interface.Common.Types (Observers)
+import Daml.Finance.Interface.Common.Util (flattenObservers)
+import DA.Set (singleton)
+
+type F = Factory
+
+instance EquityFactory.HasImplementation Factory
+-- | Factory template for instrument creation.
+template Factory
+  with
+    provider : Party
+      -- ^ The factory's provider.
+    observers : Observers
+      -- ^ The factory's observers.
+  where
+    signatory provider
+    observer flattenObservers observers
+
+    implements EquityFactory.F where
+      asDisclosure = toInterface @Disclosure.I this
+      view = EquityFactory.View with provider
+      createImpl EquityFactory.Create{instrument; validAsOf; observers} = do
+        cid <- toInterfaceContractId <$> create Instrument with depository = instrument.depository; issuer = instrument.issuer; id = instrument.id; validAsOf; observers
+        Instrument.createReference instrument.depository cid
+        pure cid
+      removeImpl EquityFactory.Remove{instrument}  = do
+        (refCid, ref) <- fetchByKey @Instrument.R instrument
+        instrumentCid <- exercise refCid Instrument.GetCid with viewer = instrument.depository
+        archive $ fromInterfaceContractId @Instrument instrumentCid
+        archive refCid
+
+    implements Disclosure.I where
+      view = Disclosure.View with disclosureControllers = singleton $ singleton provider; observers
+      setObserversImpl Disclosure.SetObservers{newObservers} = toInterfaceContractId <$> create this with observers = newObservers
+      archiveImpl self = archive (coerceContractId self : ContractId Instrument)

--- a/src/main/daml/Daml/Finance/Interface/Asset/Factory/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Interface/Asset/Factory/Instrument.daml
@@ -1,0 +1,59 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Daml.Finance.Interface.Asset.Factory.Instrument where
+
+import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (I)
+import Daml.Finance.Interface.Asset.Types (InstrumentKey(..))
+import Daml.Finance.Interface.Common.Disclosure qualified as Disclosure (I, Implementation)
+import Daml.Finance.Interface.Common.Types (Observers)
+
+-- | Type synonym for `Factory`.
+type F = Factory
+
+-- View of `Factory`.
+data View = View
+  with
+    provider : Party
+      -- ^ The provider of the `Factory`.
+  deriving (Eq, Ord, Show)
+
+-- | Interface that allows implementing templates to create instruments.
+interface Factory where
+  asDisclosure : Disclosure.I
+    -- ^ Conversion to `Disclosure` interface.
+  view : View
+    -- ^ Acquire the default interface view.
+  createImpl : Create -> Update (ContractId Instrument.I)
+    -- ^ Implementation of `Create` choice.
+  removeImpl : Remove -> Update ()
+    -- ^ Implementation of `Remove` choice.
+
+  nonconsuming choice Create : ContractId Instrument.I
+    -- ^ Create a new account.
+    with
+      instrument : InstrumentKey
+        -- ^ The instrument's key.
+      validAsOf : Time
+        -- ^ Timestamp as of which the instrument is valid.
+      observers : Observers
+        -- ^ The instrument's observers.
+    controller instrument.depository, instrument.issuer
+    do
+      createImpl this arg
+
+  nonconsuming choice Remove : ()
+    -- ^ Archive an account.
+    with
+      instrument : InstrumentKey
+        -- ^ The account's key.
+    controller instrument.depository, instrument.issuer
+      do
+        removeImpl this arg
+
+-- | Type constraint used to require templates implementing `Factory` to also
+-- implement `Disclosure`.
+type Implementation t = (HasToInterface t Factory, Disclosure.Implementation t)
+instance HasToInterface Factory Disclosure.I where _toInterface = asDisclosure
+class (Implementation t) => HasImplementation t
+instance HasImplementation Factory

--- a/src/main/daml/Daml/Finance/Interface/Bond/FixedRate.daml
+++ b/src/main/daml/Daml/Finance/Interface/Bond/FixedRate.daml
@@ -1,0 +1,84 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Daml.Finance.Interface.Bond.FixedRate where
+
+import Daml.Finance.Common.Date.Calendar (BusinessDayConventionEnum)
+import Daml.Finance.Common.Date.DayCount (DayCountConventionEnum)
+import Daml.Finance.Common.Date.RollConvention (PeriodEnum)
+import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (I, K)
+import Daml.Finance.Interface.Asset.Types (InstrumentKey(..))
+import Daml.Finance.Interface.Common.Disclosure qualified as Disclosure (I, Implementation)
+import Daml.Finance.Interface.Common.Types (Observers)
+
+-- | Type synonym for `Factory`.
+type F = Factory
+
+-- | View of `Factory`.
+data View = View
+  with
+    provider : Party
+      -- ^ The provider of the `Factory`.
+  deriving (Eq, Ord, Show)
+
+-- | Interface that allows implementing templates to create instruments.
+interface Factory where
+  asDisclosure : Disclosure.I
+    -- ^ Conversion to `Disclosure` interface.
+  view : View
+    -- ^ Acquire the default interface view.
+  createImpl : Create -> Update (ContractId Instrument.I)
+    -- ^ Implementation of `Create` choice.
+  removeImpl : Remove -> Update ()
+    -- ^ Implementation of `Remove` choice.
+
+  nonconsuming choice Create : ContractId Instrument.I
+    -- ^ Create a new account.
+    with
+      instrument : InstrumentKey
+        -- ^ The instrument's key.
+      couponRate : Decimal
+        -- ^ The fixed coupon rate, per annum. For example, in case of a "3.5% p.a coupon" this should be 0.035.
+      issueDate : Date
+        -- ^ The date when the bond was issued.
+      firstCouponDate : Date
+        -- ^ The first coupon date of the bond.
+      maturityDate : Date
+        -- ^ The last coupon date (and the redemption date) of the bond.
+      holidayCalendarIds : [Text]
+        -- ^ the identifier of the holiday calendar to be used for the coupon schedule.
+      calendarDataProvider : Party
+        -- ^ The reference data provider to use for the holiday calendar.
+      dayCountConvention : DayCountConventionEnum
+        -- ^ The day count convention used to calculate day count fractions. For example: Act360.
+      businessDayConvention : BusinessDayConventionEnum
+        -- ^ An enum type to specify how a non-business day is adjusted. For example: FOLLOWING.
+      couponPeriod : PeriodEnum
+        -- ^ The coupon period. For example, in case of a 3M coupon period (a coupon every 3 months), this should be M.
+      couponPeriodMultiplier : Int
+        -- ^ The coupon period multiplier. For example, in case of a 3M coupon period (a coupon every 3 months), this should be 3.
+      currency : Instrument.K
+        -- ^ The currency of the bond. For example, if the bond pays in USD this should be a USD cash instrument.
+      lastEventTimestamp : Time
+        -- ^ (Market) time of the last recorded lifecycle event. If no event has occurred yet, the time of creation should be used.
+      observers : Observers
+        -- ^ The instrument's observers.
+    controller instrument.depository, instrument.issuer
+    do
+      createImpl this arg
+
+  nonconsuming choice Remove : ()
+    -- ^ Archive an account.
+    with
+      instrument : InstrumentKey
+        -- ^ The account's key.
+    controller instrument.depository, instrument.issuer
+      do
+        removeImpl this arg
+
+-- | Type constraint used to require templates implementing `Factory` to also
+-- implement `Disclosure`.
+type Implementation t = (HasToInterface t Factory, Disclosure.Implementation t)
+instance HasToInterface Factory Disclosure.I where _toInterface = asDisclosure
+class (Implementation t) => HasImplementation t
+instance HasImplementation Factory

--- a/src/main/daml/Daml/Finance/Interface/Bond/FloatingRate.daml
+++ b/src/main/daml/Daml/Finance/Interface/Bond/FloatingRate.daml
@@ -1,0 +1,86 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Daml.Finance.Interface.Bond.FloatingRate where
+
+import Daml.Finance.Common.Date.Calendar (BusinessDayConventionEnum)
+import Daml.Finance.Common.Date.DayCount (DayCountConventionEnum)
+import Daml.Finance.Common.Date.RollConvention (PeriodEnum)
+import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (I, K)
+import Daml.Finance.Interface.Asset.Types (InstrumentKey(..))
+import Daml.Finance.Interface.Common.Disclosure qualified as Disclosure (I, Implementation)
+import Daml.Finance.Interface.Common.Types (Observers)
+
+-- | Type synonym for `Factory`.
+type F = Factory
+
+-- | View of `Factory`.
+data View = View
+  with
+    provider : Party
+      -- ^ The provider of the `Factory`.
+  deriving (Eq, Ord, Show)
+
+-- | Interface that allows implementing templates to create instruments.
+interface Factory where
+  asDisclosure : Disclosure.I
+    -- ^ Conversion to `Disclosure` interface.
+  view : View
+    -- ^ Acquire the default interface view.
+  createImpl : Create -> Update (ContractId Instrument.I)
+    -- ^ Implementation of `Create` choice.
+  removeImpl : Remove -> Update ()
+    -- ^ Implementation of `Remove` choice.
+
+  nonconsuming choice Create : ContractId Instrument.I
+    -- ^ Create a new account.
+    with
+      instrument : InstrumentKey
+        -- ^ The instrument's key.
+      referenceRateId : Text
+        -- ^ The floating rate reference ID. For example, in case of "3M Euribor + 0.5%" this should a valid reference to the "3M Euribor" reference rate.
+      couponSpread : Decimal
+        -- ^ The floating rate coupon spread. For example, in case of "3M Euribor + 0.5%" this should be 0.005.
+      issueDate : Date
+        -- ^ The date when the bond was issued.
+      firstCouponDate : Date
+        -- ^ The first coupon date of the bond.
+      maturityDate : Date
+        -- ^ The last coupon date (and the redemption date) of the bond.
+      holidayCalendarIds : [Text]
+        -- ^ the identifier of the holiday calendar to be used for the coupon schedule.
+      calendarDataProvider : Party
+        -- ^ The reference data provider to use for the holiday calendar.
+      dayCountConvention : DayCountConventionEnum
+        -- ^ The day count convention used to calculate day count fractions. For example: Act360.
+      businessDayConvention : BusinessDayConventionEnum
+        -- ^ An enum type to specify how a non-business day is adjusted. For example: FOLLOWING.
+      couponPeriod : PeriodEnum
+        -- ^ The coupon period. For example, in case of a 3M coupon period (a coupon every 3 months), this should be M.
+      couponPeriodMultiplier : Int
+        -- ^ The coupon period multiplier. For example, in case of a 3M coupon period (a coupon every 3 months), this should be 3.
+      currency : Instrument.K
+        -- ^ The currency of the bond. For example, if the bond pays in USD this should be a USD cash instrument.
+      lastEventTimestamp : Time
+        -- ^ (Market) time of the last recorded lifecycle event. If no event has occurred yet, the time of creation should be used.
+      observers : Observers
+        -- ^ The instrument's observers.
+    controller instrument.depository, instrument.issuer
+    do
+      createImpl this arg
+
+  nonconsuming choice Remove : ()
+    -- ^ Archive an account.
+    with
+      instrument : InstrumentKey
+        -- ^ The account's key.
+    controller instrument.depository, instrument.issuer
+      do
+        removeImpl this arg
+
+-- | Type constraint used to require templates implementing `Factory` to also
+-- implement `Disclosure`.
+type Implementation t = (HasToInterface t Factory, Disclosure.Implementation t)
+instance HasToInterface Factory Disclosure.I where _toInterface = asDisclosure
+class (Implementation t) => HasImplementation t
+instance HasImplementation Factory

--- a/src/main/daml/Daml/Finance/Interface/Bond/InflationLinked.daml
+++ b/src/main/daml/Daml/Finance/Interface/Bond/InflationLinked.daml
@@ -1,0 +1,88 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Daml.Finance.Interface.Bond.InflationLinked where
+
+import Daml.Finance.Common.Date.Calendar (BusinessDayConventionEnum)
+import Daml.Finance.Common.Date.DayCount (DayCountConventionEnum)
+import Daml.Finance.Common.Date.RollConvention (PeriodEnum)
+import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (I, K)
+import Daml.Finance.Interface.Asset.Types (InstrumentKey(..))
+import Daml.Finance.Interface.Common.Disclosure qualified as Disclosure (I, Implementation)
+import Daml.Finance.Interface.Common.Types (Observers)
+
+-- | Type synonym for `Factory`.
+type F = Factory
+
+-- | View of `Factory`.
+data View = View
+  with
+    provider : Party
+      -- ^ The provider of the `Factory`.
+  deriving (Eq, Ord, Show)
+
+-- | Interface that allows implementing templates to create instruments.
+interface Factory where
+  asDisclosure : Disclosure.I
+    -- ^ Conversion to `Disclosure` interface.
+  view : View
+    -- ^ Acquire the default interface view.
+  createImpl : Create -> Update (ContractId Instrument.I)
+    -- ^ Implementation of `Create` choice.
+  removeImpl : Remove -> Update ()
+    -- ^ Implementation of `Remove` choice.
+
+  nonconsuming choice Create : ContractId Instrument.I
+    -- ^ Create a new account.
+    with
+      instrument : InstrumentKey
+        -- ^ The instrument's key.
+      inflationIndexId : Text
+        -- ^ The inflation index reference ID. For example, in case of "0.5% p.a coupon, CPI adjusted principal" this should a valid reference to the "CPI" index.
+      inflationIndexBaseValue : Decimal
+        -- ^ The value of the inflation index on the first reference date of this bond (called "dated date" on US TIPS). This is used as the base value for the principal adjustment.
+      couponRate : Decimal
+        -- ^ The fixed coupon rate, per annum. For example, in case of a "0.5% p.a coupon, CPI adjusted principal" this should be 0.005.
+      issueDate : Date
+        -- ^ The date when the bond was issued.
+      firstCouponDate : Date
+        -- ^ The first coupon date of the bond.
+      maturityDate : Date
+        -- ^ The last coupon date (and the redemption date) of the bond.
+      holidayCalendarIds : [Text]
+        -- ^ the identifier of the holiday calendar to be used for the coupon schedule.
+      calendarDataProvider : Party
+        -- ^ The reference data provider to use for the holiday calendar.
+      dayCountConvention : DayCountConventionEnum
+        -- ^ The day count convention used to calculate day count fractions. For example: Act360.
+      businessDayConvention : BusinessDayConventionEnum
+        -- ^ An enum type to specify how a non-business day is adjusted. For example: FOLLOWING.
+      couponPeriod : PeriodEnum
+        -- ^ The coupon period. For example, in case of a 3M coupon period (a coupon every 3 months), this should be M.
+      couponPeriodMultiplier : Int
+        -- ^ The coupon period multiplier. For example, in case of a 3M coupon period (a coupon every 3 months), this should be 3.
+      currency : Instrument.K
+        -- ^ The currency of the bond. For example, if the bond pays in USD this should be a USD cash instrument.
+      lastEventTimestamp : Time
+        -- ^ (Market) time of the last recorded lifecycle event. If no event has occurred yet, the time of creation should be used.
+      observers : Observers
+        -- ^ The instrument's observers.
+    controller instrument.depository, instrument.issuer
+    do
+      createImpl this arg
+
+  nonconsuming choice Remove : ()
+    -- ^ Archive an account.
+    with
+      instrument : InstrumentKey
+        -- ^ The account's key.
+    controller instrument.depository, instrument.issuer
+      do
+        removeImpl this arg
+
+-- | Type constraint used to require templates implementing `Factory` to also
+-- implement `Disclosure`.
+type Implementation t = (HasToInterface t Factory, Disclosure.Implementation t)
+instance HasToInterface Factory Disclosure.I where _toInterface = asDisclosure
+class (Implementation t) => HasImplementation t
+instance HasImplementation Factory

--- a/src/main/daml/Daml/Finance/Interface/Bond/ZeroCoupon.daml
+++ b/src/main/daml/Daml/Finance/Interface/Bond/ZeroCoupon.daml
@@ -1,0 +1,65 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Daml.Finance.Interface.Bond.ZeroCoupon where
+
+import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (I, K)
+import Daml.Finance.Interface.Asset.Types (InstrumentKey(..))
+import Daml.Finance.Interface.Common.Disclosure qualified as Disclosure (I, Implementation)
+import Daml.Finance.Interface.Common.Types (Observers)
+
+-- | Type synonym for `Factory`.
+type F = Factory
+
+-- | View of `Factory`.
+data View = View
+  with
+    provider : Party
+      -- ^ The provider of the `Factory`.
+  deriving (Eq, Ord, Show)
+
+-- | Interface that allows implementing templates to create instruments.
+interface Factory where
+  asDisclosure : Disclosure.I
+    -- ^ Conversion to `Disclosure` interface.
+  view : View
+    -- ^ Acquire the default interface view.
+  createImpl : Create -> Update (ContractId Instrument.I)
+    -- ^ Implementation of `Create` choice.
+  removeImpl : Remove -> Update ()
+    -- ^ Implementation of `Remove` choice.
+
+  nonconsuming choice Create : ContractId Instrument.I
+    -- ^ Create a new account.
+    with
+      instrument : InstrumentKey
+        -- ^ The instrument's key.
+      issueDate : Date
+        -- ^ The date when the bond was issued.
+      maturityDate : Date
+        -- ^ The last coupon date (and the redemption date) of the bond.
+      currency : Instrument.K
+        -- ^ The currency of the bond. For example, if the bond pays in USD this should be a USD cash instrument.
+      lastEventTimestamp : Time
+        -- ^ (Market) time of the last recorded lifecycle event. If no event has occurred yet, the time of creation should be used.
+      observers : Observers
+        -- ^ The instrument's observers.
+    controller instrument.depository, instrument.issuer
+    do
+      createImpl this arg
+
+  nonconsuming choice Remove : ()
+    -- ^ Archive an account.
+    with
+      instrument : InstrumentKey
+        -- ^ The account's key.
+    controller instrument.depository, instrument.issuer
+      do
+        removeImpl this arg
+
+-- | Type constraint used to require templates implementing `Factory` to also
+-- implement `Disclosure`.
+type Implementation t = (HasToInterface t Factory, Disclosure.Implementation t)
+instance HasToInterface Factory Disclosure.I where _toInterface = asDisclosure
+class (Implementation t) => HasImplementation t
+instance HasImplementation Factory

--- a/src/main/daml/Daml/Finance/Interface/Derivative/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Derivative/Factory.daml
@@ -1,0 +1,64 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Daml.Finance.Interface.Derivative.Factory where
+
+import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (I)
+import Daml.Finance.Interface.Asset.Types (InstrumentKey(..))
+import Daml.Finance.Interface.Common.Disclosure qualified as Disclosure (I, Implementation)
+import Daml.Finance.Interface.Common.Types (Observers)
+import Daml.Finance.Interface.Derivative.Types (C)
+
+-- | Type synonym for `Factory`.
+type F = Factory
+
+-- View of `Factory`.
+data View = View
+  with
+    provider : Party
+      -- ^ The provider of the `Factory`.
+  deriving (Eq, Ord, Show)
+
+-- | Interface that allows implementing templates to create instruments.
+interface Factory where
+  asDisclosure : Disclosure.I
+    -- ^ Conversion to `Disclosure` interface.
+  view : View
+    -- ^ Acquire the default interface view.
+  createImpl : Create -> Update (ContractId Instrument.I)
+    -- ^ Implementation of `Create` choice.
+  removeImpl : Remove -> Update ()
+    -- ^ Implementation of `Remove` choice.
+
+  nonconsuming choice Create : ContractId Instrument.I
+    -- ^ Create a new account.
+    with
+      instrument : InstrumentKey
+        -- ^ The instrument's key.
+      claims : C
+        -- ^ The claim tree.
+      acquisitionTime : Time
+        -- ^ The claim's acquisition time. This usually corresponds to the start date of the contract.
+      lastEventTimestamp : Time
+        -- ^ (Market) time of the last recorded lifecycle event. If no event has occurred yet, the time of creation should be used.
+      observers : Observers
+        -- ^ The instrument's observers.
+    controller instrument.depository, instrument.issuer
+    do
+      createImpl this arg
+
+  nonconsuming choice Remove : ()
+    -- ^ Archive an account.
+    with
+      instrument : InstrumentKey
+        -- ^ The account's key.
+    controller instrument.depository, instrument.issuer
+      do
+        removeImpl this arg
+
+-- | Type constraint used to require templates implementing `Factory` to also
+-- implement `Disclosure`.
+type Implementation t = (HasToInterface t Factory, Disclosure.Implementation t)
+instance HasToInterface Factory Disclosure.I where _toInterface = asDisclosure
+class (Implementation t) => HasImplementation t
+instance HasImplementation Factory

--- a/src/main/daml/Daml/Finance/Interface/Equity/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Equity/Factory.daml
@@ -1,0 +1,59 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Daml.Finance.Interface.Equity.Factory where
+
+import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (I)
+import Daml.Finance.Interface.Asset.Types (InstrumentKey(..))
+import Daml.Finance.Interface.Common.Disclosure qualified as Disclosure (I, Implementation)
+import Daml.Finance.Interface.Common.Types (Observers)
+
+-- | Type synonym for `Factory`.
+type F = Factory
+
+-- View of `Factory`.
+data View = View
+  with
+    provider : Party
+      -- ^ The provider of the `Factory`.
+  deriving (Eq, Ord, Show)
+
+-- | Interface that allows implementing templates to create instruments.
+interface Factory where
+  asDisclosure : Disclosure.I
+    -- ^ Conversion to `Disclosure` interface.
+  view : View
+    -- ^ Acquire the default interface view.
+  createImpl : Create -> Update (ContractId Instrument.I)
+    -- ^ Implementation of `Create` choice.
+  removeImpl : Remove -> Update ()
+    -- ^ Implementation of `Remove` choice.
+
+  nonconsuming choice Create : ContractId Instrument.I
+    -- ^ Create a new account.
+    with
+      instrument : InstrumentKey
+        -- ^ The instrument's key.
+      validAsOf : Time
+        -- ^ (Market) time of the last recorded lifecycle event. If no event has occurred yet, the time of creation should be used.
+      observers : Observers
+        -- ^ The instrument's observers.
+    controller instrument.depository, instrument.issuer
+    do
+      createImpl this arg
+
+  nonconsuming choice Remove : ()
+    -- ^ Archive an account.
+    with
+      instrument : InstrumentKey
+        -- ^ The account's key.
+    controller instrument.depository, instrument.issuer
+      do
+        removeImpl this arg
+
+-- | Type constraint used to require templates implementing `Factory` to also
+-- implement `Disclosure`.
+type Implementation t = (HasToInterface t Factory, Disclosure.Implementation t)
+instance HasToInterface Factory Disclosure.I where _toInterface = asDisclosure
+class (Implementation t) => HasImplementation t
+instance HasImplementation Factory

--- a/src/test/daml/Daml/Finance/Bond/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Bond/Test/Util.daml
@@ -8,10 +8,10 @@ import DA.Set (Set, empty, singleton)
 import Daml.Finance.Asset.Test.Util.Holding (verifyOwnerOfHolding)
 import Daml.Finance.Asset.Test.Util.Instrument (createReference)
 import Daml.Finance.Asset.Test.Util.Instrument qualified as Instrument (submitExerciseInterfaceByKeyCmd)
-import Daml.Finance.Bond.FixedRate (FixedRateBond(..))
-import Daml.Finance.Bond.FloatingRate (FloatingRateBond(..))
-import Daml.Finance.Bond.InflationLinked (InflationLinkedBond(..))
-import Daml.Finance.Bond.ZeroCoupon (ZeroCouponBond(..))
+import Daml.Finance.Bond.FixedRate qualified as FixedRate (Instrument(..))
+import Daml.Finance.Bond.FloatingRate qualified as FloatingRate (Instrument(..))
+import Daml.Finance.Bond.InflationLinked qualified as InflationLinked (Instrument(..))
+import Daml.Finance.Bond.ZeroCoupon qualified as ZeroCoupon (Instrument(..))
 import Daml.Finance.Common.Date.Calendar
 import Daml.Finance.Common.Date.DayCount
 import Daml.Finance.Common.Date.RollConvention
@@ -36,25 +36,25 @@ import Prelude hiding (lookup)
 originateFixedRateBond : Party -> Party -> Text -> [(Text, Set Parties)] -> Time -> Date -> [Text] -> Party -> Date-> Date -> DayCountConventionEnum -> BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Script Instrument.K
 originateFixedRateBond depository issuer label observers lastEventTimestamp issueDate holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention businessDayConvention couponRate couponPeriod couponPeriodMultiplier currency = do
   cid <- toInterfaceContractId @Instrument.I <$> submitMulti [depository, issuer] [] do
-    createCmd FixedRateBond with depository; issuer; id = (Id with label; version = "0"); observers = M.fromList observers; lastEventTimestamp; issueDate; holidayCalendarIds; calendarDataProvider; firstCouponDate; maturityDate; dayCountConvention; businessDayConvention; couponRate; couponPeriod; couponPeriodMultiplier; currency
+    createCmd FixedRate.Instrument with depository; issuer; id = (Id with label; version = "0"); observers = M.fromList observers; lastEventTimestamp; issueDate; holidayCalendarIds; calendarDataProvider; firstCouponDate; maturityDate; dayCountConvention; businessDayConvention; couponRate; couponPeriod; couponPeriodMultiplier; currency
   createReference cid depository issuer observers
 
 originateZeroCouponBond : Party -> Party -> Text -> [(Text, Set Parties)] -> Time -> Date -> Date -> Deliverable -> Script Instrument.K
 originateZeroCouponBond depository issuer label observers lastEventTimestamp issueDate maturityDate currency = do
   cid <- toInterfaceContractId <$> submitMulti [depository, issuer] [] do
-    createCmd ZeroCouponBond with depository; issuer; id = (Id with label; version = "0"); observers = M.fromList observers; lastEventTimestamp; issueDate; maturityDate; currency
+    createCmd ZeroCoupon.Instrument with depository; issuer; id = (Id with label; version = "0"); observers = M.fromList observers; lastEventTimestamp; issueDate; maturityDate; currency
   createReference cid depository issuer observers
 
 originateFloatingRateBond : Party -> Party -> Text -> [(Text, Set Parties)] -> Time -> Date -> [Text] -> Party -> Date -> Date -> DayCountConventionEnum -> BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Text -> Script Instrument.K
 originateFloatingRateBond depository issuer label observers lastEventTimestamp issueDate holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention businessDayConvention couponRate couponPeriod couponPeriodMultiplier currency referenceRateId = do
   cid <- toInterfaceContractId <$> submitMulti [depository, issuer] [] do
-    createCmd FloatingRateBond with depository; issuer; id = (Id with label; version = "0"); observers = M.fromList observers; lastEventTimestamp; issueDate; holidayCalendarIds; calendarDataProvider; firstCouponDate; maturityDate; dayCountConvention; businessDayConvention; couponSpread=couponRate; referenceRateId; couponPeriod; couponPeriodMultiplier; currency
+    createCmd FloatingRate.Instrument with depository; issuer; id = (Id with label; version = "0"); observers = M.fromList observers; lastEventTimestamp; issueDate; holidayCalendarIds; calendarDataProvider; firstCouponDate; maturityDate; dayCountConvention; businessDayConvention; couponSpread=couponRate; referenceRateId; couponPeriod; couponPeriodMultiplier; currency
   createReference cid depository issuer observers
 
 originateInflationLinkedBond : Party -> Party -> Text -> [(Text, Set Parties)] -> Time -> Date -> [Text] -> Party -> Date -> Date -> DayCountConventionEnum -> BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Text -> Decimal -> Script Instrument.K
 originateInflationLinkedBond depository issuer label observers lastEventTimestamp issueDate holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention businessDayConvention couponRate couponPeriod couponPeriodMultiplier currency inflationIndexId inflationIndexBaseValue = do
   cid <- toInterfaceContractId <$> submitMulti [depository, issuer] [] do
-    createCmd InflationLinkedBond with depository; issuer; id = (Id with label; version = "0"); observers = M.fromList observers; lastEventTimestamp; issueDate; holidayCalendarIds; calendarDataProvider; firstCouponDate; maturityDate; dayCountConvention; businessDayConvention; couponRate; inflationIndexId; couponPeriod; couponPeriodMultiplier; currency; inflationIndexBaseValue
+    createCmd InflationLinked.Instrument with depository; issuer; id = (Id with label; version = "0"); observers = M.fromList observers; lastEventTimestamp; issueDate; holidayCalendarIds; calendarDataProvider; firstCouponDate; maturityDate; dayCountConvention; businessDayConvention; couponRate; inflationIndexId; couponPeriod; couponPeriodMultiplier; currency; inflationIndexBaseValue
   createReference cid depository issuer observers
 
 lifecycleBond : [Party] -> Date -> Instrument.K -> Party -> Party -> [ContractId Observable.I] -> Script (ContractId Lifecyclable.I, [ContractId Effect.I])

--- a/src/test/daml/Daml/Finance/Bond/Test/ZeroCoupon.daml
+++ b/src/test/daml/Daml/Finance/Bond/Test/ZeroCoupon.daml
@@ -11,7 +11,7 @@ import Daml.Finance.Asset.Test.Util.Account qualified as Account (createAccount,
 import Daml.Finance.Asset.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
 import Daml.Finance.Asset.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Finance.Bond.Test.Util (lifecycleBond, originateZeroCouponBond, verifyNoLifecycleEffects)
-import Daml.Finance.Bond.ZeroCoupon (ZeroCouponBond)
+import Daml.Finance.Bond.ZeroCoupon qualified as ZeroCoupon (Instrument)
 import Daml.Finance.Interface.Asset.Instrument qualified as Instrument (K, getKey)
 import Daml.Finance.Interface.Asset.Transferable qualified as Transferable (I)
 import Daml.Finance.Interface.Asset.Types (AccountKey)
@@ -28,7 +28,7 @@ lifecycleAndVerifyRedemptionEffectsAndSettlement : [Party] -> Date -> Instrument
 lifecycleAndVerifyRedemptionEffectsAndSettlement readAs today bondInstrument settler issuer investor investorBondTransferableCid custodianCashRedemptionTransferableCid custodianAccount investorAccount obs custodian = do
   (bondLifecyclableCid2, [effectCid]) <- lifecycleBond readAs today bondInstrument settler issuer []
 
-  Some newBondInstrument <- queryContractId @ZeroCouponBond issuer $ coerceContractId bondLifecyclableCid2
+  Some newBondInstrument <- queryContractId @ZeroCoupon.Instrument issuer $ coerceContractId bondLifecyclableCid2
   let newBondInstrumentKey = Instrument.getKey newBondInstrument
 
   -- Create settlement factory


### PR DESCRIPTION
This introduced a dependency from `D.F.Interface.Bond` to `D.F.Common`, which is undesirable as the Common package contains utility function implementations. https://github.com/DACH-NY/daml-finance/issues/288 is to address this.

I haven't included the factories in the tests, as I wanted to do https://github.com/DACH-NY/daml-finance/issues/280 first, which should simplify a lot of parameter passing around.