### PR TITLE
Implement FX Swaps

### DIFF
--- a/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
@@ -84,6 +84,12 @@ createRedemptionClaim cashInstrumentCid maturityDate = do
   prepareAndTagClaims redemptionClaim "Redemption payment"
 -- FIXED_RATE_BOND_REDEMPTION_CLAIM_END
 
+-- | Create an FX leg claim.
+createFxLegPrincipalClaim : Applicative f => Decimal -> Decimal -> Deliverable -> Date -> f [TaggedClaim]
+createFxLegPrincipalClaim weightMultiplier fxRateMultiplier cashInstrumentCid valueDate = do
+  let redemptionClaim = [when (TimeGte $ valueDate) $ scale (Const weightMultiplier * Const fxRateMultiplier) $ one cashInstrumentCid]
+  prepareAndTagClaims redemptionClaim "FX leg payment"
+
 -- | HIDE
 -- Type-class constraint verified by the bond templates.
 type IsBond t =

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
@@ -87,8 +87,8 @@ createRedemptionClaim cashInstrumentCid maturityDate = do
 -- | Create an FX leg claim.
 createFxLegPrincipalClaim : Applicative f => Decimal -> Decimal -> Deliverable -> Date -> f [TaggedClaim]
 createFxLegPrincipalClaim weightMultiplier fxRateMultiplier cashInstrumentCid valueDate = do
-  let redemptionClaim = [when (TimeGte $ valueDate) $ scale (Const weightMultiplier * Const fxRateMultiplier) $ one cashInstrumentCid]
-  prepareAndTagClaims redemptionClaim "FX leg payment"
+  let fxLegClaim = [when (TimeGte $ valueDate) $ scale (Const weightMultiplier * Const fxRateMultiplier) $ one cashInstrumentCid]
+  prepareAndTagClaims fxLegClaim "FX leg payment"
 
 -- | HIDE
 -- Type-class constraint verified by the bond templates.

--- a/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange.daml
@@ -63,8 +63,8 @@ template Instrument
       view = HasClaims.View with acquisitionTime = dateToDateClockTime issueDate
       getClaims = do
         -- get the initial claims tree (as of the swap's acquisition time)
-        baseCurrencyFirstPayment <- createFxLegPrincipalClaim 1.0 1.0 baseCurrency firstPaymentDate
-        foreignCurrencyFirstPayment <- createFxLegPrincipalClaim (-1.0) firstFxRate foreignCurrency firstPaymentDate
+        baseCurrencyFirstPayment <- createFxLegPrincipalClaim (-1.0) 1.0 baseCurrency firstPaymentDate
+        foreignCurrencyFirstPayment <- createFxLegPrincipalClaim 1.0 firstFxRate foreignCurrency firstPaymentDate
         baseCurrencyFinalPayment <- createFxLegPrincipalClaim 1.0 1.0 baseCurrency maturityDate
         foreignCurrencyFinalPayment <- createFxLegPrincipalClaim (-1.0) finalFxRate foreignCurrency maturityDate
         debug baseCurrencyFirstPayment

--- a/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange.daml
@@ -67,7 +67,6 @@ template Instrument
         foreignCurrencyFirstPayment <- createFxLegPrincipalClaim 1.0 firstFxRate foreignCurrency firstPaymentDate
         baseCurrencyFinalPayment <- createFxLegPrincipalClaim 1.0 1.0 baseCurrency maturityDate
         foreignCurrencyFinalPayment <- createFxLegPrincipalClaim (-1.0) finalFxRate foreignCurrency maturityDate
-        debug baseCurrencyFirstPayment
         pure $ mconcat [baseCurrencyFirstPayment, foreignCurrencyFirstPayment, baseCurrencyFinalPayment, foreignCurrencyFinalPayment]
 
     interface instance Instrument.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange.daml
@@ -10,8 +10,6 @@ import Daml.Finance.Interface.Instrument.Generic.HasClaims qualified as HasClaim
 import Daml.Finance.Interface.Instrument.Swap.ForeignExchange qualified as ForeignExchange (Create(..), Factory, HasImplementation, Remove(..), View(..))
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Evolve(..), View(..))
 import Daml.Finance.Interface.Types.Common (Id(..), InstrumentKey(..), PartiesMap)
-import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
-import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..))
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, SetObservers(..), View(..), flattenObservers)
 import Prelude hiding (key)
 
@@ -37,28 +35,16 @@ template Instrument
       -- ^ The instrument's version.
     description : Text
       -- ^ A description of the instrument.
-    referenceRateId : Text
-      -- ^ The floating rate reference ID. For example, in case of "3M Euribor vs 2.5% fix" this should be a valid reference to the "3M Euribor" reference rate.
-    issuerPaysFix : Bool
-      -- ^ Indicate whether the issuer of the instrument pays the fix or the floating leg of the swap.
-    fixRate : Decimal
-      -- ^ The interest rate of the fix leg. For example, in case of "3M Euribor vs 2.5% fix" this should be 0.025.
-    periodicSchedule : PeriodicSchedule
-      -- ^ The schedule for the periodic swap payments.
     firstFxRate : Decimal
       -- ^ The fx rate used for the first swap payment.
     finalFxRate : Decimal
       -- ^ The fx rate used for the final swap payment.
-    firstPaymentDate : Date
+    issueDate : Date
       -- ^ The date when the swap was issued.
+    firstPaymentDate : Date
+      -- ^ The first payment date of the swap.
     maturityDate : Date
       -- ^ The final payment date of the swap.
-    holidayCalendarIds : [Text]
-      -- ^ The identifier of the holiday calendar to be used for the swap payment schedule.
-    calendarDataProvider : Party
-      -- ^ The reference data provider to use for the holiday calendar.
-    dayCountConvention : DayCountConventionEnum
-      -- ^ The day count convention used to calculate day count fractions. For example: Act360.
     baseCurrency : Instrument.K
       -- ^ The base currency of the swap, which will be exchanged to another (foreign) currency on the first payment date. For example, in case of USD this should be a USD cash instrument.
     foreignCurrency : Instrument.K
@@ -74,17 +60,9 @@ template Instrument
     let instrumentKey = InstrumentKey with depository; issuer; id; version
 
     interface instance HasClaims.I for Instrument where
-      view = HasClaims.View with acquisitionTime = dateToDateClockTime periodicSchedule.effectiveDate
+      view = HasClaims.View with acquisitionTime = dateToDateClockTime issueDate
       getClaims = do
         -- get the initial claims tree (as of the swap's acquisition time)
-        schedule <- rollPaymentSchedule periodicSchedule holidayCalendarIds issuer calendarDataProvider
-        let
-          useAdjustedDatesForDcf = True
-          --fixLegWeight = if issuerPaysFix then 1.0 else -1.0
-          --floatingLegWeight = -fixLegWeight
-        --fixClaims <- createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf fixRate fixLegWeight dayCountConvention currency
-        --floatingClaims <- createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf 0.0 floatingLegWeight dayCountConvention currency referenceRateId
-        --pure $ mconcat [fixClaims, floatingClaims]
         baseCurrencyFirstPayment <- createFxLegPrincipalClaim 1.0 1.0 baseCurrency firstPaymentDate
         foreignCurrencyFirstPayment <- createFxLegPrincipalClaim (-1.0) firstFxRate foreignCurrency firstPaymentDate
         baseCurrencyFinalPayment <- createFxLegPrincipalClaim 1.0 1.0 baseCurrency maturityDate
@@ -126,25 +104,19 @@ template Factory
     interface instance ForeignExchange.Factory for Factory where
       asDisclosure = toInterface @Disclosure.I this
       view = ForeignExchange.View with provider
-      create' ForeignExchange.Create{instrument; description; referenceRateId; issuerPaysFix; fixRate; periodicSchedule; firstFxRate; finalFxRate; firstPaymentDate; maturityDate; holidayCalendarIds; calendarDataProvider; dayCountConvention; baseCurrency; foreignCurrency; lastEventTimestamp; observers} = do
+      create' ForeignExchange.Create{instrument; description; firstFxRate; finalFxRate; issueDate; firstPaymentDate; maturityDate; baseCurrency; foreignCurrency; lastEventTimestamp; observers} = do
         cid <- toInterfaceContractId <$> create Instrument
           with
             depository = instrument.depository
             issuer = instrument.issuer
-            issuerPaysFix
             id = instrument.id
             version = instrument.version
             description
-            referenceRateId
-            fixRate
-            periodicSchedule
             firstFxRate
             finalFxRate
+            issueDate
             firstPaymentDate
             maturityDate
-            holidayCalendarIds
-            calendarDataProvider
-            dayCountConvention
             baseCurrency
             foreignCurrency
             lastEventTimestamp

--- a/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange.daml
@@ -1,0 +1,163 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Daml.Finance.Instrument.Swap.ForeignExchange where
+
+import DA.Set (singleton)
+import Daml.Finance.Instrument.Generic.Util
+import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (GetCid(..), HasImplementation, I, K, R, View(..), createReference, disclosureUpdateReference)
+import Daml.Finance.Interface.Instrument.Generic.HasClaims qualified as HasClaims (I, View(..))
+import Daml.Finance.Interface.Instrument.Swap.ForeignExchange qualified as ForeignExchange (Create(..), Factory, HasImplementation, Remove(..), View(..))
+import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Evolve(..), View(..))
+import Daml.Finance.Interface.Types.Common (Id(..), InstrumentKey(..), PartiesMap)
+import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
+import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..))
+import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, SetObservers(..), View(..), flattenObservers)
+import Prelude hiding (key)
+
+-- | Type synonym for `Instrument`.
+type T = Instrument
+
+instance Instrument.HasImplementation T
+
+-- | This template models a foreign exchange swap (FX Swap).
+-- It has two legs: an initial FX transaction and a final FX transaction.
+-- Both FX rates and transaction dates are predetermined between the counterparties.
+-- For example: 1000k USD vs 1100k EUR (fx rate: 1.10) today
+--              1000k USD vs 1200k EUR (fx rate: 1.20) in 6 months
+template Instrument
+  with
+    depository : Party
+      -- ^ The depository of the instrument.
+    issuer : Party
+      -- ^ The issuer of the instrument.
+    id : Id
+      -- ^ An identifier of the instrument.
+    version : Text
+      -- ^ The instrument's version.
+    description : Text
+      -- ^ A description of the instrument.
+    referenceRateId : Text
+      -- ^ The floating rate reference ID. For example, in case of "3M Euribor vs 2.5% fix" this should be a valid reference to the "3M Euribor" reference rate.
+    issuerPaysFix : Bool
+      -- ^ Indicate whether the issuer of the instrument pays the fix or the floating leg of the swap.
+    fixRate : Decimal
+      -- ^ The interest rate of the fix leg. For example, in case of "3M Euribor vs 2.5% fix" this should be 0.025.
+    periodicSchedule : PeriodicSchedule
+      -- ^ The schedule for the periodic swap payments.
+    firstFxRate : Decimal
+      -- ^ The fx rate used for the first swap payment.
+    finalFxRate : Decimal
+      -- ^ The fx rate used for the final swap payment.
+    firstPaymentDate : Date
+      -- ^ The date when the swap was issued.
+    maturityDate : Date
+      -- ^ The final payment date of the swap.
+    holidayCalendarIds : [Text]
+      -- ^ The identifier of the holiday calendar to be used for the swap payment schedule.
+    calendarDataProvider : Party
+      -- ^ The reference data provider to use for the holiday calendar.
+    dayCountConvention : DayCountConventionEnum
+      -- ^ The day count convention used to calculate day count fractions. For example: Act360.
+    baseCurrency : Instrument.K
+      -- ^ The base currency of the swap, which will be exchanged to another (foreign) currency on the first payment date. For example, in case of USD this should be a USD cash instrument.
+    foreignCurrency : Instrument.K
+      -- ^ The foreign currency of the swap. For example, in case of EUR this should be a EUR cash instrument.
+    observers : PartiesMap
+      -- ^ The observers of the instrument.
+    lastEventTimestamp : Time
+      -- ^ (Market) time of the last recorded lifecycle event. If no event has occurred yet, the time of creation should be used.
+  where
+    signatory depository, issuer
+    observer Disclosure.flattenObservers observers
+
+    let instrumentKey = InstrumentKey with depository; issuer; id; version
+
+    interface instance HasClaims.I for Instrument where
+      view = HasClaims.View with acquisitionTime = dateToDateClockTime periodicSchedule.effectiveDate
+      getClaims = do
+        -- get the initial claims tree (as of the swap's acquisition time)
+        schedule <- rollPaymentSchedule periodicSchedule holidayCalendarIds issuer calendarDataProvider
+        let
+          useAdjustedDatesForDcf = True
+          --fixLegWeight = if issuerPaysFix then 1.0 else -1.0
+          --floatingLegWeight = -fixLegWeight
+        --fixClaims <- createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf fixRate fixLegWeight dayCountConvention currency
+        --floatingClaims <- createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf 0.0 floatingLegWeight dayCountConvention currency referenceRateId
+        --pure $ mconcat [fixClaims, floatingClaims]
+        baseCurrencyFirstPayment <- createFxLegPrincipalClaim 1.0 1.0 baseCurrency firstPaymentDate
+        foreignCurrencyFirstPayment <- createFxLegPrincipalClaim (-1.0) firstFxRate foreignCurrency firstPaymentDate
+        baseCurrencyFinalPayment <- createFxLegPrincipalClaim 1.0 1.0 baseCurrency maturityDate
+        foreignCurrencyFinalPayment <- createFxLegPrincipalClaim (-1.0) finalFxRate foreignCurrency maturityDate
+        debug baseCurrencyFirstPayment
+        pure $ mconcat [baseCurrencyFirstPayment, foreignCurrencyFirstPayment, baseCurrencyFinalPayment, foreignCurrencyFinalPayment]
+
+    interface instance Instrument.I for Instrument where
+      asDisclosure = toInterface @Disclosure.I this
+      view = Instrument.View with depository; issuer; id; version; description; validAsOf = lastEventTimestamp
+      getKey = instrumentKey
+
+    interface instance Lifecycle.I for Instrument where
+      view = Lifecycle.View with lifecycler = issuer
+      evolve Lifecycle.Evolve{ruleName; settler; eventCid; clockCid; observableCids} self =
+        case ruleName of
+          "Time" -> processClockUpdate settler eventCid clockCid self this observableCids
+          other -> abort $ "Unknown lifecycle rule " <> other
+
+    interface instance Disclosure.I for Instrument where
+      view = Disclosure.View with disclosureControllers = singleton issuer; observers
+      setObservers Disclosure.SetObservers{newObservers} = do
+        cid <- toInterfaceContractId <$> create this with observers = newObservers
+        Instrument.disclosureUpdateReference newObservers instrumentKey cid
+      archive' self = archive (coerceContractId self : ContractId Instrument)
+
+instance ForeignExchange.HasImplementation Factory
+-- | Factory template for instrument creation.
+template Factory
+  with
+    provider : Party
+      -- ^ The factory's provider.
+    observers : PartiesMap
+      -- ^ The factory's observers.
+  where
+    signatory provider
+    observer Disclosure.flattenObservers observers
+
+    interface instance ForeignExchange.Factory for Factory where
+      asDisclosure = toInterface @Disclosure.I this
+      view = ForeignExchange.View with provider
+      create' ForeignExchange.Create{instrument; description; referenceRateId; issuerPaysFix; fixRate; periodicSchedule; firstFxRate; finalFxRate; firstPaymentDate; maturityDate; holidayCalendarIds; calendarDataProvider; dayCountConvention; baseCurrency; foreignCurrency; lastEventTimestamp; observers} = do
+        cid <- toInterfaceContractId <$> create Instrument
+          with
+            depository = instrument.depository
+            issuer = instrument.issuer
+            issuerPaysFix
+            id = instrument.id
+            version = instrument.version
+            description
+            referenceRateId
+            fixRate
+            periodicSchedule
+            firstFxRate
+            finalFxRate
+            firstPaymentDate
+            maturityDate
+            holidayCalendarIds
+            calendarDataProvider
+            dayCountConvention
+            baseCurrency
+            foreignCurrency
+            lastEventTimestamp
+            observers
+        Instrument.createReference instrument.depository cid
+        pure cid
+      remove ForeignExchange.Remove{instrument} = do
+        (refCid, ref) <- fetchByKey @Instrument.R instrument
+        instrumentCid <- exercise refCid Instrument.GetCid with viewer = instrument.depository
+        archive $ fromInterfaceContractId @Instrument instrumentCid
+        archive refCid
+
+    interface instance Disclosure.I for Factory where
+      view = Disclosure.View with disclosureControllers = singleton provider; observers
+      setObservers Disclosure.SetObservers{newObservers} = toInterfaceContractId <$> create this with observers = newObservers
+      archive' self = archive (coerceContractId self : ContractId Instrument)

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/ForeignExchange.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/ForeignExchange.daml
@@ -20,7 +20,7 @@ data View = View
       -- ^ The provider of the `Factory`.
   deriving (Eq, Ord, Show)
 
--- | Interface that allows implementing templates to create interest rate swaps.
+-- | Interface that allows implementing templates to create foreign exchange swaps.
 interface Factory where
   viewtype V
 
@@ -45,13 +45,13 @@ interface Factory where
       issueDate : Date
         -- ^ The date when the swap was issued.
       firstPaymentDate : Date
-        -- ^ The date when the swap was issued.
+        -- ^ The first payment date of the swap.
       maturityDate : Date
         -- ^ The final payment date of the swap.
       baseCurrency : Instrument.K
-        -- ^ The currency of the swap. For example, if the swap pays in USD this should be a USD cash instrument.
+        -- ^ The base currency of the swap, which will be exchanged to another (foreign) currency on the first payment date. For example, in case of USD this should be a USD cash instrument.
       foreignCurrency : Instrument.K
-        -- ^ The currency of the swap. For example, if the swap pays in USD this should be a USD cash instrument.
+        -- ^ The foreign currency of the swap. For example, in case of EUR this should be a EUR cash instrument.
       lastEventTimestamp : Time
         -- ^ (Market) time of the last recorded lifecycle event. If no event has occurred yet, the time of creation should be used.
       observers : PartiesMap

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/ForeignExchange.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/ForeignExchange.daml
@@ -5,8 +5,6 @@ module Daml.Finance.Interface.Instrument.Swap.ForeignExchange where
 
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (I, K)
 import Daml.Finance.Interface.Types.Common (InstrumentKey(..), PartiesMap)
-import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
-import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..))
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, Implementation)
 
 -- | Type synonym for `Factory`.
@@ -40,28 +38,16 @@ interface Factory where
         -- ^ The instrument's key.
       description : Text
         -- ^ The description of the swap.
-      referenceRateId : Text
-        -- ^ The floating rate reference ID. For example, in case of "3M Euribor vs 2.5% fix" this should be a valid reference to the "3M Euribor" reference rate.
-      issuerPaysFix : Bool
-        -- ^ Indicate whether the issuer of the instrument pays the fix or the floating leg of the swap.
-      fixRate : Decimal
-        -- ^ The interest rate of the fix leg. For example, in case of "3M Euribor vs 2.5% fix" this should be 0.025.
-      periodicSchedule : PeriodicSchedule
-        -- ^ The schedule for the periodic swap payments.
       firstFxRate : Decimal
         -- ^ The fx rate used for the first swap payment.
       finalFxRate : Decimal
         -- ^ The fx rate used for the final swap payment.
+      issueDate : Date
+        -- ^ The date when the swap was issued.
       firstPaymentDate : Date
         -- ^ The date when the swap was issued.
       maturityDate : Date
         -- ^ The final payment date of the swap.
-      holidayCalendarIds : [Text]
-        -- ^ The identifier of the holiday calendar to be used for the swap payment schedule.
-      calendarDataProvider : Party
-        -- ^ The reference data provider to use for the holiday calendar.
-      dayCountConvention : DayCountConventionEnum
-        -- ^ The day count convention used to calculate day count fractions. For example: Act360.
       baseCurrency : Instrument.K
         -- ^ The currency of the swap. For example, if the swap pays in USD this should be a USD cash instrument.
       foreignCurrency : Instrument.K

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/ForeignExchange.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/ForeignExchange.daml
@@ -1,0 +1,90 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Daml.Finance.Interface.Instrument.Swap.ForeignExchange where
+
+import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (I, K)
+import Daml.Finance.Interface.Types.Common (InstrumentKey(..), PartiesMap)
+import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
+import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..))
+import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, Implementation)
+
+-- | Type synonym for `Factory`.
+type F = Factory
+
+-- | Type synonym for `View`.
+type V = View
+
+-- | View of `Factory`.
+data View = View
+  with
+    provider : Party
+      -- ^ The provider of the `Factory`.
+  deriving (Eq, Ord, Show)
+
+-- | Interface that allows implementing templates to create interest rate swaps.
+interface Factory where
+  viewtype V
+
+  asDisclosure : Disclosure.I
+    -- ^ Conversion to `Disclosure` interface.
+  create' : Create -> Update (ContractId Instrument.I)
+    -- ^ Implementation of `Create` choice.
+  remove : Remove -> Update ()
+    -- ^ Implementation of `Remove` choice.
+
+  nonconsuming choice Create : ContractId Instrument.I
+    -- ^ Create a new instrument.
+    with
+      instrument : InstrumentKey
+        -- ^ The instrument's key.
+      description : Text
+        -- ^ The description of the swap.
+      referenceRateId : Text
+        -- ^ The floating rate reference ID. For example, in case of "3M Euribor vs 2.5% fix" this should be a valid reference to the "3M Euribor" reference rate.
+      issuerPaysFix : Bool
+        -- ^ Indicate whether the issuer of the instrument pays the fix or the floating leg of the swap.
+      fixRate : Decimal
+        -- ^ The interest rate of the fix leg. For example, in case of "3M Euribor vs 2.5% fix" this should be 0.025.
+      periodicSchedule : PeriodicSchedule
+        -- ^ The schedule for the periodic swap payments.
+      firstFxRate : Decimal
+        -- ^ The fx rate used for the first swap payment.
+      finalFxRate : Decimal
+        -- ^ The fx rate used for the final swap payment.
+      firstPaymentDate : Date
+        -- ^ The date when the swap was issued.
+      maturityDate : Date
+        -- ^ The final payment date of the swap.
+      holidayCalendarIds : [Text]
+        -- ^ The identifier of the holiday calendar to be used for the swap payment schedule.
+      calendarDataProvider : Party
+        -- ^ The reference data provider to use for the holiday calendar.
+      dayCountConvention : DayCountConventionEnum
+        -- ^ The day count convention used to calculate day count fractions. For example: Act360.
+      baseCurrency : Instrument.K
+        -- ^ The currency of the swap. For example, if the swap pays in USD this should be a USD cash instrument.
+      foreignCurrency : Instrument.K
+        -- ^ The currency of the swap. For example, if the swap pays in USD this should be a USD cash instrument.
+      lastEventTimestamp : Time
+        -- ^ (Market) time of the last recorded lifecycle event. If no event has occurred yet, the time of creation should be used.
+      observers : PartiesMap
+        -- ^ The instrument's observers.
+    controller instrument.depository, instrument.issuer
+    do
+      create' this arg
+
+  nonconsuming choice Remove : ()
+    -- ^ Archive an instrument.
+    with
+      instrument : InstrumentKey
+        -- ^ The instrument's key.
+    controller instrument.depository, instrument.issuer
+      do
+        remove this arg
+
+-- | Type constraint for requiring templates to implement `Factory` along with `Disclosure`.
+type Implementation t = (HasToInterface t Factory, Disclosure.Implementation t)
+instance HasToInterface Factory Disclosure.I where _toInterface = asDisclosure
+class (Implementation t) => HasImplementation t
+instance HasImplementation Factory

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/ForeignExchange.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/ForeignExchange.daml
@@ -4,17 +4,10 @@
 module Daml.Finance.Instrument.Swap.Test.ForeignExchange where
 
 import DA.Date
-import DA.Map qualified as M (empty, fromList)
+import DA.Map qualified as M (fromList)
 import DA.Set (singleton)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
-import Daml.Finance.Instrument.Generic.Util
 import Daml.Finance.Instrument.Swap.Test.Util
-import Daml.Finance.Interface.Types.Common (Id(..))
-import Daml.Finance.Interface.Types.Date.Calendar
-import Daml.Finance.Interface.Types.Date.DayCount
-import Daml.Finance.Interface.Types.Date.RollConvention
-import Daml.Finance.Data.Reference.HolidayCalendar
-import Daml.Finance.Data.Observable.Observation (Observation(..))
 import Daml.Finance.Test.Util.Account qualified as Account (createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
@@ -23,8 +16,8 @@ import Daml.Script
 -- Calculate interest rate payment on an interest rate swap, including lifecycling and creation of new instrument version
 run : Script ()
 run = script do
-  [custodian, issuer, investor, calendarDataProvider, publicParty] <-
-    createParties ["Custodian", "Issuer", "Investor", "Calendar Data Provider", "PublicParty"]
+  [custodian, issuer, investor, publicParty] <-
+    createParties ["Custodian", "Issuer", "Investor", "PublicParty"]
 
   -- Account and holding factory
   let pp = [("FactoryProvider", singleton publicParty)]
@@ -47,60 +40,34 @@ run = script do
     issueDate = date 2019 Jan 16
     firstPaymentDate = date 2019 Feb 15
     maturityDate = date 2019 May 15
-    referenceRateId = "USD/LIBOR/3M"
-    issuerPaysFix = False
-    fixRate = 0.0201
-    paymentPeriod = M
-    paymentPeriodMultiplier = 3
-    dayCountConvention = Act360
-    businessDayConvention = ModifiedFollowing
     firstFxRate = 1.1
     finalFxRate = 1.2
-    firstPaymentAmount : Decimal = 1_000_000.0 -- The first payment is smaller than a regularly because the first period is shorter (only 1 month)
     firstFixPaymentAmount : Decimal = 1_100_000.0
     firstFloatingPaymentAmount : Decimal = 1_000_000.0
-    secondPaymentAmount : Decimal = 4466.0694 -- The second payment corresponds to a regular (3 month) period
     secondFixPaymentAmount : Decimal = 1_200_000.0
     secondFloatingPaymentAmount : Decimal = 1_000_000.0
     principalAmount = 1_000_000.0
-    observations = M.fromList [(dateToDateClockTime (date 2019 Jan 16), 0.0027406), (dateToDateClockTime (date 2019 Feb 15), 0.002035)]
-    holidayCalendarId = ["USD"]
-    cal =
-      HolidayCalendarData with
-        id = "USD"
-        weekend = [Saturday, Sunday]
-        holidays = [date 2019 Dec 19]
 
-  -- A reference data provider publishes the holiday calendar on the ledger
-  calendarCid <- submitMulti [calendarDataProvider] [] do
-    createCmd HolidayCalendar with
-      agency = calendarDataProvider
-      entity = cal.id
-      calendar = cal
-      observers = M.fromList pp
-
-  observableCid <- coerceContractId <$> submitMulti [issuer] [] do createCmd Observation with provider = issuer; id = Id referenceRateId; observations; observers = M.empty
-
-  swapInstrument <- originateForeignExchangeSwap custodian issuer "SwapTest1" "Interest rate swap" pp now issueDate holidayCalendarId calendarDataProvider firstPaymentDate maturityDate dayCountConvention businessDayConvention fixRate paymentPeriod paymentPeriodMultiplier cashInstrumentCid foreignCashInstrumentCid referenceRateId issuerPaysFix firstFxRate finalFxRate
+  swapInstrument <- originateForeignExchangeSwap custodian issuer "SwapTest1" "Foreign exchange swap" pp now issueDate firstPaymentDate maturityDate cashInstrumentCid foreignCashInstrumentCid firstFxRate finalFxRate
   investorSwapTransferableCid <- Account.credit [publicParty] swapInstrument principalAmount investorAccount
 
   -- One day before the first payment date: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (subtractDays firstPaymentDate 1) swapInstrument custodian issuer [observableCid]
+  verifyNoLifecycleEffects [publicParty] (subtractDays firstPaymentDate 1) swapInstrument custodian issuer []
 
   -- First payment date: Lifecycle and verify that there are lifecycle effects for fix and floating payments.
   investorCashForFixPaymentTransferableCid <- Account.credit [publicParty] foreignCashInstrumentCid firstFixPaymentAmount investorAccount
   custodianCashForFloatingPaymentTransferableCid <- Account.credit [publicParty] cashInstrumentCid firstFloatingPaymentAmount custodianAccount
-  (swapInstrumentAfterFirstPayment, investorSwapTransferableCid) <- lifecycleAndVerifySwapPaymentEffectsAndSettlement [publicParty] firstPaymentDate swapInstrument custodian issuer investor investorSwapTransferableCid investorCashForFixPaymentTransferableCid custodianCashForFloatingPaymentTransferableCid custodianAccount investorAccount observers custodian [observableCid]
+  (swapInstrumentAfterFirstPayment, investorSwapTransferableCid) <- lifecycleAndVerifySwapPaymentEffectsAndSettlement [publicParty] firstPaymentDate swapInstrument custodian issuer investor investorSwapTransferableCid investorCashForFixPaymentTransferableCid custodianCashForFloatingPaymentTransferableCid custodianAccount investorAccount observers custodian []
 
   -- One day after the first payment date: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment custodian issuer [observableCid]
+  verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment custodian issuer []
 
   -- One day before expiry: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (subtractDays maturityDate 1) swapInstrumentAfterFirstPayment custodian issuer [observableCid]
+  verifyNoLifecycleEffects [publicParty] (subtractDays maturityDate 1) swapInstrumentAfterFirstPayment custodian issuer []
 
   -- Lifecycle on the second payment date, which is also the expiry date. Verify that there are lifecycle effects for fix and floating payments.
   investorCashForFixPaymentTransferableCid <- Account.credit [publicParty] foreignCashInstrumentCid secondFixPaymentAmount investorAccount
   custodianCashForFloatingPaymentTransferableCid <- Account.credit [publicParty] cashInstrumentCid secondFloatingPaymentAmount custodianAccount
-  lifecycleAndVerifyFinalSwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment custodian issuer investor investorSwapTransferableCid investorCashForFixPaymentTransferableCid custodianCashForFloatingPaymentTransferableCid custodianAccount investorAccount observers custodian [observableCid]
+  lifecycleAndVerifyFinalSwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment custodian issuer investor investorSwapTransferableCid investorCashForFixPaymentTransferableCid custodianCashForFloatingPaymentTransferableCid custodianAccount investorAccount observers custodian []
 
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/ForeignExchange.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/ForeignExchange.daml
@@ -1,0 +1,106 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Daml.Finance.Instrument.Swap.Test.ForeignExchange where
+
+import DA.Date
+import DA.Map qualified as M (empty, fromList)
+import DA.Set (singleton)
+import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
+import Daml.Finance.Instrument.Generic.Util
+import Daml.Finance.Instrument.Swap.Test.Util
+import Daml.Finance.Interface.Types.Common (Id(..))
+import Daml.Finance.Interface.Types.Date.Calendar
+import Daml.Finance.Interface.Types.Date.DayCount
+import Daml.Finance.Interface.Types.Date.RollConvention
+import Daml.Finance.Data.Reference.HolidayCalendar
+import Daml.Finance.Data.Observable.Observation (Observation(..))
+import Daml.Finance.Test.Util.Account qualified as Account (createAccount, createFactory, credit)
+import Daml.Finance.Test.Util.Common (createParties)
+import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
+import Daml.Script
+
+-- Calculate interest rate payment on an interest rate swap, including lifecycling and creation of new instrument version
+run : Script ()
+run = script do
+  [custodian, issuer, investor, calendarDataProvider, publicParty] <-
+    createParties ["Custodian", "Issuer", "Investor", "Calendar Data Provider", "PublicParty"]
+
+  -- Account and holding factory
+  let pp = [("FactoryProvider", singleton publicParty)]
+  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory custodian pp
+  holdingFactoryCid <- toInterfaceContractId <$> submitMulti [custodian] [] do
+    createCmd Fungible.Factory with provider = custodian; observers = M.fromList pp
+
+  -- Create accounts
+  [custodianAccount, investorAccount] <- mapA (Account.createAccount "Default Account" [publicParty] accountFactoryCid holdingFactoryCid [] custodian) [custodian, investor]
+
+  -- Distribute commercial-bank cash
+  now <- getTime
+  let observers = [("PublicParty", singleton publicParty)]
+  cashInstrumentCid <- Instrument.originate custodian issuer "USD" "US Dollars" observers now
+  foreignCashInstrumentCid <- Instrument.originate custodian issuer "EUR" "Euro" observers now
+
+  -- Create and distribute swap
+  -- Fix vs floating interest rate swap: Libor 3M vs 2.01% p.a. payment every 3M
+  let
+    issueDate = date 2019 Jan 16
+    firstPaymentDate = date 2019 Feb 15
+    maturityDate = date 2019 May 15
+    referenceRateId = "USD/LIBOR/3M"
+    issuerPaysFix = False
+    fixRate = 0.0201
+    paymentPeriod = M
+    paymentPeriodMultiplier = 3
+    dayCountConvention = Act360
+    businessDayConvention = ModifiedFollowing
+    firstFxRate = 1.1
+    finalFxRate = 1.2
+    firstPaymentAmount : Decimal = 1_000_000.0 -- The first payment is smaller than a regularly because the first period is shorter (only 1 month)
+    firstFixPaymentAmount : Decimal = 1_100_000.0
+    firstFloatingPaymentAmount : Decimal = 1_000_000.0
+    secondPaymentAmount : Decimal = 4466.0694 -- The second payment corresponds to a regular (3 month) period
+    secondFixPaymentAmount : Decimal = 1_200_000.0
+    secondFloatingPaymentAmount : Decimal = 1_000_000.0
+    principalAmount = 1_000_000.0
+    observations = M.fromList [(dateToDateClockTime (date 2019 Jan 16), 0.0027406), (dateToDateClockTime (date 2019 Feb 15), 0.002035)]
+    holidayCalendarId = ["USD"]
+    cal =
+      HolidayCalendarData with
+        id = "USD"
+        weekend = [Saturday, Sunday]
+        holidays = [date 2019 Dec 19]
+
+  -- A reference data provider publishes the holiday calendar on the ledger
+  calendarCid <- submitMulti [calendarDataProvider] [] do
+    createCmd HolidayCalendar with
+      agency = calendarDataProvider
+      entity = cal.id
+      calendar = cal
+      observers = M.fromList pp
+
+  observableCid <- coerceContractId <$> submitMulti [issuer] [] do createCmd Observation with provider = issuer; id = Id referenceRateId; observations; observers = M.empty
+
+  swapInstrument <- originateForeignExchangeSwap custodian issuer "SwapTest1" "Interest rate swap" pp now issueDate holidayCalendarId calendarDataProvider firstPaymentDate maturityDate dayCountConvention businessDayConvention fixRate paymentPeriod paymentPeriodMultiplier cashInstrumentCid foreignCashInstrumentCid referenceRateId issuerPaysFix firstFxRate finalFxRate
+  investorSwapTransferableCid <- Account.credit [publicParty] swapInstrument principalAmount investorAccount
+
+  -- One day before the first payment date: try to lifecycle and verify that there are no lifecycle effects.
+  verifyNoLifecycleEffects [publicParty] (subtractDays firstPaymentDate 1) swapInstrument custodian issuer [observableCid]
+
+  -- First payment date: Lifecycle and verify that there are lifecycle effects for fix and floating payments.
+  investorCashForFixPaymentTransferableCid <- Account.credit [publicParty] foreignCashInstrumentCid firstFixPaymentAmount investorAccount
+  custodianCashForFloatingPaymentTransferableCid <- Account.credit [publicParty] cashInstrumentCid firstFloatingPaymentAmount custodianAccount
+  (swapInstrumentAfterFirstPayment, investorSwapTransferableCid) <- lifecycleAndVerifySwapPaymentEffectsAndSettlement [publicParty] firstPaymentDate swapInstrument custodian issuer investor investorSwapTransferableCid investorCashForFixPaymentTransferableCid custodianCashForFloatingPaymentTransferableCid custodianAccount investorAccount observers custodian [observableCid]
+
+  -- One day after the first payment date: try to lifecycle and verify that there are no lifecycle effects.
+  verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment custodian issuer [observableCid]
+
+  -- One day before expiry: try to lifecycle and verify that there are no lifecycle effects.
+  verifyNoLifecycleEffects [publicParty] (subtractDays maturityDate 1) swapInstrumentAfterFirstPayment custodian issuer [observableCid]
+
+  -- Lifecycle on the second payment date, which is also the expiry date. Verify that there are lifecycle effects for fix and floating payments.
+  investorCashForFixPaymentTransferableCid <- Account.credit [publicParty] foreignCashInstrumentCid secondFixPaymentAmount investorAccount
+  custodianCashForFloatingPaymentTransferableCid <- Account.credit [publicParty] cashInstrumentCid secondFloatingPaymentAmount custodianAccount
+  lifecycleAndVerifyFinalSwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment custodian issuer investor investorSwapTransferableCid investorCashForFixPaymentTransferableCid custodianCashForFloatingPaymentTransferableCid custodianAccount investorAccount observers custodian [observableCid]
+
+  pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/ForeignExchange.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/ForeignExchange.daml
@@ -13,7 +13,7 @@ import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Script
 
--- Calculate interest rate payment on an interest rate swap, including lifecycling and creation of new instrument version
+-- Calculate fx payments payment on an foreign exchange swap, including lifecycling and creation of new instrument version.
 run : Script ()
 run = script do
   [custodian, issuer, investor, publicParty] <-
@@ -35,17 +35,17 @@ run = script do
   foreignCashInstrumentCid <- Instrument.originate custodian issuer "EUR" "Euro" observers now
 
   -- Create and distribute swap
-  -- Fix vs floating interest rate swap: Libor 3M vs 2.01% p.a. payment every 3M
+  -- Foreign exchange swap: USD vs EUR
   let
     issueDate = date 2019 Jan 16
     firstPaymentDate = date 2019 Feb 15
     maturityDate = date 2019 May 15
     firstFxRate = 1.1
     finalFxRate = 1.2
-    firstFixPaymentAmount : Decimal = 1_100_000.0
-    firstFloatingPaymentAmount : Decimal = 1_000_000.0
-    secondFixPaymentAmount : Decimal = 1_200_000.0
-    secondFloatingPaymentAmount : Decimal = 1_000_000.0
+    firstForeignPaymentAmount : Decimal = 1_100_000.0
+    firstBasePaymentAmount : Decimal = 1_000_000.0
+    secondForeignPaymentAmount : Decimal = 1_200_000.0
+    secondBasePaymentAmount : Decimal = 1_000_000.0
     principalAmount = 1_000_000.0
 
   swapInstrument <- originateForeignExchangeSwap custodian issuer "SwapTest1" "Foreign exchange swap" pp now issueDate firstPaymentDate maturityDate cashInstrumentCid foreignCashInstrumentCid firstFxRate finalFxRate
@@ -54,10 +54,10 @@ run = script do
   -- One day before the first payment date: try to lifecycle and verify that there are no lifecycle effects.
   verifyNoLifecycleEffects [publicParty] (subtractDays firstPaymentDate 1) swapInstrument custodian issuer []
 
-  -- First payment date: Lifecycle and verify that there are lifecycle effects for fix and floating payments.
-  investorCashForFixPaymentTransferableCid <- Account.credit [publicParty] foreignCashInstrumentCid firstFixPaymentAmount investorAccount
-  custodianCashForFloatingPaymentTransferableCid <- Account.credit [publicParty] cashInstrumentCid firstFloatingPaymentAmount custodianAccount
-  (swapInstrumentAfterFirstPayment, investorSwapTransferableCid) <- lifecycleAndVerifySwapPaymentEffectsAndSettlement [publicParty] firstPaymentDate swapInstrument custodian issuer investor investorSwapTransferableCid investorCashForFixPaymentTransferableCid custodianCashForFloatingPaymentTransferableCid custodianAccount investorAccount observers custodian []
+  -- First payment date: Lifecycle and verify that there are lifecycle effects for the fx payments.
+  investorCashForBasePaymentTransferableCid <- Account.credit [publicParty] cashInstrumentCid firstBasePaymentAmount investorAccount
+  custodianCashForForeignPaymentTransferableCid <- Account.credit [publicParty] foreignCashInstrumentCid firstForeignPaymentAmount custodianAccount
+  (swapInstrumentAfterFirstPayment, investorSwapTransferableCid) <- lifecycleAndVerifySwapPaymentEffectsAndSettlement [publicParty] firstPaymentDate swapInstrument custodian issuer investor investorSwapTransferableCid investorCashForBasePaymentTransferableCid custodianCashForForeignPaymentTransferableCid custodianAccount investorAccount observers custodian []
 
   -- One day after the first payment date: try to lifecycle and verify that there are no lifecycle effects.
   verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment custodian issuer []
@@ -65,9 +65,9 @@ run = script do
   -- One day before expiry: try to lifecycle and verify that there are no lifecycle effects.
   verifyNoLifecycleEffects [publicParty] (subtractDays maturityDate 1) swapInstrumentAfterFirstPayment custodian issuer []
 
-  -- Lifecycle on the second payment date, which is also the expiry date. Verify that there are lifecycle effects for fix and floating payments.
-  investorCashForFixPaymentTransferableCid <- Account.credit [publicParty] foreignCashInstrumentCid secondFixPaymentAmount investorAccount
-  custodianCashForFloatingPaymentTransferableCid <- Account.credit [publicParty] cashInstrumentCid secondFloatingPaymentAmount custodianAccount
-  lifecycleAndVerifyFinalSwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment custodian issuer investor investorSwapTransferableCid investorCashForFixPaymentTransferableCid custodianCashForFloatingPaymentTransferableCid custodianAccount investorAccount observers custodian []
+  -- Lifecycle on the second payment date, which is also the expiry date. Verify that there are lifecycle effects for the fx payments.
+  investorCashForForeignPaymentTransferableCid <- Account.credit [publicParty] foreignCashInstrumentCid secondForeignPaymentAmount investorAccount
+  custodianCashForBasePaymentTransferableCid <- Account.credit [publicParty] cashInstrumentCid secondBasePaymentAmount custodianAccount
+  lifecycleAndVerifyFinalSwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment custodian issuer investor investorSwapTransferableCid investorCashForForeignPaymentTransferableCid custodianCashForBasePaymentTransferableCid custodianAccount investorAccount observers custodian []
 
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/ForeignExchange.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/ForeignExchange.daml
@@ -13,7 +13,7 @@ import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Script
 
--- Calculate fx payments payment on an foreign exchange swap, including lifecycling and creation of new instrument version.
+-- Calculate the fx payments of a foreign exchange swap, including lifecycling and creation of new instrument version.
 run : Script ()
 run = script do
   [custodian, issuer, investor, publicParty] <-

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -6,6 +6,7 @@ module Daml.Finance.Instrument.Swap.Test.Util where
 import DA.Date
 import DA.Map qualified as M
 import DA.Set (empty, singleton)
+import Daml.Finance.Instrument.Swap.ForeignExchange qualified as ForeignExchange (Instrument(..))
 import Daml.Finance.Instrument.Swap.InterestRate qualified as InterestRateSwap (Instrument(..))
 import Daml.Finance.Interface.Holding.Base qualified as Base (I)
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I)
@@ -65,6 +66,16 @@ originateInterestRateSwap depository issuer label description observers lastEven
   cid <- toInterfaceContractId <$> submitMulti [depository, issuer] [] do
     createCmd InterestRateSwap.Instrument with depository; issuer; id = Id label; version = "0"; description; observers = M.fromList observers; lastEventTimestamp; periodicSchedule; holidayCalendarIds; calendarDataProvider; dayCountConvention; issuerPaysFix; fixRate; referenceRateId; currency
   -- CREATE_INTEREST_RATE_SWAP_INSTRUMENT_END
+  createReference cid depository issuer observers
+
+originateForeignExchangeSwap : Party -> Party -> Text -> Text -> [(Text, Parties)] -> Time -> Date -> [Text] -> Party -> Date -> Date -> DayCountConventionEnum -> BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Instrument.K -> Text -> Bool -> Decimal -> Decimal -> Script Instrument.K
+originateForeignExchangeSwap depository issuer label description observers lastEventTimestamp issueDate holidayCalendarIds calendarDataProvider firstPaymentDate maturityDate dayCountConvention businessDayConvention fixRate couponPeriod couponPeriodMultiplier baseCurrency foreignCurrency referenceRateId issuerPaysFix firstFxRate finalFxRate = do
+  let
+    periodicSchedule = createPaymentPeriodicSchedule firstPaymentDate holidayCalendarIds businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate
+  -- CREATE_FOREIGN_EXCHANGE_SWAP_INSTRUMENT_BEGIN
+  cid <- toInterfaceContractId <$> submitMulti [depository, issuer] [] do
+    createCmd ForeignExchange.Instrument with depository; issuer; id = Id label; version = "0"; description; observers = M.fromList observers; lastEventTimestamp; periodicSchedule; firstFxRate; finalFxRate; firstPaymentDate; maturityDate, holidayCalendarIds; calendarDataProvider; dayCountConvention; issuerPaysFix; fixRate; referenceRateId; baseCurrency; foreignCurrency
+  -- CREATE_FOREIGN_EXCHANGE_SWAP_INSTRUMENT_END
   createReference cid depository issuer observers
 
 -- | Lifecycle the instrument as of this date. This is a general function that can be used for both bonds and swaps.

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -68,13 +68,11 @@ originateInterestRateSwap depository issuer label description observers lastEven
   -- CREATE_INTEREST_RATE_SWAP_INSTRUMENT_END
   createReference cid depository issuer observers
 
-originateForeignExchangeSwap : Party -> Party -> Text -> Text -> [(Text, Parties)] -> Time -> Date -> [Text] -> Party -> Date -> Date -> DayCountConventionEnum -> BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Instrument.K -> Text -> Bool -> Decimal -> Decimal -> Script Instrument.K
-originateForeignExchangeSwap depository issuer label description observers lastEventTimestamp issueDate holidayCalendarIds calendarDataProvider firstPaymentDate maturityDate dayCountConvention businessDayConvention fixRate couponPeriod couponPeriodMultiplier baseCurrency foreignCurrency referenceRateId issuerPaysFix firstFxRate finalFxRate = do
-  let
-    periodicSchedule = createPaymentPeriodicSchedule firstPaymentDate holidayCalendarIds businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate
+originateForeignExchangeSwap : Party -> Party -> Text -> Text -> [(Text, Parties)] -> Time -> Date -> Date -> Date -> Instrument.K -> Instrument.K -> Decimal -> Decimal -> Script Instrument.K
+originateForeignExchangeSwap depository issuer label description observers lastEventTimestamp issueDate firstPaymentDate maturityDate baseCurrency foreignCurrency firstFxRate finalFxRate = do
   -- CREATE_FOREIGN_EXCHANGE_SWAP_INSTRUMENT_BEGIN
   cid <- toInterfaceContractId <$> submitMulti [depository, issuer] [] do
-    createCmd ForeignExchange.Instrument with depository; issuer; id = Id label; version = "0"; description; observers = M.fromList observers; lastEventTimestamp; periodicSchedule; firstFxRate; finalFxRate; firstPaymentDate; maturityDate, holidayCalendarIds; calendarDataProvider; dayCountConvention; issuerPaysFix; fixRate; referenceRateId; baseCurrency; foreignCurrency
+    createCmd ForeignExchange.Instrument with depository; issuer; id = Id label; version = "0"; description; observers = M.fromList observers; lastEventTimestamp; firstFxRate; finalFxRate; issueDate; firstPaymentDate; maturityDate, baseCurrency; foreignCurrency
   -- CREATE_FOREIGN_EXCHANGE_SWAP_INSTRUMENT_END
   createReference cid depository issuer observers
 

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -58,6 +58,7 @@ createPaymentPeriodicSchedule firstCouponDate holidayCalendarIds businessDayConv
   -- CREATE_BOND_PERIODIC_SCHEDULE_END
   periodicSchedule
 
+-- | Originate an interest rate swap.
 originateInterestRateSwap : Party -> Party -> Text -> Text -> [(Text, Parties)] -> Time -> Date -> [Text] -> Party -> Date -> Date -> DayCountConventionEnum -> BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Text -> Bool -> Script Instrument.K
 originateInterestRateSwap depository issuer label description observers lastEventTimestamp issueDate holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention businessDayConvention fixRate couponPeriod couponPeriodMultiplier currency referenceRateId issuerPaysFix = do
   let
@@ -68,6 +69,7 @@ originateInterestRateSwap depository issuer label description observers lastEven
   -- CREATE_INTEREST_RATE_SWAP_INSTRUMENT_END
   createReference cid depository issuer observers
 
+-- | Originate an FX swap.
 originateForeignExchangeSwap : Party -> Party -> Text -> Text -> [(Text, Parties)] -> Time -> Date -> Date -> Date -> Instrument.K -> Instrument.K -> Decimal -> Decimal -> Script Instrument.K
 originateForeignExchangeSwap depository issuer label description observers lastEventTimestamp issueDate firstPaymentDate maturityDate baseCurrency foreignCurrency firstFxRate finalFxRate = do
   -- CREATE_FOREIGN_EXCHANGE_SWAP_INSTRUMENT_BEGIN


### PR DESCRIPTION
I have implemented a first version of foreign exchange swaps. This is a fairly simple kind of swap, consisting of only two FX transactions (i.e. no periodic interest rate payments), so I could get rid of the PeriodicSchedule structure.

There are a few potential improvements to the contingent claims utility functions for swaps/bonds that I plan to implement as part of a separate PR. They are tracked in this issue for now: https://github.com/digital-asset/daml-finance/issues/149

Regarding documentation: I plan to add a swaps tutorial once we have a few more payoffs.