### PR TITLE
Fix comments that broke doc building

### DIFF
--- a/src/main/daml/Daml/Finance/Interface/Holding/Factory/Account.daml
+++ b/src/main/daml/Daml/Finance/Interface/Holding/Factory/Account.daml
@@ -40,7 +40,7 @@ interface Factory where
       holdingFactoryCid : ContractId Holding.F
         -- ^ Associated holding factory for the account.
       description : Text
-      -- ^ Human readable description of the account.
+        -- ^ Human readable description of the account.
       observers : Observers
         -- ^ The account's observers.
     controller account.custodian, account.owner

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Factory.daml
@@ -49,7 +49,7 @@ interface Factory where
       id : Id
         -- ^ Factory identifier.
       description : Text
-      -- ^ Batch description.
+        -- ^ Batch description.
       steps : [Step]
         -- ^ Settlement steps to instruct.
     controller instructors


### PR DESCRIPTION
Seems that `make doc-html` breaks if the comments after template variables are not "properly" indented. I have fixed a couple of those problems below. Doc building now works again, at least on my machine.