### PR TITLE
Election Identifier

### DIFF
--- a/src/main/daml/Daml/Finance/Instrument/Generic/Election.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Election.daml
@@ -5,6 +5,7 @@ module Daml.Finance.Instrument.Generic.Election where
 
 import DA.Map qualified as M (fromList)
 import DA.Set (fromList, singleton)
+import DA.Text (sha256)
 import Daml.Finance.Interface.Holding.Base qualified as Base (I)
 import Daml.Finance.Interface.Holding.Util (getAmount, getCustodian, getInstrument, getOwner)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (K)
@@ -93,8 +94,6 @@ template ElectionFactory
           -- ^ A holding used to verify that the elector is entitled to make the election.
         amount : Decimal
           -- ^ Number of units of instrument to which the election applies.
-        label : Text
-          -- ^ Unique identifier for this election.
       controller elector
       do
         holding <- fetch holdingCid
@@ -109,7 +108,7 @@ template ElectionFactory
             | otherwise = error "Election can be made only on behalf of the owner or the custodian"
         create Election
           with
-            id
+            id = Id . sha256 $ show id <> show claim <> show elector <> show electionTime
             description
             claim
             electionTime

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
@@ -118,7 +118,6 @@ run = script do
       electionTime = dateToDateClockTime intermediateDate
       holdingCid = investorGenericTransferableCid
       amount = 5000.0
-      label = "Election - " <> show intermediateDate
 
   -- Create election
   callBondCid : ContractId Election.I <- toInterfaceContractId <$> submitMulti [bank] [publicParty] do
@@ -127,7 +126,6 @@ run = script do
       electionTime = dateToDateClockTime intermediateDate
       holdingCid = fromInterfaceContractId investorGenericTransferableCid
       amount = 1.0
-      label = "Election - " <> show intermediateDate
 
   -- Apply election to generate new instrument version + effects
   (_, [effectCid]) <- submitMulti [issuer] [] do

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/EuropeanOption.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/EuropeanOption.daml
@@ -133,7 +133,6 @@ run = script do
       electionTime = dateToDateClockTime maturity
       holdingCid = investor1GenericTransferableCid
       amount = 5000.0
-      label = "Election - " <> show maturity
 
   -- Create election
   exerciseOptionCid : ContractId Election.I <- toInterfaceContractId <$> submitMulti [investor1] [publicParty] do
@@ -142,7 +141,6 @@ run = script do
       electionTime = dateToDateClockTime maturity
       holdingCid = investor1GenericTransferableCid
       amount = 500.0
-      label = "Election - " <> show maturity
 
   -- Apply election to generate new instrument version + effects
   (_, [effectCid]) <- submitMulti [broker] [] do
@@ -208,7 +206,6 @@ run = script do
       electionTime = dateToDateClockTime maturity
       holdingCid = investor2GenericTransferableCid
       amount = 1000.0
-      label = "Election - " <> show maturity
 
   (_, [effectCid]) <- submitMulti [broker] [] do
     exerciseCmd expireOptionCid Election.Apply


### PR DESCRIPTION
Remove the requirement for the `elector` to provide an Id when requesting to create a new election. 