### PR TITLE
Align day-count enums with ISDA CDM and ISO20022

### DIFF
--- a/src/main/daml/Daml/Finance/Interface/Types/Date/DayCount.daml
+++ b/src/main/daml/Daml/Finance/Interface/Types/Date/DayCount.daml
@@ -7,20 +7,20 @@ module Daml.Finance.Interface.Types.Date.DayCount
 -- | An enum type to specify a day count convention used to calculate day count fractions.
 -- For a detailed definition of each convention, we refer to the "Method of Interest Computation Indicator" definitions in the context of the ISO-20022 standard. Where useful, we provide disambiguation comments.
 data DayCountConventionEnum
-  = Act360
-  -- ^ Actual 360.
+  = Act360 -- DayCountFractionEnum_ACT_360
+  -- ^ Actual 360. In CDM it is called *DayCountFractionEnum_ACT_360*. In ISO20022 it is called *A004*.
   | Act365_Fixed
-  -- ^ Actual 365 fixed.
+  -- ^ Actual 365 fixed. In CDM it is called *DayCountFractionEnum_ACT_365_FIXED*. In ISO20022 it is called *A005*.
   | ActAct_ISDA
-  -- ^ Actual Actual ISDA.
+  -- ^ Actual Actual ISDA. In CDM it is called *DayCountFractionEnum_ACT_ACT_ISDA*. In ISO20022 it is called *A008*.
   | ActAct_ICMA
-  -- ^ Actual Actual ICMA (also called ISMA in the 1998 ISDA paper).
+  -- ^ Actual Actual ICMA. In CDM it is called *DayCountFractionEnum_ACT_ACT_ICMA* and *DayCountFractionEnum_ACT_ACT_ISMA* (they are identical: https://www.isda.org/2011/01/07/act-act-icma/). In ISO20022 it is called *A006*. Also called ISMA in the 1998 ISDA paper.
   | Basis_30360
-  -- ^ 30/360 (also, 30/360 ISDA or A001 or American Basic rule).
+  -- ^ 30/360. In CDM it is called *DayCountFractionEnum__30_360*. In ISO20022 it is called *A001*. Also called 30/360 ISDA or American Basic rule.
   | Basis_30360_ICMA
-  -- ^ 30/360 ICMA (also, A011 or Basic Rule). This corresponds to "30E/360" of the 2006 ISDA definitions.
+  -- ^ 30/360 ICMA. In CDM it is called *DayCountFractionEnum__30E_360*. In ISO20022 it is called *A011*. Also called Basic Rule. This corresponds to "30E/360" of the 2006 ISDA definitions.
   | Basis_30E360
-  -- ^ 30E/360 (also, A007 or Eurobond basis). This corresponds to "30E360 (ISDA)" of the 2006 ISDA definitions.
+  -- ^ 30E/360. In CDM it is called *DayCountFractionEnum__30E_360_ISDA*. In ISO20022 it is called *A007*. Also called Eurobond basis. This corresponds to "30E360 (ISDA)" of the 2006 ISDA definitions.
   | Basis_30E3360
-  -- ^ 30E3/360 (also, A013 or Eurobond basis model 3).
+  -- ^ 30E3/360. Currently not included in CDM. In ISO20022 it is called *A013*. Also called Eurobond basis model 3.
   deriving (Eq, Show)

--- a/src/main/daml/Daml/Finance/Interface/Types/Date/DayCount.daml
+++ b/src/main/daml/Daml/Finance/Interface/Types/Date/DayCount.daml
@@ -11,6 +11,10 @@ data DayCountConventionEnum
   -- ^ Actual 360. In CDM it is called *DayCountFractionEnum_ACT_360*. In ISO20022 it is called *A004*.
   | Act365_Fixed
   -- ^ Actual 365 fixed. In CDM it is called *DayCountFractionEnum_ACT_365_FIXED*. In ISO20022 it is called *A005*.
+  | Act365L
+  -- ^ Actual 365L. In CDM it is called *DayCountFractionEnum_ACT_365L*. In ISO20022 it is called *A009*.
+  | ActAct_AFB
+  -- ^ Actual Actual AFB. In CDM it is called *DayCountFractionEnum_ACT_ACT_AFB*. In ISO20022 it is called *A010*.
   | ActAct_ISDA
   -- ^ Actual Actual ISDA. In CDM it is called *DayCountFractionEnum_ACT_ACT_ISDA*. In ISO20022 it is called *A008*.
   | ActAct_ICMA
@@ -23,9 +27,4 @@ data DayCountConventionEnum
   -- ^ 30E/360. In CDM it is called *DayCountFractionEnum__30E_360_ISDA*. In ISO20022 it is called *A007*. Also called Eurobond basis. This corresponds to "30E360 (ISDA)" of the 2006 ISDA definitions.
   | Basis_30E3360
   -- ^ 30E3/360. Currently not included in CDM. In ISO20022 it is called *A013*. Also called Eurobond basis model 3.
-
-  | Act365L
-  -- ^ Actual 365L. In CDM it is called *DayCountFractionEnum_ACT_365L*. In ISO20022 it is called *A009*.
-  -- | ActAct_AFB
-  -- ^ Actual Actual AFB. In CDM it is called *DayCountFractionEnum_ACT_ACT_AFB*. In ISO20022 it is called *A010*.
   deriving (Eq, Show)

--- a/src/main/daml/Daml/Finance/Interface/Types/Date/DayCount.daml
+++ b/src/main/daml/Daml/Finance/Interface/Types/Date/DayCount.daml
@@ -7,7 +7,7 @@ module Daml.Finance.Interface.Types.Date.DayCount
 -- | An enum type to specify a day count convention used to calculate day count fractions.
 -- For a detailed definition of each convention, we refer to the "Method of Interest Computation Indicator" definitions in the context of the ISO-20022 standard. Where useful, we provide disambiguation comments.
 data DayCountConventionEnum
-  = Act360 -- DayCountFractionEnum_ACT_360
+  = Act360
   -- ^ Actual 360. In CDM it is called *DayCountFractionEnum_ACT_360*. In ISO20022 it is called *A004*.
   | Act365_Fixed
   -- ^ Actual 365 fixed. In CDM it is called *DayCountFractionEnum_ACT_365_FIXED*. In ISO20022 it is called *A005*.
@@ -23,4 +23,9 @@ data DayCountConventionEnum
   -- ^ 30E/360. In CDM it is called *DayCountFractionEnum__30E_360_ISDA*. In ISO20022 it is called *A007*. Also called Eurobond basis. This corresponds to "30E360 (ISDA)" of the 2006 ISDA definitions.
   | Basis_30E3360
   -- ^ 30E3/360. Currently not included in CDM. In ISO20022 it is called *A013*. Also called Eurobond basis model 3.
+
+  | Act365L
+  -- ^ Actual 365L. In CDM it is called *DayCountFractionEnum_ACT_365L*. In ISO20022 it is called *A009*.
+  -- | ActAct_AFB
+  -- ^ Actual Actual AFB. In CDM it is called *DayCountFractionEnum_ACT_ACT_AFB*. In ISO20022 it is called *A010*.
   deriving (Eq, Show)

--- a/src/main/daml/Daml/Finance/Util/Date/DayCount.daml
+++ b/src/main/daml/Daml/Finance/Util/Date/DayCount.daml
@@ -64,7 +64,7 @@ calcPeriodDcfActActIsda p useAdjustedDates maturityDate =
               nDaysY2 = subDate endDate dateYearEnd - 1
               nTotDaysY1 = if isLeapYear y1 then 366 else 365
               nTotDaysY2 = if isLeapYear y2 then 366 else 365
-      _ -> error "The coupon end date must be in the same or in the following calendar year"
+      _ -> error "The coupon end date must be in the same or in a following calendar year"
 
 -- | Calculate Actual Actual day count fraction according to the ISMA method.
 calcPeriodDcfActActIsma : SchedulePeriod -> Bool -> Date -> Frequency -> Decimal

--- a/src/main/daml/Daml/Finance/Util/Date/DayCount.daml
+++ b/src/main/daml/Daml/Finance/Util/Date/DayCount.daml
@@ -22,6 +22,7 @@ calcDcf _ f t | f > t = error "fromDate is greater than toDate"
 calcDcf Act360 f t = calcDcfAct360 f t
 calcDcf Act365_Fixed f t = calcDcfAct365Fixed f t
 calcDcf Act365L f t = calcDcfAct365L f t
+calcDcf ActAct_AFB f t = calcDcfActActAfb f t
 calcDcf ActAct_ISDA f t = error "This calculation requires the knowledge of the stub period. Please, call `calcPeriodDcf` instead."
 calcDcf ActAct_ICMA f t = error "This calculation requires the knowledge of the stub period. Please, call `calcPeriodDcf` instead."
 calcDcf Basis_30360 f t = calcDcf30360 f t
@@ -100,6 +101,20 @@ calcPeriodDcfActActIsma p useAdjustedDates maturityDate frequency =
           notionalMaturityDate = next notionalPaymentDate period frequency.rollConvention
           nDaysP1 = subDate notionalPaymentDate startDate
           nDaysP2 = subDate endDate notionalPaymentDate
+
+-- | HIDE
+-- | Calculate Actual Actual AFB day count fraction.
+calcDcfActActAfb : Date -> Date -> Decimal
+calcDcfActActAfb fromDate toDate =
+  let
+    (y1, m1, d1) = toGregorian fromDate
+    (y2, m2, d2) = toGregorian toDate
+    feb29IncludedInY1 = isLeapYear y1 && fromDate <= getDateEndOfFebruary y1 && getDateEndOfFebruary y1 <= toDate
+    feb29IncludedInY2 = isLeapYear y2 && fromDate <= getDateEndOfFebruary y2 && getDateEndOfFebruary y2 <= toDate
+    nTotDays = if feb29IncludedInY1 || feb29IncludedInY2 then 366 else 365
+    nDays = subDate toDate fromDate
+  in
+    if nDays <= nTotDays then intToDecimal nDays / intToDecimal nTotDays else error "coupon period more than one year not supported"
 
 -- | HIDE
 -- | Calculate Actual 360 day count fraction.

--- a/src/main/daml/Daml/Finance/Util/Date/DayCount.daml
+++ b/src/main/daml/Daml/Finance/Util/Date/DayCount.daml
@@ -21,6 +21,7 @@ calcDcf : DayCountConventionEnum -> Date -> Date -> Decimal
 calcDcf _ f t | f > t = error "fromDate is greater than toDate"
 calcDcf Act360 f t = calcDcfAct360 f t
 calcDcf Act365_Fixed f t = calcDcfAct365Fixed f t
+calcDcf Act365L f t = calcDcfAct365L f t
 calcDcf ActAct_ISDA f t = error "This calculation requires the knowledge of the stub period. Please, call `calcPeriodDcf` instead."
 calcDcf ActAct_ICMA f t = error "This calculation requires the knowledge of the stub period. Please, call `calcPeriodDcf` instead."
 calcDcf Basis_30360 f t = calcDcf30360 f t
@@ -111,6 +112,16 @@ calcDcfAct360 fromDate toDate =
 calcDcfAct365Fixed : Date -> Date -> Decimal
 calcDcfAct365Fixed fromDate toDate =
   (/ 365.0) . intToDecimal $ subDate toDate fromDate
+
+-- | HIDE
+-- | Calculate Actual 365L (Leap-year) day count fraction.
+calcDcfAct365L : Date -> Date -> Decimal
+calcDcfAct365L fromDate toDate =
+  let
+    (y2, m2, d2) = toGregorian toDate
+    nTotDaysY2 = if isLeapYear y2 then 366 else 365
+  in
+    (/ intToDecimal nTotDaysY2) . intToDecimal $ subDate toDate fromDate
 
 -- | HIDE
 -- | Calculate 30/360 day count fraction. This is also known as the '30/360 (ISDA)' or 'Bond Basis' day count convention.

--- a/src/test/daml/Daml/Finance/Util/Test/Date/DayCount.daml
+++ b/src/test/daml/Daml/Finance/Util/Test/Date/DayCount.daml
@@ -255,7 +255,7 @@ testPeriodDcfCalculation_longInitial = do
   calcPeriodDcf ActAct_AFB (periods !! 0) useAdjustedDatesForDcf maturityDate frequency === 0.9150684932
   calcPeriodDcf ActAct_AFB (periods !! 1) useAdjustedDatesForDcf maturityDate frequency === 0.504109589
   calcPeriodDcf ActAct_ISDA (periods !! 0) useAdjustedDatesForDcf maturityDate frequency === 0.9150684931
-  calcPeriodDcf ActAct_ISDA (periods !! 1) useAdjustedDatesForDcf maturityDate frequency === 0.5040047908 -- TODO: verify with paper
+  calcPeriodDcf ActAct_ISDA (periods !! 1) useAdjustedDatesForDcf maturityDate frequency === 0.5040047908 -- Corrected in updated version of the paper: https://www.isda.org/a/pIJEE/The-Actual-Actual-Day-Count-Fraction-1999.pdf
   calcPeriodDcf ActAct_ICMA (periods !! 0) useAdjustedDatesForDcf maturityDate frequency === 0.9157608696
   calcPeriodDcf ActAct_ICMA (periods !! 1) useAdjustedDatesForDcf maturityDate frequency === 0.5
 

--- a/src/test/daml/Daml/Finance/Util/Test/Date/DayCount.daml
+++ b/src/test/daml/Daml/Finance/Util/Test/Date/DayCount.daml
@@ -199,6 +199,7 @@ testPeriodDcfCalculation_regularPeriod = do
     maturityDate = D.date 2004 May 1
     useAdjustedDatesForDcf = True
     frequency = Frequency with rollConvention = DOM 1; period = M; periodMultiplier = 6
+  calcPeriodDcf ActAct_AFB period useAdjustedDatesForDcf maturityDate frequency === 0.4972677596
   calcPeriodDcf ActAct_ISDA period useAdjustedDatesForDcf maturityDate frequency === 0.4977243806
   calcPeriodDcf ActAct_ICMA period useAdjustedDatesForDcf maturityDate frequency === 0.5
 
@@ -223,6 +224,8 @@ testPeriodDcfCalculation_shortInitial = do
     maturityDate = D.date 2000 Jul 1
     useAdjustedDatesForDcf = True
     frequency = Frequency with rollConvention = DOM 1; period = M; periodMultiplier = 12
+  calcPeriodDcf ActAct_AFB (periods !! 0) useAdjustedDatesForDcf maturityDate frequency === 0.4109589041
+  calcPeriodDcf ActAct_AFB (periods !! 1) useAdjustedDatesForDcf maturityDate frequency === 1.0
   calcPeriodDcf ActAct_ISDA (periods !! 0) useAdjustedDatesForDcf maturityDate frequency === 0.4109589041
   calcPeriodDcf ActAct_ISDA (periods !! 1) useAdjustedDatesForDcf maturityDate frequency === 1.0013773486
   calcPeriodDcf ActAct_ICMA (periods !! 0) useAdjustedDatesForDcf maturityDate frequency === 0.4109589041
@@ -249,8 +252,10 @@ testPeriodDcfCalculation_longInitial = do
     maturityDate = D.date 2004 Jan 15
     useAdjustedDatesForDcf = True
     frequency = Frequency with rollConvention = DOM 15; period = M; periodMultiplier = 6
+  calcPeriodDcf ActAct_AFB (periods !! 0) useAdjustedDatesForDcf maturityDate frequency === 0.9150684932
+  calcPeriodDcf ActAct_AFB (periods !! 1) useAdjustedDatesForDcf maturityDate frequency === 0.504109589
   calcPeriodDcf ActAct_ISDA (periods !! 0) useAdjustedDatesForDcf maturityDate frequency === 0.9150684931
-  calcPeriodDcf ActAct_ISDA (periods !! 1) useAdjustedDatesForDcf maturityDate frequency === 0.5040047908
+  calcPeriodDcf ActAct_ISDA (periods !! 1) useAdjustedDatesForDcf maturityDate frequency === 0.5040047908 -- TODO: verify with paper
   calcPeriodDcf ActAct_ICMA (periods !! 0) useAdjustedDatesForDcf maturityDate frequency === 0.9157608696
   calcPeriodDcf ActAct_ICMA (periods !! 1) useAdjustedDatesForDcf maturityDate frequency === 0.5
 
@@ -275,6 +280,8 @@ testPeriodDcfCalculation_shortFinal = do
     maturityDate = D.date 2000 Jun 30
     useAdjustedDatesForDcf = True
     frequency = Frequency with rollConvention = DOM 30; period = M; periodMultiplier = 6
+  calcPeriodDcf ActAct_AFB (periods !! 0) useAdjustedDatesForDcf maturityDate frequency === 0.504109589
+  calcPeriodDcf ActAct_AFB (periods !! 1) useAdjustedDatesForDcf maturityDate frequency === 0.4153005464
   calcPeriodDcf ActAct_ISDA (periods !! 0) useAdjustedDatesForDcf maturityDate frequency === 0.5038925069
   calcPeriodDcf ActAct_ISDA (periods !! 1) useAdjustedDatesForDcf maturityDate frequency === 0.4153005464
   calcPeriodDcf ActAct_ICMA (periods !! 0) useAdjustedDatesForDcf maturityDate frequency === 0.5
@@ -293,5 +300,6 @@ testPeriodDcfCalculation_longFinal = do
     maturityDate = D.date 2000 Apr 30
     useAdjustedDatesForDcf = True
     frequency = Frequency with rollConvention = EOM; period = M; periodMultiplier = 3
+  calcPeriodDcf ActAct_AFB period useAdjustedDatesForDcf maturityDate frequency === 0.4153005464
   calcPeriodDcf ActAct_ISDA period useAdjustedDatesForDcf maturityDate frequency === 0.4155400854
   calcPeriodDcf ActAct_ICMA period useAdjustedDatesForDcf maturityDate frequency === 0.4157608696

--- a/src/test/daml/Daml/Finance/Util/Test/Date/DayCount.daml
+++ b/src/test/daml/Daml/Finance/Util/Test/Date/DayCount.daml
@@ -23,11 +23,13 @@ testDcfCalculation = do
 
   calcDcf Act360 d1 d2 === 1.0138888889
   calcDcf Act365_Fixed d1 d2 === 1.0
+  calcDcf Act365L d1 d2 === 1.0
   calcDcf Basis_30360 d1 d2 === 1.0
   calcDcf Basis_30360_ICMA d1 d2 === 1.0
   calcDcf Basis_30E3360 d1 d2 === 1.0
 
   calcDcf Act365_Fixed d1 d3 === 4.002739726
+  calcDcf Act365L d1 d3 === 4.002739726
   calcDcf Basis_30360 d1 d3 === 4.0
   calcDcf Basis_30E3360 d1 d3 === 4.0
 
@@ -36,6 +38,8 @@ testDcfCalculation = do
     d4 = date 2022 Apr 30
     d5 = date 2022 Jul 31
 
+  calcDcf Act365_Fixed d4 d5 === 0.2520547945
+  calcDcf Act365L d4 d5 === 0.2520547945
   calcDcf Basis_30360 d4 d5 === 0.25
   calcDcf Basis_30360_ICMA d4 d5 === 0.25
   calcDcf Basis_30E3360 d4 d5 === 0.25
@@ -111,6 +115,8 @@ testDcfCalculation = do
     d20 = date 2019 Aug 31
     d21 = date 2020 Feb 28
 
+  calcDcf Act365_Fixed d20 d21 === 0.495890411
+  calcDcf Act365L d20 d21 === 0.4945355191
   calcDcf Basis_30360 d20 d21 === 0.4944444444
   calcDcf Basis_30360_ICMA d20 d21 === 0.4944444444
   calcDcf Basis_30E3360 d20 d21 === 0.4944444444


### PR DESCRIPTION
I have aligned the Daml Finance day-count enums with the ones in ISDA CDM and ISO20022. Since neither of those two standards is complete, we decided to stick with the current Daml Finance enums and map to both standards in the comments.

Also, there were two day-count methods that existed in both ISDA CDM and ISO20022 but not in Daml Finance. I have now implemented these as well:

- ActAct_AFB: implemented according to the 1999 ISDA paper (including the tests provided there)
- Act365L: implemented according to the 2006 ISDA definitions