### PR TITLE
Update SDK and fix regressions

### DIFF
--- a/daml.yaml
+++ b/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance
 source: src/test/daml
 version: 0.1.1
@@ -12,5 +12,5 @@ dependencies:
 data-dependencies:
   - lib/contingent-claims-3.0.0.20220721.1.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15
   - --include=src/main/daml

--- a/docs/code-samples/getting-started/daml.yaml
+++ b/docs/code-samples/getting-started/daml.yaml
@@ -4,7 +4,7 @@
 # for config file options, refer to
 # https://docs.daml.com/tools/assistant.html#project-config-file-daml-yaml
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: quickstart-finance
 source: daml
 init-script: Scripts.Transfer:runTransfer
@@ -24,4 +24,4 @@ data-dependencies:
   - lib/daml-finance-instrument-base-0.1.2.dar
   - lib/daml-finance-settlement-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/main/daml/Daml.Finance.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Holding/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-holding
 source: daml
 version: 0.1.2
@@ -14,4 +14,4 @@ data-dependencies:
   - ../Daml.Finance.Interface.Holding/.daml/dist/daml-finance-interface-holding-0.1.2.dar
   - ../Daml.Finance.Interface.Instrument.Base/.daml/dist/daml-finance-interface-instrument-base-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/main/daml/Daml.Finance.Instrument.Base/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Base/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-instrument-base
 source: daml
 version: 0.1.2
@@ -13,4 +13,4 @@ data-dependencies:
   - ../Daml.Finance.Interface.Util/.daml/dist/daml-finance-interface-util-0.1.2.dar
   - ../Daml.Finance.Interface.Instrument.Base/.daml/dist/daml-finance-interface-instrument-base-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-instrument-bond
 source: daml
 version: 0.1.2
@@ -21,4 +21,4 @@ data-dependencies:
   - ../Daml.Finance.Lifecycle/.daml/dist/daml-finance-lifecycle-0.1.2.dar
   - ../Daml.Finance.RefData/.daml/dist/daml-finance-refdata-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-instrument-equity
 source: daml
 version: 0.1.2
@@ -16,4 +16,4 @@ data-dependencies:
   - ../Daml.Finance.Interface.Instrument.Equity/.daml/dist/daml-finance-interface-instrument-equity-0.1.2.dar
   - ../Daml.Finance.Lifecycle/.daml/dist/daml-finance-lifecycle-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-instrument-generic
 source: daml
 version: 0.1.2
@@ -18,4 +18,4 @@ data-dependencies:
   - ../Daml.Finance.Util/.daml/dist/daml-finance-util-0.1.2.dar
   - ../Daml.Finance.Lifecycle/.daml/dist/daml-finance-lifecycle-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-interface-holding
 source: daml
 version: 0.1.2
@@ -12,4 +12,4 @@ data-dependencies:
   - ../Daml.Finance.Interface.Types/.daml/dist/daml-finance-interface-types-0.1.2.dar
   - ../Daml.Finance.Interface.Util/.daml/dist/daml-finance-interface-util-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-interface-instrument-base
 source: daml
 version: 0.1.2
@@ -13,4 +13,4 @@ data-dependencies:
   - ../Daml.Finance.Interface.Util/.daml/dist/daml-finance-interface-util-0.1.2.dar
   - ../Daml.Finance.Interface.Holding/.daml/dist/daml-finance-interface-holding-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-interface-instrument-bond
 source: daml
 version: 0.1.2
@@ -13,4 +13,4 @@ data-dependencies:
   - ../Daml.Finance.Interface.Util/.daml/dist/daml-finance-interface-util-0.1.2.dar
   - ../Daml.Finance.Interface.Instrument.Base/.daml/dist/daml-finance-interface-instrument-base-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-interface-instrument-equity
 source: daml
 version: 0.1.2
@@ -14,4 +14,4 @@ data-dependencies:
   - ../Daml.Finance.Interface.Instrument.Base/.daml/dist/daml-finance-interface-instrument-base-0.1.2.dar
   - ../Daml.Finance.Interface.Lifecycle/.daml/dist/daml-finance-interface-lifecycle-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-interface-instrument-generic
 source: daml
 version: 0.1.2
@@ -15,4 +15,4 @@ data-dependencies:
   - ../Daml.Finance.Interface.Instrument.Base/.daml/dist/daml-finance-interface-instrument-base-0.1.2.dar
   - ../Daml.Finance.Interface.Lifecycle/.daml/dist/daml-finance-interface-lifecycle-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-interface-lifecycle
 source: daml
 version: 0.1.2
@@ -14,4 +14,4 @@ data-dependencies:
   - ../Daml.Finance.Interface.Instrument.Base/.daml/dist/daml-finance-interface-instrument-base-0.1.2.dar
   - ../Daml.Finance.Interface.Settlement/.daml/dist/daml-finance-interface-settlement-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-interface-settlement
 source: daml
 version: 0.1.2
@@ -14,4 +14,4 @@ data-dependencies:
   - ../Daml.Finance.Interface.Holding/.daml/dist/daml-finance-interface-holding-0.1.2.dar
   - ../Daml.Finance.Interface.Instrument.Base/.daml/dist/daml-finance-interface-instrument-base-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/main/daml/Daml.Finance.Interface.Types/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-interface-types
 source: daml
 version: 0.1.2
@@ -9,4 +9,4 @@ dependencies:
   - daml-prim
   - daml-stdlib
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-interface-util
 source: daml
 version: 0.1.2
@@ -11,4 +11,4 @@ dependencies:
 data-dependencies:
   - ../Daml.Finance.Interface.Types/.daml/dist/daml-finance-interface-types-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-lifecycle
 source: daml
 version: 0.1.2
@@ -16,4 +16,4 @@ data-dependencies:
   - ../Daml.Finance.Interface.Settlement/.daml/dist/daml-finance-interface-settlement-0.1.2.dar
   - ../Daml.Finance.Interface.Lifecycle/.daml/dist/daml-finance-interface-lifecycle-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/main/daml/Daml.Finance.RefData/daml.yaml
+++ b/package/main/daml/Daml.Finance.RefData/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-refdata
 source: daml
 version: 0.1.2
@@ -13,4 +13,4 @@ data-dependencies:
   - ../Daml.Finance.Interface.Util/.daml/dist/daml-finance-interface-util-0.1.2.dar
   - ../Daml.Finance.Interface.Lifecycle/.daml/dist/daml-finance-interface-lifecycle-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/main/daml/Daml.Finance.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Settlement/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-settlement
 source: daml
 version: 0.1.2
@@ -15,4 +15,4 @@ data-dependencies:
   - ../Daml.Finance.Interface.Settlement/.daml/dist/daml-finance-interface-settlement-0.1.2.dar
   - ../Daml.Finance.Util/.daml/dist/daml-finance-util-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/main/daml/Daml.Finance.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-util
 source: daml
 version: 0.1.2
@@ -11,4 +11,4 @@ dependencies:
 data-dependencies:
   - ../Daml.Finance.Interface.Types/.daml/dist/daml-finance-interface-types-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-holding-test
 source: daml
 version: 0.1.2
@@ -16,4 +16,4 @@ data-dependencies:
   - ../../../main/daml/Daml.Finance.Holding/.daml/dist/daml-finance-holding-0.1.2.dar
   - ../Daml.Finance.Test.Util/.daml/dist/daml-finance-test-util-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-instrument-bond-test
 source: daml
 version: 0.1.2
@@ -24,4 +24,4 @@ data-dependencies:
   - ../../../main/daml/Daml.Finance.Instrument.Bond/.daml/dist/daml-finance-instrument-bond-0.1.2.dar
   - ../Daml.Finance.Test.Util/.daml/dist/daml-finance-test-util-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-instrument-equity-test
 source: daml
 version: 0.1.2
@@ -23,4 +23,4 @@ data-dependencies:
   - ../../../main/daml/Daml.Finance.Instrument.Equity/.daml/dist/daml-finance-instrument-equity-0.1.2.dar
   - ../Daml.Finance.Test.Util/.daml/dist/daml-finance-test-util-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-instrument-generic-test
 source: daml
 version: 0.1.2
@@ -25,4 +25,4 @@ data-dependencies:
   - ../../../main/daml/Daml.Finance.Instrument.Generic/.daml/dist/daml-finance-instrument-generic-0.1.2.dar
   - ../Daml.Finance.Test.Util/.daml/dist/daml-finance-test-util-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/test/daml/Daml.Finance.RefData.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.RefData.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-refdata-test
 source: daml
 version: 0.1.2
@@ -15,4 +15,4 @@ data-dependencies:
   - ../../../main/daml/Daml.Finance.RefData/.daml/dist/daml-finance-refdata-0.1.2.dar
   - ../Daml.Finance.Test.Util/.daml/dist/daml-finance-test-util-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-settlement-test
 source: daml
 version: 0.1.2
@@ -19,4 +19,4 @@ data-dependencies:
   - ../../../main/daml/Daml.Finance.Settlement/.daml/dist/daml-finance-settlement-0.1.2.dar
   - ../Daml.Finance.Test.Util/.daml/dist/daml-finance-test-util-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/test/daml/Daml.Finance.Test.Util/daml.yaml
+++ b/package/test/daml/Daml.Finance.Test.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-test-util
 source: daml
 version: 0.1.2
@@ -17,4 +17,4 @@ data-dependencies:
   - ../../../main/daml/Daml.Finance.Holding/.daml/dist/daml-finance-holding-0.1.2.dar
   - ../../../main/daml/Daml.Finance.Instrument.Base/.daml/dist/daml-finance-instrument-base-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/package/test/daml/Daml.Finance.Util.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Util.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.4.0-snapshot.20220823.10466.0.1ab16059
+sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-util-test
 source: daml
 version: 0.1.2
@@ -13,4 +13,4 @@ data-dependencies:
   - ../../../main/daml/Daml.Finance.Interface.Types/.daml/dist/daml-finance-interface-types-0.1.2.dar
   - ../../../main/daml/Daml.Finance.Util/.daml/dist/daml-finance-util-0.1.2.dar
 build-options:
-  - --target=1.dev
+  - --target=1.15

--- a/src/main/daml/Daml/Finance/Holding/Fungible.daml
+++ b/src/main/daml/Daml/Finance/Holding/Fungible.daml
@@ -84,7 +84,7 @@ template Fungible
       transfer Transferable.Transfer{newOwnerAccount} = do
         -- Account sanity checks
         newAccount <- fetchInterfaceByKey @Account.R newOwnerAccount
-        let v = _view newAccount
+        let v = view newAccount
         v.owner === newOwnerAccount.owner
         v.custodian === account.custodian
         -- Create new holding via Credit

--- a/src/main/daml/Daml/Finance/Holding/Fungible.daml
+++ b/src/main/daml/Daml/Finance/Holding/Fungible.daml
@@ -80,7 +80,7 @@ template Fungible
 
     interface instance Transferable.I for Fungible where
       asLockable = toInterface @Lockable.I this
-      view = Transferable.View ()
+      view = Transferable.View {}
       transfer Transferable.Transfer{newOwnerAccount} = do
         -- Account sanity checks
         newAccount <- fetchInterfaceByKey @Account.R newOwnerAccount

--- a/src/main/daml/Daml/Finance/Holding/NonFungible.daml
+++ b/src/main/daml/Daml/Finance/Holding/NonFungible.daml
@@ -79,7 +79,7 @@ template NonFungible
 
     interface instance Transferable.I for NonFungible where
       asLockable = toInterface @Lockable.I this
-      view = Transferable.View ()
+      view = Transferable.View {}
       transfer Transferable.Transfer{newOwnerAccount} = do
         -- Account sanity checks
         newAccount <- fetchInterfaceByKey @Account.R newOwnerAccount

--- a/src/main/daml/Daml/Finance/Holding/NonFungible.daml
+++ b/src/main/daml/Daml/Finance/Holding/NonFungible.daml
@@ -83,7 +83,7 @@ template NonFungible
       transfer Transferable.Transfer{newOwnerAccount} = do
         -- Account sanity checks
         newAccount <- fetchInterfaceByKey @Account.R newOwnerAccount
-        let v = _view newAccount
+        let v = view newAccount
         v.owner === newOwnerAccount.owner
         v.custodian === account.custodian
         -- Create new holding via Credit

--- a/src/main/daml/Daml/Finance/Instrument/Bond/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/Util.daml
@@ -111,7 +111,7 @@ mapClaimToUTCTime =
 -- | Rule to process a clock update event.
 processClockUpdate : IsBond t => Party -> ContractId Event.I -> ContractId Clock.I -> ContractId Lifecycle.I -> t -> [ContractId Observable.I] -> Update (ContractId Lifecycle.I, [ContractId Effect.I])
 processClockUpdate settler eventCid _ self instrument observableCids = do
-  v <- _view <$> fetch eventCid
+  v <- view <$> fetch eventCid
   let
     claimInstrument = toInterface @HasClaims.I instrument
     acquisitionTime = HasClaims.getAcquisitionTime claimInstrument
@@ -146,6 +146,6 @@ processClockUpdate settler eventCid _ self instrument observableCids = do
       consumed
       produced
       settlementDate
-      observers = (.observers) . _view $ toInterface @Disclosure.I instrument
+      observers = (.observers) . view $ toInterface @Disclosure.I instrument
     pure (toInterfaceContractId newInstrumentCid, [effectCid])
   -- BOND_PROCESS_CLOCK_UPDATE_LIFECYCLE_END

--- a/src/main/daml/Daml/Finance/Instrument/Equity/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Equity/Instrument.daml
@@ -46,7 +46,7 @@ template Instrument
 
     interface instance Equity.I for Instrument where
       asInstrument = toInterface @Instrument.I this
-      view = Equity.View ()
+      view = Equity.View {}
       declareDividend Equity.DeclareDividend{id; description; effectiveDate; newInstrument; perUnitDistribution} = do
         toInterfaceContractId <$> create Distribution.Event with provider = issuer; id; description; effectiveDate; targetInstrument = instrumentKey; newInstrument; perUnitDistribution; observers
       declareStockSplit Equity.DeclareStockSplit{id; description; adjustmentFactor; newInstrument; effectiveDate} =

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Instrument.daml
@@ -100,7 +100,7 @@ template Instrument
         else do
           let
             settlementDate = toDateUTC electionTime
-            currentKey = Instrument.getKey this
+            currentKey = Instrument.getKey $ toInterface this
             newKey = currentKey with version = sha256 $ show remaining
             [claim] = fmap (.claim) remaining
           existingRefCidOpt <- lookupByKey @Instrument.R newKey
@@ -142,7 +142,7 @@ processClockUpdate settler eventCid _ self instrument observableCids = do
   else do
     let
       settlementDate = toDateUTC v.eventTime
-      currentKey = Instrument.getKey instrument
+      currentKey = Instrument.getKey $ toInterface instrument
       [claim] = fmap (.claim) remaining
       newKey = currentKey with version = sha256 $ show remaining
     existingRefCidOpt <- lookupByKey @Instrument.R newKey

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Instrument.daml
@@ -90,7 +90,7 @@ template Instrument
         election <- fetch electionCid
         instrumentClaim <- HasClaims.getClaims $ toInterface @HasClaims.I this
         let
-          v = _view election
+          v = view election
           electionTime = Election.getElectionTime election
           election = electionEvent electionTime v.electorIsOwner v.claim
         verify (currentTime == electionTime) $ "Election time " <> show electionTime <> " is different than Current time " <> show currentTime
@@ -134,7 +134,7 @@ template Instrument
 -- | Rule to process a clock update event.
 processClockUpdate : Party -> ContractId Event.I -> ContractId Clock.I -> ContractId Lifecycle.I -> Instrument -> [ContractId Observable.I] -> Update (ContractId Lifecycle.I, [ContractId Effect.I])
 processClockUpdate settler eventCid _ self instrument observableCids = do
-  v <- _view <$> fetch eventCid
+  v <- view <$> fetch eventCid
   claims <- HasClaims.getClaims $ toInterface @HasClaims.I instrument
   (remaining, pending) <- lifecycle observableCids (toInterface instrument) [timeEvent v.eventTime]
   if remaining == claims && null pending then

--- a/src/main/daml/Daml/Finance/Interface/Holding/Account.daml
+++ b/src/main/daml/Daml/Finance/Interface/Holding/Account.daml
@@ -76,14 +76,14 @@ interface Account where
         -- ^ The party fetching the view.
     controller viewer
     do
-      pure $ _view this
+      pure $ view this
 
   nonconsuming choice Credit : ContractId Base.I
     -- ^ Creates a new `Holding` in the corresponding `Account`.
     with
       quantity : Quantity InstrumentKey Decimal
         -- ^ The target `Instrument` and corresponding amount.
-    controller (_view this).custodian, (_view this).owner
+    controller (view this).custodian, (view this).owner
     do
       credit this arg
 
@@ -92,7 +92,7 @@ interface Account where
     with
       holdingCid : ContractId Base.I
         -- ^ The `Holding`'s contract id.
-    controller (_view this).custodian, (_view this).owner
+    controller (view this).custodian, (view this).owner
     do
       debit this arg
 

--- a/src/main/daml/Daml/Finance/Interface/Holding/Base.daml
+++ b/src/main/daml/Daml/Finance/Interface/Holding/Base.daml
@@ -37,7 +37,7 @@ interface Base where
        -- ^ The party retrieving the view.
     controller viewer
     do
-      pure $ _view this
+      pure $ view this
 
 -- | Type constraint for requiring templates to implement `Holding` along with `Disclosure`.
 type Implementation t = (HasToInterface t I, Disclosure.Implementation t)

--- a/src/main/daml/Daml/Finance/Interface/Holding/Fungible.daml
+++ b/src/main/daml/Daml/Finance/Interface/Holding/Fungible.daml
@@ -53,7 +53,7 @@ interface Fungible where
         -- ^ The party fetching the view.
     controller actor
     do
-      pure $ _view this
+      pure $ view this
 
   choice Split : SplitResult
     -- ^ Split a fungible contract into multiple contracts by amount.
@@ -61,7 +61,7 @@ interface Fungible where
       amounts : [Decimal]
         -- ^ The quantities to split the fungible asset by, creating a new contract per amount.
         -- The sum of the quantities is required to be smaller or equal to the amount on the fungible contract.
-    controller (_view this).modifiers, getLocker this
+    controller (view this).modifiers, getLocker this
     do
       verifySplit amounts $ getAmount this
       splitResult <- split this arg
@@ -74,7 +74,7 @@ interface Fungible where
     with
       fungibleCids : [ContractId Fungible]
         -- ^ The fungible contracts to merge which will get consumed.
-    controller (_view this).modifiers, getLocker this
+    controller (view this).modifiers, getLocker this
     do
       oldFungibles <- mapA fetch $ fmap (toInterfaceContractId @I) fungibleCids
       newFungibleCid <- merge this arg

--- a/src/main/daml/Daml/Finance/Interface/Holding/Lockable.daml
+++ b/src/main/daml/Daml/Finance/Interface/Holding/Lockable.daml
@@ -68,7 +68,7 @@ interface Lockable where
         -- ^ The party retrieving the view.
     controller viewer
     do
-      pure $ _view this
+      pure $ view this
 
   choice Acquire : ContractId Lockable
     -- ^ Lock a contract.
@@ -79,12 +79,12 @@ interface Lockable where
         -- ^ Reason for acquiring a lock.
       lockType : LockType
         -- ^ Type of lock to acquire
-    controller (_view $ asHolding this).account.owner, newLocker
+    controller (view $ asHolding this).account.owner, newLocker
     do
       validateRequest this arg
       lockableCid <- acquire this arg
       lockable <- fetch lockableCid
-      let lock = fromSomeNote "Contract has not been locked." (_view lockable).lock
+      let lock = fromSomeNote "Contract has not been locked." (view lockable).lock
       lock.locker === newLocker
       fromList (signatory lockable) `intersection` newLocker === newLocker
       pure lockableCid
@@ -93,7 +93,7 @@ interface Lockable where
     -- ^ Unlock a locked contract.
     with
       context : Text
-    controller case (_view this).lock of None -> mempty; Some lock -> lock.locker
+    controller case (view this).lock of None -> mempty; Some lock -> lock.locker
     do
       release this arg
 
@@ -101,7 +101,7 @@ interface Lockable where
 -- Validate a new acquire request.
 validateRequest : Lockable -> Acquire -> Update (Optional Lock)
 validateRequest this (Acquire with newLocker; context; lockType) = do
-  let lock = (_view this).lock
+  let lock = (view this).lock
   whenSome lock \lock -> do
     lock.locker === newLocker
     lock.lockType === lockType

--- a/src/main/daml/Daml/Finance/Interface/Holding/Transferable.daml
+++ b/src/main/daml/Daml/Finance/Interface/Holding/Transferable.daml
@@ -34,7 +34,7 @@ interface Transferable where
         -- ^ The party retrieving the view.
     controller viewer
     do
-      pure $ _view this
+      pure $ view this
 
   choice Transfer : ContractId Transferable
     -- ^ Transfer a contract to a new owner

--- a/src/main/daml/Daml/Finance/Interface/Holding/Transferable.daml
+++ b/src/main/daml/Daml/Finance/Interface/Holding/Transferable.daml
@@ -16,11 +16,11 @@ type I = Transferable
 type V = View
 
 -- | View for `Transferable`.
-data View = View () deriving (Eq, Ord, Show)
+data View = View {} deriving (Eq, Ord, Show)
 
 -- | An interface respresenting a contract where ownership can be transfered to other parties
 interface Transferable where
-  viewtype V
+  viewtype View
 
   asLockable : Lockable.I
     -- ^ Conversion to `Lockable` interface.

--- a/src/main/daml/Daml/Finance/Interface/Holding/Util.daml
+++ b/src/main/daml/Daml/Finance/Interface/Holding/Util.daml
@@ -23,24 +23,24 @@ fetchAccount holding = fetchInterfaceByKey @Account.R $ getAccount (toInterface 
 
 -- | Get the  key of a holding.
 getInstrument : (HasToInterface t Base.I) => t -> InstrumentKey
-getInstrument holding = (_view $ toInterface @Base.I holding).instrument
+getInstrument holding = (view $ toInterface @Base.I holding).instrument
 
 -- | Get the account key of a holding.
 getAccount : (HasToInterface t Base.I) => t -> AccountKey
-getAccount holding = (_view $ toInterface @Base.I holding).account
+getAccount holding = (view $ toInterface @Base.I holding).account
 
 -- | Get the custodian of a holding.
 getCustodian : (HasToInterface t Base.I) => t -> Party
-getCustodian holding = (_view $ toInterface @Base.I holding).account.custodian
+getCustodian holding = (view $ toInterface @Base.I holding).account.custodian
 
 -- | Get the owner of a holding.
 getOwner : (HasToInterface t Base.I) => t -> Party
-getOwner holding = (_view $ toInterface @Base.I holding).account.owner
+getOwner holding = (view $ toInterface @Base.I holding).account.owner
 
 -- | Get the amount of a holding.
 getAmount : (HasToInterface t Base.I) => t -> Decimal
-getAmount holding = (_view $ toInterface @Base.I holding).amount
+getAmount holding = (view $ toInterface @Base.I holding).amount
 
 -- | Get the lockers of a lockable holding.
 getLocker : (HasToInterface t Lockable.I) => t -> Parties
-getLocker lockable = case (_view $ toInterface @Lockable.I lockable).lock of None -> mempty; Some lock -> lock.locker
+getLocker lockable = case (view $ toInterface @Lockable.I lockable).lock of None -> mempty; Some lock -> lock.locker

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Base/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Base/Instrument.daml
@@ -69,7 +69,7 @@ interface Instrument where
         -- ^ The party retrieving the view.
     controller viewer
     do
-      pure $ _view this
+      pure $ view this
 
 -- | Type constraint for requiring templates to implement `Instrument` along with `Disclosure`.
 type Implementation t = (HasToInterface t I, Disclosure.Implementation t)

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Equity/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Equity/Instrument.daml
@@ -16,7 +16,7 @@ type I = Instrument
 type V = View
 
 -- | View for `Instrument`.
-data View = View () deriving (Eq, Ord, Show)
+data View = View {} deriving (Eq, Ord, Show)
 
 -- | An interface for a generic equity instrument.
 interface Instrument where

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Equity/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Equity/Instrument.daml
@@ -38,7 +38,7 @@ interface Instrument where
         -- ^ The party retrieving the view.
     controller viewer
     do
-      pure $ _view this
+      pure $ view this
 
   nonconsuming choice DeclareDividend : ContractId Event.I
     -- ^ Declare a dividend distribution to shareholders.
@@ -53,7 +53,7 @@ interface Instrument where
         -- ^ Instrument held after the dividend distribution (ie. "ex-dividend" stock).
       perUnitDistribution : [BaseInstrument.Q]
         -- ^ Distributed quantities per unit held.
-    controller (_view $ asInstrument this).issuer
+    controller (view $ asInstrument this).issuer
     do
       declareDividend this arg
 
@@ -72,7 +72,7 @@ interface Instrument where
         -- ^ Adjustment factor for the stock split.
         -- A factor of between 0 and 1 represents a classic stock split (eg. 2-for-1 or two new for one old).
         -- A factor above 1 represents a reverse stock split (eg. 1-for-2 or one new for two old).
-    controller (_view $ asInstrument this).issuer
+    controller (view $ asInstrument this).issuer
     do
       verify (adjustmentFactor > 0.0) "Factor cannot be equal to or below zero."
       declareStockSplit this arg
@@ -88,7 +88,7 @@ interface Instrument where
         -- ^ Date the replacement is to be executed.
       perUnitReplacement : [BaseInstrument.Q]
         -- ^ Payout offered to shareholders per held share.
-    controller (_view $ asInstrument this).issuer
+    controller (view $ asInstrument this).issuer
     do
       declareReplacement this arg
 

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Generic/Election.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Generic/Election.daml
@@ -58,7 +58,7 @@ interface Election where
         -- ^ The party retrieving the view.
     controller viewer
     do
-      pure $ _view this
+      pure $ view this
 
   nonconsuming choice Apply : (ContractId Lifecycle.I, [ContractId Effect.I])
     -- ^ applies the election to the instrument, returning the new instrument as well
@@ -70,9 +70,9 @@ interface Election where
         -- ^ set of observables
       settler : Party
         -- ^ parties responsible for settling effects
-    controller (_view this).provider
+    controller (view this).provider
     do
-      let v = _view this
+      let v = view this
       (newInstrumentCid, effects) <- Instrument.exerciseInterfaceByKey @Exercisable v.instrument v.provider ApplyElection
         with
           clockCid
@@ -115,7 +115,7 @@ interface Exercisable where
         -- ^ The party retrieving the view.
     controller viewer
     do
-      pure $ _view this
+      pure $ view this
 
   nonconsuming choice ApplyElection : (ContractId Lifecycle.I, [ContractId Effect.I])
     -- ^ Applies an election to the instrument.
@@ -128,7 +128,7 @@ interface Exercisable where
         -- ^ Set of observables.
       settler : Party
         -- ^ The party settling the transaction.
-    controller (_view this).lifecycler
+    controller (view this).lifecycler
     do
       (instrument, effects) <- applyElection this arg self
       pure (coerceContractId instrument, effects)

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Generic/HasClaims.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Generic/HasClaims.daml
@@ -42,7 +42,7 @@ interface HasClaims where
         -- ^ The party retrieving the view.
     controller viewer
     do
-      pure $ _view this
+      pure $ view this
 
 -- | Type constraint for requiring templates to implement `HasClaims`.
 type Implementation t = HasToInterface t I
@@ -59,4 +59,4 @@ getClaim instrument = do
 
 -- | Retrieves the claim's acquisition time.
 getAcquisitionTime : HasClaims -> Time
-getAcquisitionTime = (.acquisitionTime) . _view
+getAcquisitionTime = (.acquisitionTime) . view

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Generic/Util/Claims/Lifecycle.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Generic/Util/Claims/Lifecycle.daml
@@ -92,7 +92,7 @@ collectObservables : [ContractId Observable.I] -> Update (Observable -> Time -> 
 collectObservables observableCids = do
   os <- M.fromList <$> forA observableCids \cid -> do
     observation <- fetch cid
-    pure ((_view observation).obsKey, observation)
+    pure ((view observation).obsKey, observation)
   pure \key t -> case M.lookup key os of
     Some o -> Observable.observe o t
     None -> do abort $ "Missing observable" <> show key <> " at time " <> show t

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Clock.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Clock.daml
@@ -29,7 +29,7 @@ interface Clock where
         -- ^ The party retrieving the view.
     controller viewer
     do
-      pure $ _view this
+      pure $ view this
 
 -- | Type constraint for requiring interface implementations for `Clock`.
 type Implementation t = HasToInterface t I
@@ -37,7 +37,7 @@ class (Implementation t) => HasImplementation t
 instance HasImplementation I
 
 instance HasUTCTimeConversion Clock where
-  toUTCTime c = (_view c).clockTime
+  toUTCTime c = (view c).clockTime
 
 instance Ord Clock where
   x <= y = toUTCTime x <= toUTCTime y

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Effect.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Effect.daml
@@ -44,7 +44,7 @@ interface Effect where
         -- ^ The party retrieving the view.
     controller viewer
     do
-      pure $ _view this
+      pure $ view this
 
   nonconsuming choice Calculate : CalculationResult
     -- ^ Given a holding, it calculates the instrument quantities to settle.
@@ -63,7 +63,7 @@ interface Effect where
     with
       newProvider : Party
         -- ^ The new provider.
-    controller (_view this).provider, newProvider
+    controller (view this).provider, newProvider
     do
       setProvider this arg
 

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Event.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Event.daml
@@ -33,7 +33,7 @@ interface Event where
         -- ^ The party retrieving the view.
     controller viewer
     do
-      pure $ _view this
+      pure $ view this
 
 -- | Type constraint for requiring templates to implement `Event`.
 type Implementation t = HasToInterface t I
@@ -45,4 +45,4 @@ instance Ord Event where
 
 -- | Given an event, retrieves the event time.
 getEventTime : Event -> Time
-getEventTime e = (_view e).eventTime
+getEventTime e = (view e).eventTime

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Observable.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Observable.daml
@@ -34,7 +34,7 @@ interface Observable where
         -- ^ The party retrieving the view.
     controller viewer
     do
-      pure $ _view this
+      pure $ view this
 
   nonconsuming choice Observe : Decimal
     -- ^ Observe the `Observable`.

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Rule/Claim.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Rule/Claim.daml
@@ -15,7 +15,7 @@ type I = Claim
 type V = View
 
 -- | View for `Settlement`.
-data View = View () deriving (Eq, Ord, Show)
+data View = View {} deriving (Eq, Ord, Show)
 
 -- | Data type wrapping the results of `Claim`ing an `Effect`.
 data ClaimResult = ClaimResult

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Rule/Claim.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Rule/Claim.daml
@@ -42,7 +42,7 @@ interface Claim where
         -- ^ The party retrieving the view.
     controller viewer
     do
-      pure $ _view this
+      pure $ view this
 
   nonconsuming choice ClaimEffect : ClaimResult
     -- ^ Claim an effect and generate corresponding settlement instructions.

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Rule/Lifecycle.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Rule/Lifecycle.daml
@@ -35,7 +35,7 @@ interface Lifecycle where
         -- ^ The party retrieving the view.
     controller viewer
     do
-      pure $ _view this
+      pure $ view this
 
   nonconsuming choice Evolve : (ContractId Lifecycle, [ContractId Effect.I])
     -- ^ Process an event. It returns a tuple of the lifecycled instrument (or the original instrument when the former does not exist) and the effects.
@@ -50,7 +50,7 @@ interface Lifecycle where
         -- ^ Current time. This is also an observable, but not a strictly 'Decimal' one.
       observableCids : [ContractId Observable]
         -- ^ Set of numerical time-dependent observables.
-    controller (_view this).lifecycler
+    controller (view this).lifecycler
     do
       evolve this arg self
 

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Batch.daml
@@ -40,11 +40,11 @@ interface Batch where
         -- ^ The party retrieving the view.
     controller viewer
     do
-      pure $ _view this
+      pure $ view this
 
   choice Settle : [ContractId Transferable.I]
     -- ^ Execute settlement.
-    controller (_view this).settler
+    controller (view this).settler
     do
       settle this
 

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Factory.daml
@@ -37,7 +37,7 @@ interface Factory where
         -- ^ The party retrieving the view.
     controller viewer
     do
-      pure $ _view this
+      pure $ view this
 
   nonconsuming choice Instruct : (ContractId Batch.I, [ContractId Instruction.I])
     --  ^ Generate settlement instructions, and a batch for settling them.

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Instruction.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Instruction.daml
@@ -45,14 +45,14 @@ interface Instruction where
         -- ^ The party retrieving the view.
     controller viewer
     do
-      pure $ _view this
+      pure $ view this
 
   choice Allocate : ContractId Instruction
     -- ^ Allocate an asset to an instruction.
     with
       allocation : Allocation
         -- ^ Allocation of an instruction.
-    controller (_view this).step.sender
+    controller (view this).step.sender
     do
       allocate this arg
 
@@ -61,13 +61,13 @@ interface Instruction where
     with
       approval : Approval
         -- ^ Approval of an instruction.
-    controller (_view this).step.receiver
+    controller (view this).step.receiver
     do
       approve this arg
 
   choice Execute : (Optional (ContractId Transferable.I))
     -- ^ Execute the instruction.
-    controller (_view this).settler
+    controller (view this).settler
     do
       execute this
 

--- a/src/main/daml/Daml/Finance/Interface/Util/Disclosure.daml
+++ b/src/main/daml/Daml/Finance/Interface/Util/Disclosure.daml
@@ -42,7 +42,7 @@ interface Disclosure where
         -- ^ The party retrieving the view.
     controller viewer
     do
-      pure $ _view this
+      pure $ view this
 
   choice SetObservers : ContractId Disclosure
     -- ^ Set the observers for a contract.
@@ -53,7 +53,7 @@ interface Disclosure where
         -- ^ Observers to set for this contract. This overrides the existing observers.
     controller disclosers
     do
-      assertMsg "controller must be authorized to SetObservers" $ disclosers `member` (_view this).disclosureControllers
+      assertMsg "controller must be authorized to SetObservers" $ disclosers `member` (view this).disclosureControllers
       setObservers this arg
 
   choice AddObservers : ContractId Disclosure
@@ -65,11 +65,11 @@ interface Disclosure where
         -- ^ Observer context to add to a contract.
     controller disclosers
     do
-      assertMsg "controller must be authorized to AddObservers" $ disclosers `member` (_view this).disclosureControllers
+      assertMsg "controller must be authorized to AddObservers" $ disclosers `member` (view this).disclosureControllers
       let
         elem = fromOptional empty (M.lookup observersToAdd._1 (view @Disclosure this).observers)
         value = insert observersToAdd._2 elem
-        newObservers = M.insert observersToAdd._1 value ((_view this).observers)
+        newObservers = M.insert observersToAdd._1 value ((view this).observers)
       setObservers this (SetObservers with disclosers; newObservers)
 
   nonconsuming choice RemoveObservers : Optional (ContractId Disclosure)
@@ -80,7 +80,7 @@ interface Disclosure where
         -- ^ Observer context to remove.
     controller observersToRemove._2
     do
-      let observers = (_view this).observers
+      let observers = (view this).observers
       fromOptional None <$> T.mapA
         (\elem -> do
           let

--- a/src/main/daml/Daml/Finance/Lifecycle/Rule/Claim.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Rule/Claim.daml
@@ -37,7 +37,7 @@ template Rule
     signatory custodian, owner
 
     interface instance Claim.I for Rule where
-      view = Claim.View()
+      view = Claim.View {}
       claimEffect Claim.ClaimEffect{claimer; holdingCids; effectCid} = do
         assertMsg "Effect can only be claimed by authorized parties." $ claimer `member` claimers
         effectView <- exercise effectCid Effect.GetView with viewer = claimer

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -7,14 +7,14 @@ module Daml.Finance.Settlement.Batch
   ) where
 
 import DA.Foldable (forA_)
-import DA.Optional (fromSome, fromSomeNote)
+import DA.Optional (fromSomeNote)
 import DA.Set (fromList, singleton, size)
 import DA.List (groupOn)
 import Daml.Finance.Interface.Holding.Account qualified as Account (exerciseInterfaceByKey)
 import Daml.Finance.Interface.Holding.Base qualified as Base (I)
 import Daml.Finance.Interface.Holding.Util (fetchAccount, getAccount)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (HasImplementation, I, View(..))
-import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Execute(..))
+import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Execute(..), I)
 import Daml.Finance.Interface.Settlement.Types (Step(..))
 import Daml.Finance.Interface.Types.Common (Id(..), Parties)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, RemoveObservers(..))
@@ -53,7 +53,7 @@ template Batch
             (instructionCid, instruction) <- fetchByKey @Instruction (requestors, instructionId)
             let
               receiverAccount = fromSomeNote "Receiving account not set" instruction.account
-              senderTransferableCid = fst $ fromSomeNote "Holding not allocated" instruction.allocation
+              senderTransferableCid = fromSomeNote "Holding not allocated" instruction.allocation
               holdingCid : ContractId Base.I = coerceContractId senderTransferableCid
             holding <- fetch holdingCid
             fetchAccount holding
@@ -64,8 +64,9 @@ template Batch
             -- NOTE: ideally we should exerciseByKey (but currently doesn't work for interface choices).
             -- (as a workaround we could proxy the choice in the same contract)
             (instructionCid, instruction) <- fetchByKey @Instruction (requestors, instructionId)
-            transferableCid <- exercise instructionCid Instruction.Execute
-            pure (transferableCid, (snd $ fromSome instruction.allocation, instruction.step.quantity.unit))
+            transferableCid <- exercise (toInterfaceContractId @Instruction.I instructionCid) Instruction.Execute
+            transferable <- fetch transferableCid
+            pure (transferableCid, (interfaceTypeRep transferable, instruction.step.quantity.unit))
         l <- mapA settleInstruction instructionIds
         -- check consistency
         let

--- a/src/main/daml/Daml/Finance/Settlement/Instruction.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Instruction.daml
@@ -34,7 +34,7 @@ template Instruction
       -- ^ Instruction identifier.
     step : Step
       -- ^ Settlement step.
-    allocation : Optional (ContractId Transferable.I, Text)
+    allocation : Optional (ContractId Transferable.I)
       -- ^ Allocated holding and its template type rep text representation.
     account : Optional AccountKey
       -- ^ Receiving account.
@@ -61,8 +61,8 @@ template Instruction
         accountCid <- Account.exerciseInterfaceByKey @Disclosure.I (getAccount transferable) step.sender Disclosure.AddObservers with disclosers = singleton step.sender; observersToAdd = (show id, singleton settler)
         getAmount transferable === step.quantity.amount
         getInstrument transferable === step.quantity.unit
-        toInterfaceContractId <$> create this with allocation = Some (transferableCid, templateTypeRepToText $ interfaceTypeRep transferable); signed = insert step.sender signed
+        toInterfaceContractId <$> create this with allocation = Some transferableCid; signed = insert step.sender signed
       approve Instruction.Approve{receiverAccount} = do
         Account.exerciseInterfaceByKey @Disclosure.I receiverAccount step.receiver Disclosure.AddObservers with disclosers = singleton step.receiver; observersToAdd = (show id, singleton settler)
         toInterfaceContractId <$> create this with signed = insert step.receiver signed; account = Some receiverAccount
-      execute = exercise (fst $ fromSome allocation) Transferable.Transfer with newOwnerAccount = fromSome account
+      execute = exercise (fromSome allocation) Transferable.Transfer with newOwnerAccount = fromSome account

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
@@ -16,7 +16,7 @@ import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument
 import Daml.Finance.Interface.Instrument.Generic.Types (Deliverable)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (I)
 import Daml.Finance.Interface.Lifecycle.Observable qualified as Observable (I)
-import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..))
+import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), I)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Evolve(..))
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
@@ -137,7 +137,7 @@ lifecycleAndVerifyCouponEffectsAndSettlement readAs today bondInstrument settler
 
   -- CLAIM_EFFECT_BOND_BEGIN
   -- Claim effect
-  lifecycleClaimRuleCid <- submitMulti [custodian, investor] [] do
+  lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [custodian, investor] [] do
     createCmd Claim.Rule
       with
         custodian
@@ -185,7 +185,7 @@ lifecycleAndVerifyRedemptionEffectsAndSettlement readAs today bondInstrument set
   settlementFactoryCid <- submitMulti [investor] [] do createCmd Factory with provider = investor; observers = empty
 
   -- Claim effect
-  lifecycleClaimRuleCid <- submitMulti [custodian, investor] [] do
+  lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [custodian, investor] [] do
     createCmd Claim.Rule
       with
         custodian

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/ZeroCoupon.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/ZeroCoupon.daml
@@ -11,7 +11,7 @@ import Daml.Finance.Instrument.Bond.Test.Util (lifecycleBond, originateZeroCoupo
 import Daml.Finance.Instrument.Bond.ZeroCoupon qualified as ZeroCoupon (Instrument)
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (K, getKey)
-import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..))
+import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), I)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Types.Common (AccountKey, Parties)
@@ -28,13 +28,13 @@ lifecycleAndVerifyRedemptionEffectsAndSettlement readAs today bondInstrument set
   (bondLifecycleCid2, [effectCid]) <- lifecycleBond readAs today bondInstrument settler issuer []
 
   Some newBondInstrument <- queryContractId @ZeroCoupon.Instrument issuer $ coerceContractId bondLifecycleCid2
-  let newBondInstrumentKey = Instrument.getKey newBondInstrument
+  let newBondInstrumentKey = Instrument.getKey $ toInterface newBondInstrument
 
   -- Create settlement factory
   settlementFactoryCid <- submitMulti [investor] [] do createCmd Factory with provider = investor; observers = empty
 
   -- Claim effect
-  lifecycleClaimRuleCid <- submitMulti [custodian, investor] [] do
+  lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [custodian, investor] [] do
     createCmd Rule
       with
         custodian

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
@@ -10,8 +10,8 @@ import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Instrument.Equity.Test.Util (originateEquity)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
 import Daml.Finance.Interface.Instrument.Equity.Instrument qualified as Equity (DeclareDividend(..), I)
-import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..))
-import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (Evolve(..))
+import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), I)
+import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (Evolve(..), I)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Types.Common (Id(..))
@@ -44,8 +44,8 @@ run = script do
   investorSecuritiesAccount <- Account.createAccount "Securities Account" [public] accountFactoryCid holdingFactoryCid [] issuer investor
 
   -- Create lifecycle rules
-  distributionRuleCid <- submit issuer do createCmd Distribution.Rule with provider = issuer; observers = M.fromList pp
-  lifecycleClaimRuleCid <- submitMulti [issuer, investor] [] do createCmd Claim.Rule with custodian = issuer; owner = investor; claimers = singleton investor; settler = investor; factoryCid = settlementFactoryCid
+  distributionRuleCid <- toInterfaceContractId @Lifecycle.I <$> submit issuer do createCmd Distribution.Rule with provider = issuer; observers = M.fromList pp
+  lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [issuer, investor] [] do createCmd Claim.Rule with custodian = issuer; owner = investor; claimers = singleton investor; settler = investor; factoryCid = settlementFactoryCid
 
   -- Create clock
   now <- getTime

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Merger.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Merger.daml
@@ -10,8 +10,8 @@ import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Instrument.Equity.Test.Util (originateEquity)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
 import Daml.Finance.Interface.Instrument.Equity.Instrument qualified as Equity (I, DeclareReplacement(..))
-import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..))
-import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (Evolve(..))
+import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), I)
+import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (Evolve(..), I)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Types.Common (Id(..))
@@ -43,8 +43,8 @@ run = script do
   investorSecuritiesAccount <- Account.createAccount "Securities Account" [public] accountFactoryCid holdingFactoryCid [] custodian investor
 
   -- Create lifecycle rules
-  replacementRuleCid <- submit merging do createCmd Replacement.Rule with provider = merging; observers = M.fromList pp
-  lifecycleClaimRuleCid <- submitMulti [custodian, investor] [] do createCmd Claim.Rule with custodian; owner = investor; claimers = singleton investor; settler = investor; factoryCid = settlementFactoryCid
+  replacementRuleCid <- toInterfaceContractId @Lifecycle.I <$> submit merging do createCmd Replacement.Rule with provider = merging; observers = M.fromList pp
+  lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [custodian, investor] [] do createCmd Claim.Rule with custodian; owner = investor; claimers = singleton investor; settler = investor; factoryCid = settlementFactoryCid
 
   -- Create clock
   now <- getTime

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/StockSplit.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/StockSplit.daml
@@ -9,8 +9,8 @@ import DA.Set (singleton)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Instrument.Equity.Test.Util (originateEquity)
 import Daml.Finance.Interface.Instrument.Equity.Instrument qualified as Equity (DeclareStockSplit(..), I)
-import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..))
-import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (Evolve(..))
+import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), I)
+import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (Evolve(..), I)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Types.Common (Id(..))
@@ -41,8 +41,8 @@ run = script do
   investorSecuritiesAccount <- Account.createAccount "Securities Account" [public] accountFactoryCid holdingFactoryCid [] issuer investor
 
   -- Create lifecycle rules
-  replacementRuleCid <- submit issuer do createCmd Replacement.Rule with provider = issuer; observers = M.fromList pp
-  lifecycleClaimRuleCid <- submitMulti [issuer, investor] [] do createCmd Claim.Rule with custodian = issuer; owner = investor; claimers = singleton investor; settler = investor; factoryCid = settlementFactoryCid
+  replacementRuleCid <- toInterfaceContractId @Lifecycle.I <$> submit issuer do createCmd Replacement.Rule with provider = issuer; observers = M.fromList pp
+  lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [issuer, investor] [] do createCmd Claim.Rule with custodian = issuer; owner = investor; claimers = singleton investor; settler = investor; factoryCid = settlementFactoryCid
 
   -- Create clock
   now <- getTime

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
@@ -16,7 +16,7 @@ import Daml.Finance.Instrument.Generic.Test.Util (originateGeneric, dateToDateCl
 import Daml.Finance.Interface.Holding.Util (getAmount, getOwner)
 import Daml.Finance.Interface.Instrument.Generic.Election qualified as Election (Apply(..), I)
 import Daml.Finance.Interface.Instrument.Generic.Types (C, Deliverable)
-import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..))
+import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), I)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Types.Common (Id(..))
@@ -138,7 +138,7 @@ run = script do
   -- Create settlement factory
   settlementFactoryCid <- submitMulti [bank] [] do createCmd Factory with provider = bank; observers = empty
 
-  lifecycleClaimRuleCid <- submitMulti [bank, investor] [] do
+  lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [bank, investor] [] do
     createCmd Claim.Rule
       with
         custodian = bank

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/EuropeanOption.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/EuropeanOption.daml
@@ -18,7 +18,7 @@ import Daml.Finance.Interface.Holding.Fungible qualified as Fungible (SplitResul
 import Daml.Finance.Interface.Holding.Util (getAmount, getOwner)
 import Daml.Finance.Interface.Instrument.Generic.Election qualified as Election (Apply(..), I)
 import Daml.Finance.Interface.Instrument.Generic.Types (C, Observable, Deliverable)
-import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..))
+import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), I)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Types.Common (Id(..))
@@ -154,7 +154,7 @@ run = script do
   settlementFactoryCid <- submitMulti [investor1] [] do createCmd Factory with provider = investor1; observers = empty
 
   -- Claim effect
-  lifecycleClaimRuleCid <- submitMulti [bank, investor1] [] do
+  lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [bank, investor1] [] do
     createCmd Claim.Rule
       with
         custodian = bank
@@ -217,7 +217,7 @@ run = script do
   -- Create settlement factory
   settlementFactoryCid <- submitMulti [investor2] [] do createCmd Factory with provider = investor2; observers = empty
 
-  lifecycleClaimRuleCid <- submitMulti [bank, investor2] [] do
+  lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [bank, investor2] [] do
     createCmd Claim.Rule
       with
         custodian = bank

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardCash.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardCash.daml
@@ -10,8 +10,8 @@ import DA.Map qualified as M (empty, fromList)
 import DA.Set (empty, singleton)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Instrument.Generic.Test.Util (originateGeneric, dateToDateClockTime)
-import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..))
-import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Evolve(..))
+import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), I)
+import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (Evolve(..), I)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Types.Common (Id(..))
@@ -86,7 +86,7 @@ run = script do
   settlementFactoryCid <- submitMulti [investor] [] do createCmd Factory with provider = investor; observers = empty
 
   -- Claim effect
-  lifecycleClaimRuleCid <- submitMulti [bank, investor] [] do
+  lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [bank, investor] [] do
     createCmd Claim.Rule
       with
         custodian = bank

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardPhysical.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardPhysical.daml
@@ -10,8 +10,8 @@ import DA.Map qualified as M (empty, fromList)
 import DA.Set (empty, singleton)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Instrument.Generic.Test.Util (originateGeneric, dateToDateClockTime)
-import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..))
-import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Evolve(..))
+import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), I)
+import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (Evolve(..), I)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Types.Common (Id(..))
@@ -86,7 +86,7 @@ run = script do
   settlementFactoryCid <- submitMulti [investor] [] do createCmd Factory with provider = investor; observers = empty
 
   -- Claim effect
-  lifecycleClaimRuleCid <- submitMulti [bank, investor] [] do
+  lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [bank, investor] [] do
     createCmd Rule
       with
         custodian = bank

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
@@ -299,7 +299,7 @@ template EffectSettlementService
 
         -- TODO : use settlement instruction instead of direct transfer, or at least make sure it gets archived
 
-        steps <- fmap ((.step) . _view) <$> mapA fetch result.instructionCids
+        steps <- fmap ((.step) . view) <$> mapA fetch result.instructionCids
 
         newHoldingsCid <- fmap toInterfaceContractId .  mconcat <$> forA steps \s -> case find (match s . Prelude.snd) holdings of
           Some (hCid, h) -> do

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
@@ -18,7 +18,7 @@ import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I,
 import Daml.Finance.Interface.Holding.Util (getAmount, getInstrument, getOwner)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (GetCid(..), R)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (SetProvider(..), GetView(..), I)
-import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..))
+import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), I)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Evolve(..))
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
@@ -172,7 +172,7 @@ run = script do
         paths = M.fromList routes
         observers = fromList [investor]
 
-  lifecycleClaimRuleCid <- submitMulti [csd, investor] [] do
+  lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [csd, investor] [] do
     createCmd Claim.Rule
       with
         custodian = csd
@@ -289,7 +289,7 @@ template EffectSettlementService
             settler = csd
             factoryCid = toInterfaceContractId settlementFactoryCid
 
-        result <- exercise lifecycleClaimRuleCid Claim.ClaimEffect with
+        result <- exercise (toInterfaceContractId @Claim.I lifecycleClaimRuleCid) Claim.ClaimEffect with
           claimer = csd
           holdingCids = [toInterfaceContractId instrumentHoldingCid]
           effectCid

--- a/src/test/daml/Daml/Finance/Settlement/Test/Batch.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Batch.daml
@@ -8,7 +8,7 @@ import DA.Set (empty, singleton)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
-import Daml.Finance.Interface.Settlement.Factory qualified as Factory (Instruct(..))
+import Daml.Finance.Interface.Settlement.Factory qualified as Factory (I, Instruct(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Settlement.Types (Step(..))
 import Daml.Finance.Interface.Types.Common (Id(..))
@@ -70,7 +70,7 @@ run = script do
       [ Step with sender = issuer; receiver = bank; quantity = Instrument.qty 1_000.0 equityInstrument
       , Step with sender = bank; receiver = issuer; quantity = Instrument.qty 200_000.0 cashInstrument
       ]
-  settlementFactoryCid <- submitMulti [bank] [] do createCmd Factory with provider = bank; observers = empty
+  settlementFactoryCid <- toInterfaceContractId @Factory.I <$> submitMulti [bank] [] do createCmd Factory with provider = bank; observers = empty
   (batchCid, [equityInstructionCid, cashInstructionCid]) <-
     submitMulti [bank] [] do exerciseCmd settlementFactoryCid Factory.Instruct with instructors = singleton bank; settler = bank; id = Id "APPL 1000@200.0USD"; description = "DVP"; steps
 

--- a/src/test/daml/Daml/Finance/Settlement/Test/BatchWithRoute.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/BatchWithRoute.daml
@@ -8,7 +8,7 @@ import DA.Set (empty, singleton)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
-import Daml.Finance.Interface.Settlement.Factory qualified as Factory (Instruct(..))
+import Daml.Finance.Interface.Settlement.Factory qualified as Factory (I, Instruct(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Settlement.Types (Step(..))
 import Daml.Finance.Interface.Types.Common (Id(..))
@@ -89,7 +89,7 @@ run = script do
       [ ("USD", Path with senderPath = [bank1, cb]; receiverPath = [issuer, bank2, cb])
       , ("AAPL", Path with senderPath = [bank1, depository]; receiverPath = [issuer, depository])
       ]
-  settlementFactoryCid <- submitMulti [bank1] [] do
+  settlementFactoryCid <- toInterfaceContractId @Factory.I <$> submitMulti [bank1] [] do
     createCmd FactoryWithIntermediaries with
         provider = bank1
         paths = M.fromList routes

--- a/src/test/daml/Daml/Finance/Settlement/Test/Intermediated.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Intermediated.daml
@@ -9,7 +9,7 @@ import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..), T)
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
-import Daml.Finance.Interface.Settlement.Factory qualified as Factory (Instruct(..))
+import Daml.Finance.Interface.Settlement.Factory qualified as Factory (I, Instruct(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..), I)
 import Daml.Finance.Interface.Settlement.Types (Step(..))
 import Daml.Finance.Interface.Types.Common (Id(..))
@@ -120,7 +120,7 @@ run useDelegatee = script do
       , Step with sender = custodian2; receiver = alice; quantity = assetQuantity
       ]
   -- Create settlement factory
-  settlementFactoryCid <- submitMulti [agent] [] do createCmd Factory with provider = agent; observers = empty
+  settlementFactoryCid <- toInterfaceContractId @Factory.I <$> submitMulti [agent] [] do createCmd Factory with provider = agent; observers = empty
 
   -- Instruct settlement
   (batchCid, [aliceInstructionCid, bank1InstructionCid, bank2InstructionCid, bobInstructionCid, custodian1InstructionCid, custodian2InstructionCid]) <-

--- a/src/test/daml/Daml/Finance/Settlement/Test/Transfer.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Transfer.daml
@@ -8,7 +8,7 @@ import DA.Set (empty, singleton)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
-import Daml.Finance.Interface.Settlement.Factory qualified as Factory (Instruct(..))
+import Daml.Finance.Interface.Settlement.Factory qualified as Factory (I, Instruct(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Settlement.Types (Step(..))
 import Daml.Finance.Interface.Types.Common (Id(..))
@@ -61,7 +61,7 @@ run = script do
   transferableCid <- coerceContractId <$> Account.credit [publicParty] cashInstrument 200_000.0 senderAccount
 
   -- Create settlement factory
-  settlementFactoryCid <- submitMulti [bank] [] do createCmd Factory with provider = bank; observers = empty
+  settlementFactoryCid <- toInterfaceContractId @Factory.I <$> submitMulti [bank] [] do createCmd Factory with provider = bank; observers = empty
 
   -- Instruct transfer
   let step = Step with sender; receiver; quantity = Instrument.qty 200_000.0 cashInstrument


### PR DESCRIPTION
Changes:
- Change empty view types from `View ()` to `View {}` (variant to record type)
- Upcast to interface to call interface choices on templates
- Remove `templateTypeRepToText` (has been deprecated) => this required me to remove the holding type consistency check from settlement for now
- Change `_view` to `view` (the two are equivalent now)
