### PR TITLE
Update the bond tutorial to reflect PeriodicSchedule

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,16 @@ Theme is copied from Daml Docs theme.
 
 `Node` and `yarn` must be installed on your machine.
 
+### Sass
+
+The `Node` version of `sass` must be installed: `gem install sass`
+
+### Grunt
+
+If grunt is not already installed: `sudo npm install -g grunt-cli`
+
+If you had to install anything new above, you may have to recreate the virtual environment: `pipenv install` again
+
 ## Building the docs
 
 1. Navigate to the root folder of the repository.

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,13 +26,13 @@ Theme is copied from Daml Docs theme.
 
 ### Sass
 
-The `Node` version of `sass` must be installed: `gem install sass`
+The `ruby` version of `sass` must be installed: `gem install sass`.
 
 ### Grunt
 
-If grunt is not already installed: `sudo npm install -g grunt-cli`
+If grunt is not already installed: `npm install grunt-cli`.
 
-If you had to install anything new above, you may have to recreate the virtual environment: `pipenv install` again
+If you had to install anything new above, but it still does not work, you may have to recreate the virtual environment: `pipenv install` again.
 
 ## Building the docs
 

--- a/docs/source/getting-started/download-daml-finance.rst
+++ b/docs/source/getting-started/download-daml-finance.rst
@@ -1,10 +1,10 @@
 .. Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Getting started : Installing Daml Finance
-#########################################
+Getting started : Download Daml Finance
+#######################################
 
-If you want to have a more detailed look in the Daml Finance codebase, you can install the repo
+If you want to have a more detailed look in the Daml Finance codebase, you can download the repo
 locally on your machine. That allows you to navigate the code, both the template definitions
 and the tests.
 
@@ -14,21 +14,21 @@ components interact with each other.
 As a pre-requisite, the `Daml SDK <https://docs.daml.com/getting-started/installation.html>`_ needs to be installed on your
 machine.
 
-In order to install `Daml Finance <https://github.com/digital-asset/daml-finance>`_, open a terminal and run:
+In order to download `Daml Finance <https://github.com/digital-asset/daml-finance>`_, open a terminal and run:
 
 .. code-block:: shell
 
    git clone git@github.com:digital-asset/daml-finance.git
 
 This creates a new folder containing `Daml Finance <https://github.com/digital-asset/daml-finance>`_ .
-Navigate to the folder and then run
+Navigate to the folder and then run:
 
 .. code-block:: shell
 
    make
 
 to download any packages that are required and then build the project.
-You can then run
+You can then run:
 
 .. code-block:: shell
 

--- a/docs/source/getting-started/download-daml-finance.rst
+++ b/docs/source/getting-started/download-daml-finance.rst
@@ -4,7 +4,7 @@
 Getting started : Download Daml Finance
 #######################################
 
-If you want to have a more detailed look in the Daml Finance codebase, you can download the repo
+If you want to have a more detailed look in the Daml Finance codebase, you can clone the repo
 locally on your machine. That allows you to navigate the code, both the template definitions
 and the tests.
 

--- a/docs/source/getting-started/intro.rst
+++ b/docs/source/getting-started/intro.rst
@@ -17,7 +17,7 @@ Next steps
 
 The :doc:`Transfer <transfer>` page describes accounts, cash instrument, deposit and transfer.
 
-The :doc:`Install Daml Finance <install-daml-finance>` page shows you how to download and install Daml Finance locally.
+The :doc:`Download Daml Finance <download-daml-finance>` page shows you how to download Daml Finance locally.
 
 The :doc:`Settlement <settlement>` page describes how to do a single transfer and an atomic delivery vs payment.
 

--- a/docs/source/getting-started/lifecycling.rst
+++ b/docs/source/getting-started/lifecycling.rst
@@ -16,7 +16,7 @@ Download the code for the tutorial
 **********************************
 
 The code of this tutorial resides in the `Daml Finance <https://github.com/digital-asset/daml-finance>`_ repo.
-You can install it locally by following :doc:`these instructions <install-daml-finance>`.
+You can download it locally by following :doc:`these instructions <download-daml-finance>`.
 
 In particular, the file ``src/test/daml/Daml/Finance/Instrument/Bond/Test/FixedRate.daml`` is the starting point
 of this tutorial.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,7 +32,7 @@ Daml Finance Documentation
 
    getting-started/intro
    getting-started/transfer
-   getting-started/install-daml-finance
+   getting-started/download-daml-finance
    getting-started/settlement
    getting-started/lifecycling
 

--- a/docs/source/tutorial/bond-extension.rst
+++ b/docs/source/tutorial/bond-extension.rst
@@ -56,7 +56,17 @@ each coupon period has. This will determine the exact coupon amount that will be
 The :ref:`business day convention <type-daml-finance-interface-types-date-calendar-businessdayconventionenum-88986>` determines how a coupon date is adjusted if it
 falls on a non-business day.
 
-We can use these variables to create a :ref:`Periodic Schedule <type-daml-finance-interface-types-date-calendar-businessdayconventionenum-88986>`. This is used to determine when coupons are paid.
+We can use these variables to create a :ref:`PeriodicSchedule <constr-daml-finance-interface-types-date-schedule-periodicschedule-99705>`:
+
+.. literalinclude:: ../../../src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
+  :language: daml
+  :start-after: -- CREATE_BOND_PERIODIC_SCHEDULE_BEGIN
+  :end-before: -- CREATE_BOND_PERIODIC_SCHEDULE_END
+
+This is used to determine the periods that are used to calculate the coupon. There are a few things to note here:
+
+- The :ref:`RollConventionEnum <type-daml-finance-interface-types-date-rollconvention-rollconventionenum-73360>` defines whether dates are rolled on month end or on a given date of the month. In our example above we went for the latter option.
+- The :ref:`StubPeriodTypeEnum <type-daml-finance-interface-types-date-schedule-stubperiodtypeenum-69372>` allows you to explicitly specify what kind of stub period the bond should have. This is optional and not used in the example above. Instead, we defined the stub implicitly by specifying a ``firstRegularPeriodStartDate``.
 
 Now that we have defined the terms we can create the bond instrument:
 

--- a/docs/source/tutorial/bond-extension.rst
+++ b/docs/source/tutorial/bond-extension.rst
@@ -8,7 +8,7 @@ Download the code for the tutorial
 **********************************
 
 The code of this tutorial resides in the `Daml Finance <https://github.com/digital-asset/daml-finance>`_ repo.
-You can install it locally by following :doc:`these instructions <../getting-started/install-daml-finance>`.
+You can download it locally by following :doc:`these instructions <../getting-started/download-daml-finance>`.
 
 In particular, the Bond test folder ``src/test/daml/Daml/Finance/Instrument/Bond/Test/`` is the starting point
 of this tutorial.
@@ -23,13 +23,13 @@ For bonds this means that you should only include the bond interface package:
 ``Daml.Finance.Interface.Instrument.Bond``.
 
 Your initialization scripts are an exception to this, since they are only run once when your app is initialized.
-These would create the factories needed. Your app can then create bonds through these factory interfaces.
+This would create the factories needed. Your app can then create bonds through these factory interfaces.
 
 How to create a bond instrument
 *******************************
 
 There are different types of bonds, which mainly differ in the way the coupon is defined.
-In order to create a bond instrument you first have to decide what type it is.
+In order to create a bond instrument you first have to decide what type of bond you need.
 The bond extension package currently supports the following bond types:
 
 Fixed rate
@@ -51,10 +51,12 @@ We start by defining the terms:
   :end-before: -- CREATE_FIXED_RATE_BOND_VARIABLES_END
 
 The :ref:`day count convention <type-daml-finance-interface-types-date-daycount-daycountconventionenum-67281>` is used to determine how many days (i.e. what fraction of a full year)
-each coupon period has. This will determine the exact coupon amount each period.
+each coupon period has. This will determine the exact coupon amount that will be paid each period.
 
 The :ref:`business day convention <type-daml-finance-interface-types-date-calendar-businessdayconventionenum-88986>` determines how a coupon date is adjusted if it
 falls on a non-business day.
+
+We can use these variables to create a :ref:`Periodic Schedule <type-daml-finance-interface-types-date-calendar-businessdayconventionenum-88986>`. This is used to determine when coupons are paid.
 
 Now that we have defined the terms we can create the bond instrument:
 

--- a/docs/source/tutorial/contingent-claims-instrument.rst
+++ b/docs/source/tutorial/contingent-claims-instrument.rst
@@ -14,7 +14,7 @@ Download the code for the tutorial
 ==================================
 
 The code of this tutorial resides in the `Daml Finance <https://github.com/digital-asset/daml-finance>`_ repo.
-You can install it locally by following :doc:`these instructions <../getting-started/install-daml-finance>`.
+You can download it locally by following :doc:`these instructions <../getting-started/download-daml-finance>`.
 
 In particular, the file ``src/test/daml/Daml/Finance/Instrument/Bond/Test/FixedRate.daml`` is the starting point
 of this tutorial.

--- a/docs/source/tutorial/derivative-extension.rst
+++ b/docs/source/tutorial/derivative-extension.rst
@@ -8,7 +8,7 @@ Download the code for the tutorial
 **********************************
 
 The code of this tutorial resides in the `Daml Finance <https://github.com/digital-asset/daml-finance>`_ repo.
-You can install it locally by following :doc:`these instructions <../getting-started/install-daml-finance>`.
+You can download it locally by following :doc:`these instructions <../getting-started/download-daml-finance>`.
 
 In particular, the file ``src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml`` is the starting point
 of this tutorial.

--- a/docs/source/tutorial/intro.rst
+++ b/docs/source/tutorial/intro.rst
@@ -17,7 +17,7 @@ The :doc:`Bond Extension <bond-extension>` tutorial introduces the different typ
 
 The :doc:`Derivative Extension <derivative-extension>` tutorial shows you how to define your own generic instrument.
 
-The :doc:`Contingent Claims Instrument <contingent-claims-instrument>` tutorial describes how to create a new instrument type (similar to the bonds in the Bond Extension)
+The :doc:`Contingent Claims Instrument <contingent-claims-instrument>` tutorial describes how to create a new instrument type (similar to the bond instruments that you saw in the Bond Extension above)
 
-The :doc:`On ledger vs on-the-fly <contingent-claims-on-ledger-vs-on-the-fly>` tutorial helps you to decide whether to store the claims tree on the ledger or generate it on-the-fly.
+The :doc:`On ledger vs on-the-fly <contingent-claims-on-ledger-vs-on-the-fly>` tutorial helps you to decide whether to explicitly store the claims tree on the ledger or generate it on-the-fly.
 

--- a/docs/source/tutorial/intro.rst
+++ b/docs/source/tutorial/intro.rst
@@ -17,7 +17,7 @@ The :doc:`Bond Extension <bond-extension>` tutorial introduces the different typ
 
 The :doc:`Derivative Extension <derivative-extension>` tutorial shows you how to define your own generic instrument.
 
-The :doc:`Contingent Claims Instrument <contingent-claims-instrument>` tutorial describes how to create a new instrument type (similar to the bond instruments that you saw in the Bond Extension above)
+The :doc:`Contingent Claims Instrument <contingent-claims-instrument>` tutorial describes how to create a new instrument type (similar to the bond instruments that you saw in the Bond Extension above).
 
 The :doc:`On ledger vs on-the-fly <contingent-claims-on-ledger-vs-on-the-fly>` tutorial helps you to decide whether to explicitly store the claims tree on the ledger or generate it on-the-fly.
 

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
@@ -37,6 +37,7 @@ import Prelude hiding (lookup)
 -- | Create a schedule for the periodic coupon payments.
 createCouponPeriodicSchedule : Date -> [Text] -> BusinessDayConventionEnum -> PeriodEnum -> Int -> Date -> Date -> PeriodicSchedule
 createCouponPeriodicSchedule firstCouponDate holidayCalendarIds businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate = do
+  -- CREATE_BOND_PERIODIC_SCHEDULE_BEGIN
   let
     (y, m, d) = toGregorian firstCouponDate
     periodicSchedule = PeriodicSchedule with
@@ -56,13 +57,15 @@ createCouponPeriodicSchedule firstCouponDate holidayCalendarIds businessDayConve
       lastRegularPeriodEndDate = Some maturityDate
       stubPeriodType = None
       terminationDate = maturityDate
+  -- CREATE_BOND_PERIODIC_SCHEDULE_END
   periodicSchedule
 
-originateFixedRateBond : Party -> Party -> Text -> Text -> [(Text, Set Parties)] -> Time -> Date -> [Text] -> Party -> Date-> Date -> DayCountConventionEnum -> BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Script Instrument.K
-originateFixedRateBond depository issuer label description observers lastEventTimestamp issueDate holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention businessDayConvention couponRate couponPeriod couponPeriodMultiplier currency = do
+originateFixedRateBond : Party -> Party -> Text -> [(Text, Set Parties)] -> Time -> Date -> [Text] -> Party -> Date-> Date -> DayCountConventionEnum -> BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Script Instrument.K
+originateFixedRateBond depository issuer label observers lastEventTimestamp issueDate holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention businessDayConvention couponRate couponPeriod couponPeriodMultiplier currency = do
   -- CREATE_FIXED_RATE_BOND_INSTRUMENT_BEGIN
   let
     periodicSchedule = createCouponPeriodicSchedule firstCouponDate holidayCalendarIds businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate
+  -- CREATE_FIXED_RATE_BOND_INSTRUMENT_BEGIN
   cid <- toInterfaceContractId @Instrument.I <$> submitMulti [depository, issuer] [] do
     createCmd FixedRate.Instrument with depository; issuer; id = Id label; version = "0"; description; observers = M.fromList observers; lastEventTimestamp; periodicSchedule; holidayCalendarIds; calendarDataProvider; dayCountConvention; couponRate; currency
   -- CREATE_FIXED_RATE_BOND_INSTRUMENT_END
@@ -76,21 +79,23 @@ originateZeroCouponBond depository issuer label description observers lastEventT
   -- CREATE_ZERO_COUPON_BOND_INSTRUMENT_END
   createReference cid depository issuer observers
 
-originateFloatingRateBond : Party -> Party -> Text -> Text -> [(Text, Set Parties)] -> Time -> Date -> [Text] -> Party -> Date -> Date -> DayCountConventionEnum -> BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Text -> Script Instrument.K
-originateFloatingRateBond depository issuer label description observers lastEventTimestamp issueDate holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention businessDayConvention couponRate couponPeriod couponPeriodMultiplier currency referenceRateId = do
+originateFloatingRateBond : Party -> Party -> Text -> [(Text, Set Parties)] -> Time -> Date -> [Text] -> Party -> Date -> Date -> DayCountConventionEnum -> BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Text -> Script Instrument.K
+originateFloatingRateBond depository issuer label observers lastEventTimestamp issueDate holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention businessDayConvention couponRate couponPeriod couponPeriodMultiplier currency referenceRateId = do
   -- CREATE_FLOATING_RATE_BOND_INSTRUMENT_BEGIN
   let
     periodicSchedule = createCouponPeriodicSchedule firstCouponDate holidayCalendarIds businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate
+  -- CREATE_FLOATING_RATE_BOND_INSTRUMENT_BEGIN
   cid <- toInterfaceContractId <$> submitMulti [depository, issuer] [] do
     createCmd FloatingRate.Instrument with depository; issuer; id = Id label; version = "0"; description; observers = M.fromList observers; lastEventTimestamp; periodicSchedule; holidayCalendarIds; calendarDataProvider; dayCountConvention; couponSpread=couponRate; referenceRateId; currency
   -- CREATE_FLOATING_RATE_BOND_INSTRUMENT_END
   createReference cid depository issuer observers
 
-originateInflationLinkedBond : Party -> Party -> Text -> Text -> [(Text, Set Parties)] -> Time -> Date -> [Text] -> Party -> Date -> Date -> DayCountConventionEnum -> BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Text -> Decimal -> Script Instrument.K
-originateInflationLinkedBond depository issuer label description observers lastEventTimestamp issueDate holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention businessDayConvention couponRate couponPeriod couponPeriodMultiplier currency inflationIndexId inflationIndexBaseValue = do
+originateInflationLinkedBond : Party -> Party -> Text -> [(Text, Set Parties)] -> Time -> Date -> [Text] -> Party -> Date -> Date -> DayCountConventionEnum -> BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Text -> Decimal -> Script Instrument.K
+originateInflationLinkedBond depository issuer label observers lastEventTimestamp issueDate holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention businessDayConvention couponRate couponPeriod couponPeriodMultiplier currency inflationIndexId inflationIndexBaseValue = do
   -- CREATE_INFLATION_LINKED_BOND_INSTRUMENT_BEGIN
   let
     periodicSchedule = createCouponPeriodicSchedule firstCouponDate holidayCalendarIds businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate
+  -- CREATE_INFLATION_LINKED_BOND_INSTRUMENT_BEGIN
   cid <- toInterfaceContractId <$> submitMulti [depository, issuer] [] do
     createCmd InflationLinked.Instrument with depository; issuer; id = Id label; version = "0"; description; observers = M.fromList observers; lastEventTimestamp; periodicSchedule; holidayCalendarIds; calendarDataProvider; dayCountConvention; couponRate; inflationIndexId; currency; inflationIndexBaseValue
   -- CREATE_INFLATION_LINKED_BOND_INSTRUMENT_END

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
@@ -60,8 +60,8 @@ createCouponPeriodicSchedule firstCouponDate holidayCalendarIds businessDayConve
   -- CREATE_BOND_PERIODIC_SCHEDULE_END
   periodicSchedule
 
-originateFixedRateBond : Party -> Party -> Text -> [(Text, Set Parties)] -> Time -> Date -> [Text] -> Party -> Date-> Date -> DayCountConventionEnum -> BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Script Instrument.K
-originateFixedRateBond depository issuer label observers lastEventTimestamp issueDate holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention businessDayConvention couponRate couponPeriod couponPeriodMultiplier currency = do
+originateFixedRateBond : Party -> Party -> Text -> Text -> [(Text, Set Parties)] -> Time -> Date -> [Text] -> Party -> Date-> Date -> DayCountConventionEnum -> BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Script Instrument.K
+originateFixedRateBond depository issuer label description observers lastEventTimestamp issueDate holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention businessDayConvention couponRate couponPeriod couponPeriodMultiplier currency = do
   -- CREATE_FIXED_RATE_BOND_INSTRUMENT_BEGIN
   let
     periodicSchedule = createCouponPeriodicSchedule firstCouponDate holidayCalendarIds businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate
@@ -79,8 +79,8 @@ originateZeroCouponBond depository issuer label description observers lastEventT
   -- CREATE_ZERO_COUPON_BOND_INSTRUMENT_END
   createReference cid depository issuer observers
 
-originateFloatingRateBond : Party -> Party -> Text -> [(Text, Set Parties)] -> Time -> Date -> [Text] -> Party -> Date -> Date -> DayCountConventionEnum -> BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Text -> Script Instrument.K
-originateFloatingRateBond depository issuer label observers lastEventTimestamp issueDate holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention businessDayConvention couponRate couponPeriod couponPeriodMultiplier currency referenceRateId = do
+originateFloatingRateBond : Party -> Party -> Text -> Text -> [(Text, Set Parties)] -> Time -> Date -> [Text] -> Party -> Date -> Date -> DayCountConventionEnum -> BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Text -> Script Instrument.K
+originateFloatingRateBond depository issuer label description observers lastEventTimestamp issueDate holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention businessDayConvention couponRate couponPeriod couponPeriodMultiplier currency referenceRateId = do
   -- CREATE_FLOATING_RATE_BOND_INSTRUMENT_BEGIN
   let
     periodicSchedule = createCouponPeriodicSchedule firstCouponDate holidayCalendarIds businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate
@@ -90,8 +90,8 @@ originateFloatingRateBond depository issuer label observers lastEventTimestamp i
   -- CREATE_FLOATING_RATE_BOND_INSTRUMENT_END
   createReference cid depository issuer observers
 
-originateInflationLinkedBond : Party -> Party -> Text -> [(Text, Set Parties)] -> Time -> Date -> [Text] -> Party -> Date -> Date -> DayCountConventionEnum -> BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Text -> Decimal -> Script Instrument.K
-originateInflationLinkedBond depository issuer label observers lastEventTimestamp issueDate holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention businessDayConvention couponRate couponPeriod couponPeriodMultiplier currency inflationIndexId inflationIndexBaseValue = do
+originateInflationLinkedBond : Party -> Party -> Text -> Text -> [(Text, Set Parties)] -> Time -> Date -> [Text] -> Party -> Date -> Date -> DayCountConventionEnum -> BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Text -> Decimal -> Script Instrument.K
+originateInflationLinkedBond depository issuer label description observers lastEventTimestamp issueDate holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention businessDayConvention couponRate couponPeriod couponPeriodMultiplier currency inflationIndexId inflationIndexBaseValue = do
   -- CREATE_INFLATION_LINKED_BOND_INSTRUMENT_BEGIN
   let
     periodicSchedule = createCouponPeriodicSchedule firstCouponDate holidayCalendarIds businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate


### PR DESCRIPTION
I have updated the bond tutorial to describe how to use a PeriodicSchedule, which is now required after the latest change to the bond templates. 

I also did some minor changes to the overall docs, including renaming `Install Daml Finance` to `Download Daml Finance` as per feedback from @GeorgSchneider previously. I updated README.md as well, to describe how to install the doc generation locally.
