### PR TITLE
Write package documentation for Swaps

### DIFF
--- a/docs/source/packages/instrument-extensions.rst
+++ b/docs/source/packages/instrument-extensions.rst
@@ -42,7 +42,6 @@ Bonds
     - :ref:`FloatingRate <module-daml-finance-instrument-bond-floatingrate-31782>`: This template models a floating rate bond. It pays a floating coupon rate at the end of every coupon period.
     - :ref:`InflationLinked <module-daml-finance-instrument-bond-inflationlinked-38254>`: This template models an inflation linked bond. It pays an inflation adjusted coupon at the end of every coupon period.
     - :ref:`ZeroCoupon <module-daml-finance-instrument-bond-zerocoupon-72656>`: This template models a zero coupon bond. It does not pay any coupons, only the redemption amount at maturity.
-    - :ref:`Util <module-daml-finance-instrument-bond-util-70458>`: Utility functions related to creating Contingent Claims for coupons / redemption and bond lifecycling logic.
 
     Check out the tutorial on :doc:`How to use the Bond extension package <../../tutorials/instrument-modeling/bond-extension>` for a description how to use the bond extension in practice.
     There is also the tutorial :doc:`How to implement a Contingent Claims-based instrument <../../tutorials/instrument-modeling/contingent-claims-instrument>`, which describes how the claims are defined and how the lifecycle interface is implemented for bonds.
@@ -88,5 +87,6 @@ Generic
     - :ref:`Election <module-daml-finance-instrument-generic-election-56972>`: Implementation of Election (e.g. the exercise of an option) and ElectionFactory (to delegate the right to create Elections).
     - :ref:`Factory <module-daml-finance-instrument-generic-factory-42712>`: Factory template for generic instrument creation.
     - :ref:`Instrument <module-daml-finance-instrument-generic-instrument-67364>`: An instrument representing a generic payoff, modelled using ``Contingent Claims``.
+    - :ref:`Util <module-daml-finance-instrument-generic-util-13331>`: Utility functions related to creating Contingent Claims for bonds/swaps including lifecycling logic.
 
     The tutorial :doc:`How to use the Derivative extension to model generic instruments <../../tutorials/instrument-modeling/derivative-extension>` describes how a payoff is defined using ``Contingent Claims`` in practice.

--- a/docs/source/packages/instrument-extensions.rst
+++ b/docs/source/packages/instrument-extensions.rst
@@ -46,6 +46,21 @@ Bonds
     Check out the tutorial on :doc:`How to use the Bond extension package <../../tutorials/instrument-modeling/bond-extension>` for a description how to use the bond extension in practice.
     There is also the tutorial :doc:`How to implement a Contingent Claims-based instrument <../../tutorials/instrument-modeling/contingent-claims-instrument>`, which describes how the claims are defined and how the lifecycle interface is implemented for bonds.
 
+Swaps
+=====
+
+- ``Daml.Finance.Interface.Instrument.Swap``
+
+    This package contains the *interface* for different types of swaps. It contains the following modules:
+
+    - :ref:`InterestRate <type-daml-finance-interface-instrument-swap-interestrate-factory-50882>`: Interface that allows implementing templates to create interest rate swaps.
+
+- ``Daml.Finance.Instrument.Swap``
+
+    This package contains the *implementation* of different types of swaps. It contains the following modules:
+
+    - :ref:`InterestRate <type-daml-finance-instrument-swap-interestrate-factory-7433>`: This template models an interest rate swap. It pays a fix vs floating interest rate at the end of every payment period.
+
 Equity
 ======
 

--- a/docs/source/tutorials/instrument-modeling/contingent-claims-instrument.rst
+++ b/docs/source/tutorials/instrument-modeling/contingent-claims-instrument.rst
@@ -54,7 +54,7 @@ In the above example, we see that the redemption claim depends on the currency a
 
 We will now create a ``Contingent Claims`` representation of the actual redemption claim:
 
-.. literalinclude:: ../../../../src/main/daml/Daml/Finance/Instrument/Bond/Util.daml
+.. literalinclude:: ../../../../src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
   :language: daml
   :start-after: -- FIXED_RATE_BOND_REDEMPTION_CLAIM_BEGIN
   :end-before: -- FIXED_RATE_BOND_REDEMPTION_CLAIM_END
@@ -67,7 +67,7 @@ We need to take a schedule of adjusted coupon dates and the day count convention
 
 Here is how we create the ``Contingent Claims`` representation of the coupons:
 
-.. literalinclude:: ../../../../src/main/daml/Daml/Finance/Instrument/Bond/Util.daml
+.. literalinclude:: ../../../../src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
   :language: daml
   :start-after: -- FIXED_RATE_BOND_COUPON_CLAIMS_BEGIN
   :end-before: -- FIXED_RATE_BOND_COUPON_CLAIMS_END
@@ -90,7 +90,7 @@ consistent with the lifecycle mechanism.
 
 This is all done in the ``processClockUpdate`` function. We will now break it apart to describe the steps in more detail:
 
-.. literalinclude:: ../../../../src/main/daml/Daml/Finance/Instrument/Bond/Util.daml
+.. literalinclude:: ../../../../src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
   :language: daml
   :start-after: -- BOND_PROCESS_CLOCK_UPDATE_INITAL_CLAIMS_BEGIN
   :end-before: -- BOND_PROCESS_CLOCK_UPDATE_INITAL_CLAIMS_END
@@ -100,7 +100,7 @@ This represents the bond as of inception.
 By keeping track of ``lastEventTimestamp`` (in our case: the last time a coupon was paid),
 we can "fast forward" to the remaining claims of the instrument:
 
-.. literalinclude:: ../../../../src/main/daml/Daml/Finance/Instrument/Bond/Util.daml
+.. literalinclude:: ../../../../src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
   :language: daml
   :start-after: -- BOND_PROCESS_CLOCK_UPDATE_LIFECYCLE_FASTFORWARD_BEGIN
   :end-before: -- BOND_PROCESS_CLOCK_UPDATE_LIFECYCLE_FASTFORWARD_END
@@ -108,7 +108,7 @@ we can "fast forward" to the remaining claims of the instrument:
 Finally, we can lifecycle the instrument as of the current time (as descibed by the Clock template).
 If there is a lifecycle effect (for example a coupon), we will create an Effect for it, which can then be settled.
 
-.. literalinclude:: ../../../../src/main/daml/Daml/Finance/Instrument/Bond/Util.daml
+.. literalinclude:: ../../../../src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
   :language: daml
   :start-after: -- BOND_PROCESS_CLOCK_UPDATE_LIFECYCLE_BEGIN
   :end-before: -- BOND_PROCESS_CLOCK_UPDATE_LIFECYCLE_END
@@ -132,7 +132,7 @@ In the instrument definition, we need an identifier for the reference rate:
 
 In the claims definition, we can then use ``Observe`` to refer to the value of the reference rate:
 
-.. literalinclude:: ../../../../src/main/daml/Daml/Finance/Instrument/Bond/Util.daml
+.. literalinclude:: ../../../../src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
   :language: daml
   :start-after: -- FLOATING_RATE_BOND_COUPON_CLAIMS_BEGIN
   :end-before: -- FLOATING_RATE_BOND_COUPON_CLAIMS_END

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -10,7 +10,6 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/contingent-claims/v3.0.0.20220721.1/contingent-claims-3.0.0.20220721.1.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.4/daml-finance-instrument-generic-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.4/daml-finance-interface-types-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.4/daml-finance-interface-util-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.4/daml-finance-interface-instrument-base-0.1.4.dar
@@ -18,6 +17,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.4/daml-finance-interface-settlement-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.4/daml-finance-interface-instrument-generic-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/0.1.4/daml-finance-interface-instrument-bond-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.4/daml-finance-instrument-generic-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Util/0.1.4/daml-finance-util-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.4/daml-finance-lifecycle-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.RefData/0.1.4/daml-finance-refdata-0.1.4.dar

--- a/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
@@ -10,7 +10,6 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.4/daml-finance-instrument-generic-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.4/daml-finance-interface-types-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.4/daml-finance-interface-util-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.4/daml-finance-interface-holding-0.1.4.dar
@@ -18,6 +17,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.4/daml-finance-interface-settlement-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.4/daml-finance-interface-lifecycle-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.4/daml-finance-interface-instrument-generic-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.4/daml-finance-instrument-generic-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Holding/0.1.4/daml-finance-holding-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Settlement/0.1.4/daml-finance-settlement-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.4/daml-finance-lifecycle-0.1.4.dar


### PR DESCRIPTION
I have created package documentation for the new Swap package. 

I also updated the Bond documentation references after the utility functions (shared between Swap and Bond) were moved to a different package.