### PR TITLE
Include PeriodicSchedule in bonds

### DIFF
--- a/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate.daml
@@ -10,9 +10,8 @@ import Daml.Finance.Interface.Instrument.Bond.FixedRate qualified as FixedRate (
 import Daml.Finance.Interface.Instrument.Generic.HasClaims qualified as HasClaims (I, View(..))
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Evolve(..), View(..))
 import Daml.Finance.Interface.Types.Common (Id(..), InstrumentKey(..), Observers)
-import Daml.Finance.Interface.Types.Date.Calendar (BusinessDayConventionEnum)
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
-import Daml.Finance.Interface.Types.Date.RollConvention (PeriodEnum)
+import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..))
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, SetObservers(..), View(..), flattenObservers)
 import Prelude hiding (key)
 
@@ -34,24 +33,14 @@ template Instrument
       -- ^ An identifier of the instrument.
     couponRate : Decimal
       -- ^ The fixed coupon rate, per annum. For example, in case of a "3.5% p.a coupon" this should be 0.035.
-    issueDate : Date
-      -- ^ The date when the bond was issued.
-    firstCouponDate : Date
-      -- ^ The first coupon date of the bond.
-    maturityDate : Date
-      -- ^ The last coupon date (and the redemption date) of the bond.
+    periodicSchedule : PeriodicSchedule
+      -- ^ The schedule for the periodic coupon payments.
     holidayCalendarIds : [Text]
       -- ^ the identifier of the holiday calendar to be used for the coupon schedule.
     calendarDataProvider : Party
       -- ^ The reference data provider to use for the holiday calendar.
     dayCountConvention : DayCountConventionEnum
       -- ^ The day count convention used to calculate day count fractions. For example: Act360.
-    businessDayConvention : BusinessDayConventionEnum
-      -- ^ An enum type to specify how a non-business day is adjusted. For example: FOLLOWING.
-    couponPeriod : PeriodEnum
-      -- ^ The coupon period. For example, in case of a 3M coupon period (a coupon every 3 months), this should be M.
-    couponPeriodMultiplier : Int
-      -- ^ The coupon period multiplier. For example, in case of a 3M coupon period (a coupon every 3 months), this should be 3.
     currency : Instrument.K
       -- ^ The currency of the bond. For example, if the bond pays in USD this should be a USD cash instrument.
     observers : Observers
@@ -67,14 +56,14 @@ template Instrument
 
     -- FIXED_RATE_BOND_HASCLAIMS_BEGIN
     interface instance HasClaims.I for Instrument where
-      view = HasClaims.View with acquisitionTime = dateToDateClockTime issueDate
+      view = HasClaims.View with acquisitionTime = dateToDateClockTime periodicSchedule.effectiveDate
       getClaims = do
         -- get the initial claims tree (as of the bond's acquisition time)
-        (schedule, frequency) <- createCouponScheduleAndFrequency firstCouponDate holidayCalendarIds businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate issuer calendarDataProvider
+        schedule <- createCouponSchedule periodicSchedule holidayCalendarIds issuer calendarDataProvider
         let
           useAdjustedDatesForDcf = True
-        couponClaims <- createFixRateCouponClaims schedule useAdjustedDatesForDcf couponRate dayCountConvention maturityDate frequency currency
-        redemptionClaim <- createRedemptionClaim currency maturityDate
+        couponClaims <- createFixRateCouponClaims schedule periodicSchedule useAdjustedDatesForDcf couponRate dayCountConvention periodicSchedule.frequency currency
+        redemptionClaim <- createRedemptionClaim currency periodicSchedule.terminationDate
         pure $ mconcat [couponClaims, redemptionClaim]
     -- FIXED_RATE_BOND_HASCLAIMS_END
 
@@ -112,22 +101,17 @@ template Factory
     interface instance FixedRate.Factory for Factory where
       asDisclosure = toInterface @Disclosure.I this
       view = FixedRate.View with provider
-      create' FixedRate.Create{instrument; couponRate; issueDate; firstCouponDate; maturityDate; holidayCalendarIds; calendarDataProvider; dayCountConvention; businessDayConvention; couponPeriod; couponPeriodMultiplier; currency; lastEventTimestamp; observers} = do
+      create' FixedRate.Create{instrument; couponRate; periodicSchedule; holidayCalendarIds; calendarDataProvider; dayCountConvention; currency; lastEventTimestamp; observers} = do
         cid <- toInterfaceContractId <$> create Instrument
           with
             depository = instrument.depository
             issuer = instrument.issuer
             id = instrument.id
             couponRate
-            issueDate
-            firstCouponDate
-            maturityDate
+            periodicSchedule
             holidayCalendarIds
             calendarDataProvider
             dayCountConvention
-            businessDayConvention
-            couponPeriod
-            couponPeriodMultiplier
             currency
             lastEventTimestamp
             observers

--- a/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate.daml
@@ -62,7 +62,7 @@ template Instrument
         schedule <- createCouponSchedule periodicSchedule holidayCalendarIds issuer calendarDataProvider
         let
           useAdjustedDatesForDcf = True
-        couponClaims <- createFixRateCouponClaims schedule periodicSchedule useAdjustedDatesForDcf couponRate dayCountConvention periodicSchedule.frequency currency
+        couponClaims <- createFixRateCouponClaims schedule periodicSchedule useAdjustedDatesForDcf couponRate dayCountConvention currency
         redemptionClaim <- createRedemptionClaim currency periodicSchedule.terminationDate
         pure $ mconcat [couponClaims, redemptionClaim]
     -- FIXED_RATE_BOND_HASCLAIMS_END

--- a/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate.daml
@@ -59,7 +59,7 @@ template Instrument
       view = HasClaims.View with acquisitionTime = dateToDateClockTime periodicSchedule.effectiveDate
       getClaims = do
         -- get the initial claims tree (as of the bond's acquisition time)
-        schedule <- createCouponSchedule periodicSchedule holidayCalendarIds issuer calendarDataProvider
+        schedule <- rollCouponSchedule periodicSchedule holidayCalendarIds issuer calendarDataProvider
         let
           useAdjustedDatesForDcf = True
         couponClaims <- createFixRateCouponClaims schedule periodicSchedule useAdjustedDatesForDcf couponRate dayCountConvention currency

--- a/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate.daml
@@ -65,7 +65,7 @@ template Instrument
         schedule <- createCouponSchedule periodicSchedule holidayCalendarIds issuer calendarDataProvider
         let
           useAdjustedDatesForDcf = True
-        couponClaims <- createFloatingRateCouponClaims schedule useAdjustedDatesForDcf couponSpread dayCountConvention periodicSchedule.terminationDate periodicSchedule.frequency currency referenceRateId
+        couponClaims <- createFloatingRateCouponClaims schedule periodicSchedule useAdjustedDatesForDcf couponSpread dayCountConvention currency referenceRateId
         redemptionClaim <- createRedemptionClaim currency periodicSchedule.terminationDate
         pure $ mconcat [couponClaims, redemptionClaim]
 

--- a/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate.daml
@@ -10,9 +10,8 @@ import Daml.Finance.Interface.Instrument.Bond.FloatingRate qualified as Floating
 import Daml.Finance.Interface.Instrument.Generic.HasClaims qualified as HasClaims (I, View(..))
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Evolve(..), View(..))
 import Daml.Finance.Interface.Types.Common (Id(..), InstrumentKey(..), Observers)
-import Daml.Finance.Interface.Types.Date.Calendar (BusinessDayConventionEnum)
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
-import Daml.Finance.Interface.Types.Date.RollConvention (PeriodEnum)
+import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..))
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, SetObservers(..), View(..), flattenObservers)
 import Prelude hiding (key)
 
@@ -39,24 +38,14 @@ template Instrument
     -- FLOATING_RATE_BOND_TEMPLATE_UNTIL_REFRATE_END
     couponSpread : Decimal
       -- ^ The floating rate coupon spread. For example, in case of "3M Euribor + 0.5%" this should be 0.005.
-    issueDate : Date
-      -- ^ The date when the bond was issued.
-    firstCouponDate : Date
-      -- ^ The first coupon date of the bond.
-    maturityDate : Date
-      -- ^ The last coupon date (and the redemption date) of the bond.
+    periodicSchedule : PeriodicSchedule
+      -- ^ The schedule for the periodic coupon payments.
     holidayCalendarIds : [Text]
       -- ^ the identifier of the holiday calendar to be used for the coupon schedule.
     calendarDataProvider : Party
       -- ^ The reference data provider to use for the holiday calendar.
     dayCountConvention : DayCountConventionEnum
       -- ^ The day count convention used to calculate day count fractions. For example: Act360.
-    businessDayConvention : BusinessDayConventionEnum
-      -- ^ An enum type to specify how a non-business day is adjusted. For example: FOLLOWING.
-    couponPeriod : PeriodEnum
-      -- ^ The coupon period. For example, in case of a 3M coupon period (a coupon every 3 months), this should be M.
-    couponPeriodMultiplier : Int
-      -- ^ The coupon period multiplier. For example, in case of a 3M coupon period (a coupon every 3 months), this should be 3.
     currency : Instrument.K
       -- ^ The currency of the bond. For example, if the bond pays in USD this should be a USD cash instrument.
     observers : Observers
@@ -70,14 +59,14 @@ template Instrument
     let instrumentKey = InstrumentKey with depository; issuer; id
 
     interface instance HasClaims.I for Instrument where
-      view = HasClaims.View with acquisitionTime = dateToDateClockTime issueDate
+      view = HasClaims.View with acquisitionTime = dateToDateClockTime periodicSchedule.effectiveDate
       getClaims = do
         -- get the initial claims tree (as of the bond's acquisition time)
-        (schedule, frequency) <- createCouponScheduleAndFrequency firstCouponDate holidayCalendarIds businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate issuer calendarDataProvider
+        schedule <- createCouponSchedule periodicSchedule holidayCalendarIds issuer calendarDataProvider
         let
           useAdjustedDatesForDcf = True
-        couponClaims <- createFloatingRateCouponClaims schedule useAdjustedDatesForDcf couponSpread dayCountConvention maturityDate frequency currency referenceRateId
-        redemptionClaim <- createRedemptionClaim currency maturityDate
+        couponClaims <- createFloatingRateCouponClaims schedule useAdjustedDatesForDcf couponSpread dayCountConvention periodicSchedule.terminationDate periodicSchedule.frequency currency referenceRateId
+        redemptionClaim <- createRedemptionClaim currency periodicSchedule.terminationDate
         pure $ mconcat [couponClaims, redemptionClaim]
 
     interface instance Instrument.I for Instrument where
@@ -114,7 +103,7 @@ template Factory
     interface instance FloatingRate.Factory for Factory where
       asDisclosure = toInterface @Disclosure.I this
       view = FloatingRate.View with provider
-      create' FloatingRate.Create{instrument; referenceRateId; couponSpread; issueDate; firstCouponDate; maturityDate; holidayCalendarIds; calendarDataProvider; dayCountConvention; businessDayConvention; couponPeriod; couponPeriodMultiplier; currency; lastEventTimestamp; observers} = do
+      create' FloatingRate.Create{instrument; referenceRateId; couponSpread; periodicSchedule; holidayCalendarIds; calendarDataProvider; dayCountConvention; currency; lastEventTimestamp; observers} = do
         cid <- toInterfaceContractId <$> create Instrument
           with
             depository = instrument.depository
@@ -122,15 +111,10 @@ template Factory
             id = instrument.id
             referenceRateId
             couponSpread
-            issueDate
-            firstCouponDate
-            maturityDate
+            periodicSchedule
             holidayCalendarIds
             calendarDataProvider
             dayCountConvention
-            businessDayConvention
-            couponPeriod
-            couponPeriodMultiplier
             currency
             lastEventTimestamp
             observers

--- a/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate.daml
@@ -62,7 +62,7 @@ template Instrument
       view = HasClaims.View with acquisitionTime = dateToDateClockTime periodicSchedule.effectiveDate
       getClaims = do
         -- get the initial claims tree (as of the bond's acquisition time)
-        schedule <- createCouponSchedule periodicSchedule holidayCalendarIds issuer calendarDataProvider
+        schedule <- rollCouponSchedule periodicSchedule holidayCalendarIds issuer calendarDataProvider
         let
           useAdjustedDatesForDcf = True
         couponClaims <- createFloatingRateCouponClaims schedule periodicSchedule useAdjustedDatesForDcf couponSpread dayCountConvention currency referenceRateId

--- a/src/main/daml/Daml/Finance/Instrument/Bond/InflationLinked.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/InflationLinked.daml
@@ -69,7 +69,7 @@ template Instrument
           acquisitionTime = dateToDateClockTime periodicSchedule.effectiveDate
       getClaims = do
         -- get the initial claims tree (as of the bond's acquisition time)
-        schedule <- createCouponSchedule periodicSchedule holidayCalendarIds issuer calendarDataProvider
+        schedule <- rollCouponSchedule periodicSchedule holidayCalendarIds issuer calendarDataProvider
 
         let
           -- calculate the current inflation factor (how inflation has developed from the first reference date until now)

--- a/src/main/daml/Daml/Finance/Instrument/Bond/InflationLinked.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/InflationLinked.daml
@@ -12,9 +12,8 @@ import Daml.Finance.Interface.Instrument.Bond.InflationLinked qualified as Infla
 import Daml.Finance.Interface.Instrument.Generic.HasClaims qualified as HasClaims (I, View(..))
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Evolve(..), View(..))
 import Daml.Finance.Interface.Types.Common (Id(..), InstrumentKey(..), Observers)
-import Daml.Finance.Interface.Types.Date.Calendar (BusinessDayConventionEnum)
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
-import Daml.Finance.Interface.Types.Date.RollConvention (PeriodEnum)
+import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..))
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, SetObservers(..), View(..), flattenObservers)
 import Daml.Finance.Util.Date.DayCount (calcPeriodDcf)
 import Prelude hiding ((<=), key, or)
@@ -44,24 +43,14 @@ template Instrument
       -- ^ The value of the inflation index on the first reference date of this bond (called "dated date" on US TIPS). This is used as the base value for the principal adjustment.
     couponRate : Decimal
       -- ^ The fixed coupon rate, per annum. For example, in case of a "0.5% p.a. coupon, CPI adjusted principal" this should be 0.005.
-    issueDate : Date
-      -- ^ The date when the bond was issued.
-    firstCouponDate : Date
-      -- ^ The first coupon date of the bond.
-    maturityDate : Date
-      -- ^ The last coupon date (and the redemption date) of the bond.
+    periodicSchedule : PeriodicSchedule
+      -- ^ The schedule for the periodic coupon payments.
     holidayCalendarIds : [Text]
       -- ^ the identifier of the holiday calendar to be used for the coupon schedule.
     calendarDataProvider : Party
       -- ^ The reference data provider to use for the holiday calendar.
     dayCountConvention : DayCountConventionEnum
       -- ^ The day count convention used to calculate day count fractions. For example: Act360.
-    businessDayConvention : BusinessDayConventionEnum
-      -- ^ An enum type to specify how a non-business day is adjusted. For example: FOLLOWING.
-    couponPeriod : PeriodEnum
-      -- ^ The coupon period. For example, in case of a 3M coupon period (a coupon every 3 months), this should be M.
-    couponPeriodMultiplier : Int
-      -- ^ The coupon period multiplier. For example, in case of a 3M coupon period (a coupon every 3 months), this should be 3.
     currency : Instrument.K
       -- ^ The currency of the bond. For example, if the bond pays in USD this should be a USD cash instrument.
     observers : Observers
@@ -77,10 +66,10 @@ template Instrument
     interface instance HasClaims.I for Instrument where
       view = HasClaims.View
         with
-          acquisitionTime = dateToDateClockTime issueDate
+          acquisitionTime = dateToDateClockTime periodicSchedule.effectiveDate
       getClaims = do
         -- get the initial claims tree (as of the bond's acquisition time)
-        (schedule, frequency) <- createCouponScheduleAndFrequency firstCouponDate holidayCalendarIds businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate issuer calendarDataProvider
+        schedule <- createCouponSchedule periodicSchedule holidayCalendarIds issuer calendarDataProvider
 
         let
           -- calculate the current inflation factor (how inflation has developed from the first reference date until now)
@@ -89,7 +78,7 @@ template Instrument
           -- calculate the fixed rate coupons (based on an inflation adjusted principal)
           useAdjustedDatesForDcf = True
           couponClaims = map (\p ->
-            when (TimeGte $ p.adjustedEndDate) $ scale ((Const couponRate) * inflationFactor * (Const (calcPeriodDcf dayCountConvention p useAdjustedDatesForDcf maturityDate frequency))) $ one currency) schedule
+            when (TimeGte $ p.adjustedEndDate) $ scale ((Const couponRate) * inflationFactor * (Const (calcPeriodDcf dayCountConvention p useAdjustedDatesForDcf periodicSchedule.terminationDate periodicSchedule.frequency))) $ one currency) schedule
 
           -- check whether there has been deflation or inflation during the lifetime of the bond
           deflation = Observe inflationIndexId <= Const inflationIndexBaseValue
@@ -101,7 +90,7 @@ template Instrument
           inflationClaim = scale inflationFactor (one currency)
 
           -- add the redemption claim
-          redemptionClaim = when (TimeGte $ maturityDate) $ cond deflation deflationClaim inflationClaim
+          redemptionClaim = when (TimeGte $ periodicSchedule.terminationDate) $ cond deflation deflationClaim inflationClaim
 
         couponClaimsTagged <- prepareAndTagClaims couponClaims "Coupon"
         redemptionClaimTagged <- prepareAndTagClaims [redemptionClaim] "Redemption"
@@ -141,7 +130,7 @@ template Factory
     interface instance InflationLinked.Factory for Factory where
       asDisclosure = toInterface @Disclosure.I this
       view = InflationLinked.View with provider
-      create' InflationLinked.Create{instrument; inflationIndexId; inflationIndexBaseValue; couponRate; issueDate; firstCouponDate; maturityDate; holidayCalendarIds; calendarDataProvider; dayCountConvention; businessDayConvention; couponPeriod; couponPeriodMultiplier; currency; lastEventTimestamp; observers} = do
+      create' InflationLinked.Create{instrument; inflationIndexId; inflationIndexBaseValue; couponRate; periodicSchedule; holidayCalendarIds; calendarDataProvider; dayCountConvention; currency; lastEventTimestamp; observers} = do
         cid <- toInterfaceContractId <$> create Instrument
           with
             depository = instrument.depository
@@ -150,15 +139,10 @@ template Factory
             inflationIndexId
             inflationIndexBaseValue
             couponRate
-            issueDate
-            firstCouponDate
-            maturityDate
+            periodicSchedule
             holidayCalendarIds
             calendarDataProvider
             dayCountConvention
-            businessDayConvention
-            couponPeriod
-            couponPeriodMultiplier
             currency
             lastEventTimestamp
             observers

--- a/src/main/daml/Daml/Finance/Instrument/Bond/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/Util.daml
@@ -19,11 +19,9 @@ import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I, getEventTim
 import Daml.Finance.Interface.Lifecycle.Observable qualified as Observable (I)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I)
 import Daml.Finance.Interface.Types.Common (Id)
-import Daml.Finance.Interface.Types.Date.Calendar (BusinessDayAdjustment(..), BusinessDayConventionEnum)
 import Daml.Finance.Interface.Types.Date.Classes (toUTCTime)
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
-import Daml.Finance.Interface.Types.Date.RollConvention (PeriodEnum, RollConventionEnum(..))
-import Daml.Finance.Interface.Types.Date.Schedule (Frequency(..), PeriodicSchedule(..), Schedule, SchedulePeriod)
+import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..), Schedule, SchedulePeriod)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 import Daml.Finance.Lifecycle.Effect (Effect(..))
 import Daml.Finance.RefData.HolidayCalendar (GetCalendar(..), HolidayCalendar, HolidayCalendarKey(..))
@@ -31,39 +29,6 @@ import Daml.Finance.RefData.Time.DateClock (Unit(..))
 import Daml.Finance.Util.Date.DayCount (calcPeriodDcf)
 import Daml.Finance.Util.Date.Schedule (createSchedule)
 import Prelude hiding (key)
-
--- | Retrieve holiday calendar(s) from the ledger and create a coupon schedule
--- TODO: REMOVE
-createCouponScheduleAndFrequency : Date -> [Text] -> BusinessDayConventionEnum -> PeriodEnum -> Int -> Date -> Date -> Party -> Party -> Update (Schedule, Frequency)
-createCouponScheduleAndFrequency firstCouponDate holidayCalendarIds businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate issuer calendarDataAgency = do
-  let
-    (y, m, d) = toGregorian firstCouponDate
-    periodicSchedule = PeriodicSchedule with
-      businessDayAdjustment =
-        BusinessDayAdjustment with
-          calendarIds = holidayCalendarIds
-          convention = businessDayConvention
-      effectiveDateBusinessDayAdjustment = None
-      terminationDateBusinessDayAdjustment = None
-      frequency =
-        Frequency with
-          rollConvention = DOM d
-          period = couponPeriod
-          periodMultiplier = couponPeriodMultiplier
-      effectiveDate = issueDate
-      firstRegularPeriodStartDate = Some firstCouponDate
-      lastRegularPeriodEndDate = Some maturityDate
-      stubPeriodType = None
-      terminationDate = maturityDate
-    -- get a holiday calendar from the ledger
-    getCalendar holidayCalendarId = do
-      exerciseByKey @HolidayCalendar holCalKey GetCalendar with viewer = issuer where
-        holCalKey = HolidayCalendarKey with
-          agency = calendarDataAgency
-          entity = holidayCalendarId
-  -- Get the holiday calendars
-  cals <- mapA getCalendar holidayCalendarIds
-  pure $ (createSchedule cals periodicSchedule, periodicSchedule.frequency)
 
 -- | Retrieve holiday calendar(s) from the ledger and create a coupon schedule
 createCouponSchedule : PeriodicSchedule -> [Text] -> Party -> Party -> Update Schedule
@@ -87,22 +52,22 @@ prepareAndTagClaims claim tag = do
 
 -- FIXED_RATE_BOND_COUPON_CLAIMS_BEGIN
 -- | Calculate a fix coupon amount for each coupon date and create claims
-createFixRateCouponClaims : Applicative f => [SchedulePeriod] -> PeriodicSchedule -> Bool -> Decimal -> DayCountConventionEnum -> Frequency -> Deliverable -> f [TaggedClaim]
-createFixRateCouponClaims schedule periodicSchedule useAdjustedDatesForDcf couponRate dayCountConvention frequency cashInstrumentCid = do
+createFixRateCouponClaims : Applicative f => [SchedulePeriod] -> PeriodicSchedule -> Bool -> Decimal -> DayCountConventionEnum -> Deliverable -> f [TaggedClaim]
+createFixRateCouponClaims schedule periodicSchedule useAdjustedDatesForDcf couponRate dayCountConvention cashInstrumentCid = do
   let
     couponDatesAdjusted = map (.adjustedEndDate) schedule
-    couponAmounts = map (\p -> couponRate * (calcPeriodDcf dayCountConvention p useAdjustedDatesForDcf periodicSchedule.terminationDate frequency)) schedule
+    couponAmounts = map (\p -> couponRate * (calcPeriodDcf dayCountConvention p useAdjustedDatesForDcf periodicSchedule.terminationDate periodicSchedule.frequency)) schedule
     couponClaims = zipWith (\d a -> when (TimeGte $ d) $ scale (Const a) $ one cashInstrumentCid) couponDatesAdjusted couponAmounts
   prepareAndTagClaims couponClaims "Fix Coupon"
 -- FIXED_RATE_BOND_COUPON_CLAIMS_END
 
 -- FLOATING_RATE_BOND_COUPON_CLAIMS_BEGIN
 -- | Calculate a floating coupon amount for each coupon date and create claims
-createFloatingRateCouponClaims : Applicative f => [SchedulePeriod] -> Bool -> Decimal -> DayCountConventionEnum -> Date -> Frequency -> Deliverable -> Observable -> f [TaggedClaim]
-createFloatingRateCouponClaims schedule useAdjustedDatesForDcf couponSpread dayCountConvention maturityDate frequency cashInstrumentCid referenceRateId = do
+createFloatingRateCouponClaims : Applicative f => [SchedulePeriod] -> PeriodicSchedule -> Bool -> Decimal -> DayCountConventionEnum -> Deliverable -> Observable -> f [TaggedClaim]
+createFloatingRateCouponClaims schedule periodicSchedule useAdjustedDatesForDcf couponSpread dayCountConvention cashInstrumentCid referenceRateId = do
   let
     couponClaims = map (\p ->
-      when (TimeGte $ p.adjustedStartDate) $ scale ((Observe referenceRateId + Const couponSpread) * (Const (calcPeriodDcf dayCountConvention p useAdjustedDatesForDcf maturityDate frequency))) $
+      when (TimeGte $ p.adjustedStartDate) $ scale ((Observe referenceRateId + Const couponSpread) * (Const (calcPeriodDcf dayCountConvention p useAdjustedDatesForDcf periodicSchedule.terminationDate periodicSchedule.frequency))) $
       when (TimeGte $ p.adjustedEndDate) $ one cashInstrumentCid) schedule
   prepareAndTagClaims couponClaims "Floating Coupon"
 -- FLOATING_RATE_BOND_COUPON_CLAIMS_END

--- a/src/main/daml/Daml/Finance/Instrument/Bond/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/Util.daml
@@ -30,9 +30,9 @@ import Daml.Finance.Util.Date.DayCount (calcPeriodDcf)
 import Daml.Finance.Util.Date.Schedule (createSchedule)
 import Prelude hiding (key)
 
--- | Retrieve holiday calendar(s) from the ledger and create a coupon schedule
-createCouponSchedule : PeriodicSchedule -> [Text] -> Party -> Party -> Update Schedule
-createCouponSchedule periodicSchedule holidayCalendarIds issuer calendarDataAgency = do
+-- | Retrieve holiday calendar(s) from the ledger and roll out the coupon schedule.
+rollCouponSchedule : PeriodicSchedule -> [Text] -> Party -> Party -> Update Schedule
+rollCouponSchedule periodicSchedule holidayCalendarIds issuer calendarDataAgency = do
   let
     -- get a holiday calendar from the ledger
     getCalendar holidayCalendarId = do

--- a/src/main/daml/Daml/Finance/Instrument/Bond/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/Util.daml
@@ -19,20 +19,21 @@ import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I, getEventTim
 import Daml.Finance.Interface.Lifecycle.Observable qualified as Observable (I)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I)
 import Daml.Finance.Interface.Types.Common (Id)
-import Daml.Finance.Interface.Types.Date.Calendar
+import Daml.Finance.Interface.Types.Date.Calendar (BusinessDayAdjustment(..), BusinessDayConventionEnum)
 import Daml.Finance.Interface.Types.Date.Classes (toUTCTime)
-import Daml.Finance.Interface.Types.Date.DayCount
-import Daml.Finance.Interface.Types.Date.RollConvention
-import Daml.Finance.Interface.Types.Date.Schedule
+import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
+import Daml.Finance.Interface.Types.Date.RollConvention (PeriodEnum, RollConventionEnum(..))
+import Daml.Finance.Interface.Types.Date.Schedule (Frequency(..), PeriodicSchedule(..), Schedule, SchedulePeriod)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 import Daml.Finance.Lifecycle.Effect (Effect(..))
-import Daml.Finance.RefData.HolidayCalendar
+import Daml.Finance.RefData.HolidayCalendar (GetCalendar(..), HolidayCalendar, HolidayCalendarKey(..))
 import Daml.Finance.RefData.Time.DateClock (Unit(..))
-import Daml.Finance.Util.Date.DayCount
-import Daml.Finance.Util.Date.Schedule
+import Daml.Finance.Util.Date.DayCount (calcPeriodDcf)
+import Daml.Finance.Util.Date.Schedule (createSchedule)
 import Prelude hiding (key)
 
 -- | Retrieve holiday calendar(s) from the ledger and create a coupon schedule
+-- TODO: REMOVE
 createCouponScheduleAndFrequency : Date -> [Text] -> BusinessDayConventionEnum -> PeriodEnum -> Int -> Date -> Date -> Party -> Party -> Update (Schedule, Frequency)
 createCouponScheduleAndFrequency firstCouponDate holidayCalendarIds businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate issuer calendarDataAgency = do
   let
@@ -64,6 +65,20 @@ createCouponScheduleAndFrequency firstCouponDate holidayCalendarIds businessDayC
   cals <- mapA getCalendar holidayCalendarIds
   pure $ (createSchedule cals periodicSchedule, periodicSchedule.frequency)
 
+-- | Retrieve holiday calendar(s) from the ledger and create a coupon schedule
+createCouponSchedule : PeriodicSchedule -> [Text] -> Party -> Party -> Update Schedule
+createCouponSchedule periodicSchedule holidayCalendarIds issuer calendarDataAgency = do
+  let
+    -- get a holiday calendar from the ledger
+    getCalendar holidayCalendarId = do
+      exerciseByKey @HolidayCalendar holCalKey GetCalendar with viewer = issuer where
+        holCalKey = HolidayCalendarKey with
+          agency = calendarDataAgency
+          entity = holidayCalendarId
+  -- Get the holiday calendars
+  cals <- mapA getCalendar holidayCalendarIds
+  pure $ createSchedule cals periodicSchedule
+
 -- | Convert the claims to UTCTime and tag them
 prepareAndTagClaims : Applicative f => [Claim Date Decimal Deliverable Observable] -> Text -> f [TaggedClaim]
 prepareAndTagClaims claim tag = do
@@ -72,11 +87,11 @@ prepareAndTagClaims claim tag = do
 
 -- FIXED_RATE_BOND_COUPON_CLAIMS_BEGIN
 -- | Calculate a fix coupon amount for each coupon date and create claims
-createFixRateCouponClaims : Applicative f => [SchedulePeriod] -> Bool -> Decimal -> DayCountConventionEnum -> Date -> Frequency -> Deliverable -> f [TaggedClaim]
-createFixRateCouponClaims schedule useAdjustedDatesForDcf couponRate dayCountConvention maturityDate frequency cashInstrumentCid = do
+createFixRateCouponClaims : Applicative f => [SchedulePeriod] -> PeriodicSchedule -> Bool -> Decimal -> DayCountConventionEnum -> Frequency -> Deliverable -> f [TaggedClaim]
+createFixRateCouponClaims schedule periodicSchedule useAdjustedDatesForDcf couponRate dayCountConvention frequency cashInstrumentCid = do
   let
     couponDatesAdjusted = map (.adjustedEndDate) schedule
-    couponAmounts = map (\p -> couponRate * (calcPeriodDcf dayCountConvention p useAdjustedDatesForDcf maturityDate frequency)) schedule
+    couponAmounts = map (\p -> couponRate * (calcPeriodDcf dayCountConvention p useAdjustedDatesForDcf periodicSchedule.terminationDate frequency)) schedule
     couponClaims = zipWith (\d a -> when (TimeGte $ d) $ scale (Const a) $ one cashInstrumentCid) couponDatesAdjusted couponAmounts
   prepareAndTagClaims couponClaims "Fix Coupon"
 -- FIXED_RATE_BOND_COUPON_CLAIMS_END

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Bond/FixedRate.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Bond/FixedRate.daml
@@ -5,9 +5,8 @@ module Daml.Finance.Interface.Instrument.Bond.FixedRate where
 
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (I, K)
 import Daml.Finance.Interface.Types.Common (InstrumentKey(..), Observers)
-import Daml.Finance.Interface.Types.Date.Calendar (BusinessDayConventionEnum)
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
-import Daml.Finance.Interface.Types.Date.RollConvention (PeriodEnum)
+import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..))
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, Implementation)
 
 -- | Type synonym for `Factory`.
@@ -41,24 +40,16 @@ interface Factory where
         -- ^ The instrument's key.
       couponRate : Decimal
         -- ^ The fixed coupon rate, per annum. For example, in case of a "3.5% p.a. coupon" this should be 0.035.
-      issueDate : Date
-        -- ^ The date when the bond was issued.
+      periodicSchedule : PeriodicSchedule
+        -- ^ The schedule for the periodic coupon payments.
       firstCouponDate : Date
         -- ^ The first coupon date of the bond.
-      maturityDate : Date
-        -- ^ The last coupon date (and the redemption date) of the bond.
       holidayCalendarIds : [Text]
         -- ^ the identifier of the holiday calendar to be used for the coupon schedule.
       calendarDataProvider : Party
         -- ^ The reference data provider to use for the holiday calendar.
       dayCountConvention : DayCountConventionEnum
         -- ^ The day count convention used to calculate day count fractions. For example: Act360.
-      businessDayConvention : BusinessDayConventionEnum
-        -- ^ An enum type to specify how a non-business day is adjusted. For example: FOLLOWING.
-      couponPeriod : PeriodEnum
-        -- ^ The coupon period. For example, in case of a 3M coupon period (a coupon every 3 months), this should be M.
-      couponPeriodMultiplier : Int
-        -- ^ The coupon period multiplier. For example, in case of a 3M coupon period (a coupon every 3 months), this should be 3.
       currency : Instrument.K
         -- ^ The currency of the bond. For example, if the bond pays in USD this should be a USD cash instrument.
       lastEventTimestamp : Time

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Bond/FloatingRate.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Bond/FloatingRate.daml
@@ -5,9 +5,8 @@ module Daml.Finance.Interface.Instrument.Bond.FloatingRate where
 
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (I, K)
 import Daml.Finance.Interface.Types.Common (InstrumentKey(..), Observers)
-import Daml.Finance.Interface.Types.Date.Calendar (BusinessDayConventionEnum)
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
-import Daml.Finance.Interface.Types.Date.RollConvention (PeriodEnum)
+import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..))
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, Implementation)
 
 -- | Type synonym for `Factory`.
@@ -43,24 +42,14 @@ interface Factory where
         -- ^ The floating rate reference ID. For example, in case of "3M Euribor + 0.5%" this should a valid reference to the "3M Euribor" reference rate.
       couponSpread : Decimal
         -- ^ The floating rate coupon spread. For example, in case of "3M Euribor + 0.5%" this should be 0.005.
-      issueDate : Date
-        -- ^ The date when the bond was issued.
-      firstCouponDate : Date
-        -- ^ The first coupon date of the bond.
-      maturityDate : Date
-        -- ^ The last coupon date (and the redemption date) of the bond.
+      periodicSchedule : PeriodicSchedule
+        -- ^ The schedule for the periodic coupon payments.
       holidayCalendarIds : [Text]
         -- ^ the identifier of the holiday calendar to be used for the coupon schedule.
       calendarDataProvider : Party
         -- ^ The reference data provider to use for the holiday calendar.
       dayCountConvention : DayCountConventionEnum
         -- ^ The day count convention used to calculate day count fractions. For example: Act360.
-      businessDayConvention : BusinessDayConventionEnum
-        -- ^ An enum type to specify how a non-business day is adjusted. For example: FOLLOWING.
-      couponPeriod : PeriodEnum
-        -- ^ The coupon period. For example, in case of a 3M coupon period (a coupon every 3 months), this should be M.
-      couponPeriodMultiplier : Int
-        -- ^ The coupon period multiplier. For example, in case of a 3M coupon period (a coupon every 3 months), this should be 3.
       currency : Instrument.K
         -- ^ The currency of the bond. For example, if the bond pays in USD this should be a USD cash instrument.
       lastEventTimestamp : Time

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Bond/InflationLinked.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Bond/InflationLinked.daml
@@ -5,9 +5,8 @@ module Daml.Finance.Interface.Instrument.Bond.InflationLinked where
 
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (I, K)
 import Daml.Finance.Interface.Types.Common (InstrumentKey(..), Observers)
-import Daml.Finance.Interface.Types.Date.Calendar (BusinessDayConventionEnum)
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
-import Daml.Finance.Interface.Types.Date.RollConvention (PeriodEnum)
+import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..))
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, Implementation)
 
 -- | Type synonym for `Factory`.
@@ -45,10 +44,8 @@ interface Factory where
         -- ^ The value of the inflation index on the first reference date of this bond (called "dated date" on US TIPS). This is used as the base value for the principal adjustment.
       couponRate : Decimal
         -- ^ The fixed coupon rate, per annum. For example, in case of a "0.5% p.a. coupon, CPI adjusted principal" this should be 0.005.
-      issueDate : Date
-        -- ^ The date when the bond was issued.
-      firstCouponDate : Date
-        -- ^ The first coupon date of the bond.
+      periodicSchedule : PeriodicSchedule
+        -- ^ The schedule for the periodic coupon payments.
       maturityDate : Date
         -- ^ The last coupon date (and the redemption date) of the bond.
       holidayCalendarIds : [Text]
@@ -57,12 +54,6 @@ interface Factory where
         -- ^ The reference data provider to use for the holiday calendar.
       dayCountConvention : DayCountConventionEnum
         -- ^ The day count convention used to calculate day count fractions. For example: Act360.
-      businessDayConvention : BusinessDayConventionEnum
-        -- ^ An enum type to specify how a non-business day is adjusted. For example: FOLLOWING.
-      couponPeriod : PeriodEnum
-        -- ^ The coupon period. For example, in case of a 3M coupon period (a coupon every 3 months), this should be M.
-      couponPeriodMultiplier : Int
-        -- ^ The coupon period multiplier. For example, in case of a 3M coupon period (a coupon every 3 months), this should be 3.
       currency : Instrument.K
         -- ^ The currency of the bond. For example, if the bond pays in USD this should be a USD cash instrument.
       lastEventTimestamp : Time

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
@@ -79,16 +79,20 @@ originateZeroCouponBond depository issuer label observers lastEventTimestamp iss
 originateFloatingRateBond : Party -> Party -> Text -> [(Text, Set Parties)] -> Time -> Date -> [Text] -> Party -> Date -> Date -> DayCountConventionEnum -> BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Text -> Script Instrument.K
 originateFloatingRateBond depository issuer label observers lastEventTimestamp issueDate holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention businessDayConvention couponRate couponPeriod couponPeriodMultiplier currency referenceRateId = do
   -- CREATE_FLOATING_RATE_BOND_INSTRUMENT_BEGIN
+  let
+    periodicSchedule = createCouponPeriodicSchedule firstCouponDate holidayCalendarIds businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate
   cid <- toInterfaceContractId <$> submitMulti [depository, issuer] [] do
-    createCmd FloatingRate.Instrument with depository; issuer; id = (Id with label; version = "0"); observers = M.fromList observers; lastEventTimestamp; issueDate; holidayCalendarIds; calendarDataProvider; firstCouponDate; maturityDate; dayCountConvention; businessDayConvention; couponSpread=couponRate; referenceRateId; couponPeriod; couponPeriodMultiplier; currency
+    createCmd FloatingRate.Instrument with depository; issuer; id = (Id with label; version = "0"); observers = M.fromList observers; lastEventTimestamp; periodicSchedule; holidayCalendarIds; calendarDataProvider; dayCountConvention; couponSpread=couponRate; referenceRateId; currency
   -- CREATE_FLOATING_RATE_BOND_INSTRUMENT_END
   createReference cid depository issuer observers
 
 originateInflationLinkedBond : Party -> Party -> Text -> [(Text, Set Parties)] -> Time -> Date -> [Text] -> Party -> Date -> Date -> DayCountConventionEnum -> BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Text -> Decimal -> Script Instrument.K
 originateInflationLinkedBond depository issuer label observers lastEventTimestamp issueDate holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention businessDayConvention couponRate couponPeriod couponPeriodMultiplier currency inflationIndexId inflationIndexBaseValue = do
   -- CREATE_INFLATION_LINKED_BOND_INSTRUMENT_BEGIN
+  let
+    periodicSchedule = createCouponPeriodicSchedule firstCouponDate holidayCalendarIds businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate
   cid <- toInterfaceContractId <$> submitMulti [depository, issuer] [] do
-    createCmd InflationLinked.Instrument with depository; issuer; id = (Id with label; version = "0"); observers = M.fromList observers; lastEventTimestamp; issueDate; holidayCalendarIds; calendarDataProvider; firstCouponDate; maturityDate; dayCountConvention; businessDayConvention; couponRate; inflationIndexId; couponPeriod; couponPeriodMultiplier; currency; inflationIndexBaseValue
+    createCmd InflationLinked.Instrument with depository; issuer; id = (Id with label; version = "0"); observers = M.fromList observers; lastEventTimestamp; periodicSchedule; holidayCalendarIds; calendarDataProvider; dayCountConvention; couponRate; inflationIndexId; currency; inflationIndexBaseValue
   -- CREATE_INFLATION_LINKED_BOND_INSTRUMENT_END
   createReference cid depository issuer observers
 

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
@@ -3,6 +3,7 @@
 
 module Daml.Finance.Instrument.Bond.Test.Util where
 
+import DA.Date
 import DA.Map qualified as M
 import DA.Set (Set, empty, singleton)
 import Daml.Finance.Instrument.Bond.FixedRate qualified as FixedRate (Instrument(..))
@@ -20,9 +21,10 @@ import Daml.Finance.Interface.Lifecycle.Rule.Settlement qualified as Settlement 
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Types.Common
-import Daml.Finance.Interface.Types.Date.Calendar
-import Daml.Finance.Interface.Types.Date.DayCount
-import Daml.Finance.Interface.Types.Date.RollConvention
+import Daml.Finance.Interface.Types.Date.Calendar (BusinessDayAdjustment(..), BusinessDayConventionEnum)
+import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
+import Daml.Finance.Interface.Types.Date.RollConvention (PeriodEnum, RollConventionEnum(..))
+import Daml.Finance.Interface.Types.Date.Schedule (Frequency(..), PeriodicSchedule(..))
 import Daml.Finance.Lifecycle.Rule.Settlement (Rule(..))
 import Daml.Finance.RefData.Time.DateClock (DateClock(..), DateClockUpdateEvent(..), Unit(..))
 import Daml.Finance.Settlement.Factory (Factory(..))
@@ -32,11 +34,37 @@ import Daml.Finance.Test.Util.Instrument qualified as Instrument (submitExercise
 import Daml.Script
 import Prelude hiding (lookup)
 
+-- | Create a schedule for the periodic coupon payments.
+createCouponPeriodicSchedule : Date -> [Text] -> BusinessDayConventionEnum -> PeriodEnum -> Int -> Date -> Date -> PeriodicSchedule
+createCouponPeriodicSchedule firstCouponDate holidayCalendarIds businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate = do
+  let
+    (y, m, d) = toGregorian firstCouponDate
+    periodicSchedule = PeriodicSchedule with
+      businessDayAdjustment =
+        BusinessDayAdjustment with
+          calendarIds = holidayCalendarIds
+          convention = businessDayConvention
+      effectiveDateBusinessDayAdjustment = None
+      terminationDateBusinessDayAdjustment = None
+      frequency =
+        Frequency with
+          rollConvention = DOM d
+          period = couponPeriod
+          periodMultiplier = couponPeriodMultiplier
+      effectiveDate = issueDate
+      firstRegularPeriodStartDate = Some firstCouponDate
+      lastRegularPeriodEndDate = Some maturityDate
+      stubPeriodType = None
+      terminationDate = maturityDate
+  periodicSchedule
+
 originateFixedRateBond : Party -> Party -> Text -> [(Text, Set Parties)] -> Time -> Date -> [Text] -> Party -> Date-> Date -> DayCountConventionEnum -> BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Script Instrument.K
 originateFixedRateBond depository issuer label observers lastEventTimestamp issueDate holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention businessDayConvention couponRate couponPeriod couponPeriodMultiplier currency = do
   -- CREATE_FIXED_RATE_BOND_INSTRUMENT_BEGIN
+  let
+    periodicSchedule = createCouponPeriodicSchedule firstCouponDate holidayCalendarIds businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate
   cid <- toInterfaceContractId @Instrument.I <$> submitMulti [depository, issuer] [] do
-    createCmd FixedRate.Instrument with depository; issuer; id = (Id with label; version = "0"); observers = M.fromList observers; lastEventTimestamp; issueDate; holidayCalendarIds; calendarDataProvider; firstCouponDate; maturityDate; dayCountConvention; businessDayConvention; couponRate; couponPeriod; couponPeriodMultiplier; currency
+    createCmd FixedRate.Instrument with depository; issuer; id = (Id with label; version = "0"); observers = M.fromList observers; lastEventTimestamp; periodicSchedule; holidayCalendarIds; calendarDataProvider; dayCountConvention; couponRate; currency
   -- CREATE_FIXED_RATE_BOND_INSTRUMENT_END
   createReference cid depository issuer observers
 


### PR DESCRIPTION
I have included PeriodicSchedule in the bond definitions. This enables the full functionality of the PeriodicSchedule (including end stubs and EOM roll conventions) in the bond templates.

Next, I will update the bond tutorial / documentation. I will submit that as a separate PR, to reduce the risk of merge conflicts.