### PR TITLE
Implement credit default swaps

### DIFF
--- a/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate.daml
@@ -67,9 +67,9 @@ template Instrument
         let
           useAdjustedDatesForDcf = True
           weightMultiplier = 1.0
-        couponClaims <- createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf couponRate weightMultiplier dayCountConvention currency
-        redemptionClaim <- createRedemptionClaim currency periodicSchedule.terminationDate
-        pure $ mconcat [couponClaims, redemptionClaim]
+          couponClaims = createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf couponRate weightMultiplier dayCountConvention currency
+          redemptionClaim = createRedemptionClaim currency periodicSchedule.terminationDate
+        pure $ [couponClaims, redemptionClaim]
     -- FIXED_RATE_BOND_CLAIMS_END
 
     interface instance Instrument.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate.daml
@@ -70,9 +70,9 @@ template Instrument
         let
           useAdjustedDatesForDcf = True
           weightMultiplier = 1.0
-        couponClaims <- createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf couponSpread weightMultiplier dayCountConvention currency referenceRateId
-        redemptionClaim <- createRedemptionClaim currency periodicSchedule.terminationDate
-        pure $ mconcat [couponClaims, redemptionClaim]
+          couponClaims = createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf couponSpread weightMultiplier dayCountConvention currency referenceRateId
+          redemptionClaim = createRedemptionClaim currency periodicSchedule.terminationDate
+        pure $ [couponClaims, redemptionClaim]
 
     interface instance Instrument.I for Instrument where
       asDisclosure = toInterface @Disclosure.I this

--- a/src/main/daml/Daml/Finance/Instrument/Bond/InflationLinked.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/InflationLinked.daml
@@ -96,9 +96,9 @@ template Instrument
           -- add the redemption claim
           redemptionClaim = when (TimeGte $ periodicSchedule.terminationDate) $ cond deflation deflationClaim inflationClaim
 
-        couponClaimsTagged <- prepareAndTagClaims couponClaims "Coupon"
-        redemptionClaimTagged <- prepareAndTagClaims [redemptionClaim] "Redemption"
-        pure $ mconcat [couponClaimsTagged, redemptionClaimTagged]
+          couponClaimsTagged = prepareAndTagClaims couponClaims "Coupon"
+          redemptionClaimTagged = prepareAndTagClaims [redemptionClaim] "Redemption"
+        pure $ [couponClaimsTagged, redemptionClaimTagged]
 
     interface instance Instrument.I for Instrument where
       asDisclosure = toInterface @Disclosure.I this

--- a/src/main/daml/Daml/Finance/Instrument/Bond/ZeroCoupon.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/ZeroCoupon.daml
@@ -54,7 +54,7 @@ template Instrument
           acquisitionTime = dateToDateClockTime issueDate
       getClaims = do
         -- get the initial claims tree (as of the bond's acquisition time)
-        createRedemptionClaim currency maturityDate
+        pure $ [createRedemptionClaim currency maturityDate]
 
     interface instance Instrument.I for Instrument where
       asDisclosure = toInterface @Disclosure.I this

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
@@ -79,8 +79,6 @@ createCreditEventPaymentClaims weightMultiplier cashInstrumentCid defaultProbabi
   let
     creditEvent = Lte (Const 1.0, Observe defaultProbabilityReferenceId)
     payoff = scale (Const weightMultiplier * (Const 1.0 - Observe recoveryRateReferenceId)) $ one cashInstrumentCid
-    --creditEventClaims = [until (TimeGte $ periodicSchedule.terminationDate) $ until creditEvent $ when (TimeGte $ periodicSchedule.effectiveDate) $ when creditEvent $ payoff]
-    --creditEventClaims = [when (TimeGte $ periodicSchedule.effectiveDate) $ until (TimeGte $ periodicSchedule.terminationDate) $ when creditEvent $ until creditEvent $ payoff]
     creditEventClaims = [when (TimeGte $ periodicSchedule.effectiveDate) $ until (TimeGte $ periodicSchedule.terminationDate) $ when creditEvent $ payoff]
   prepareAndTagClaims creditEventClaims "Credit event payment"
 

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
@@ -79,7 +79,7 @@ createCreditEventPaymentClaims weightMultiplier cashInstrumentCid defaultProbabi
   let
     creditEvent = Lte (Const 1.0, Observe defaultProbabilityReferenceId)
     payoff = scale (Const weightMultiplier * (Const 1.0 - Observe recoveryRateReferenceId)) $ one cashInstrumentCid
-    creditEventClaims = [when (TimeGte $ periodicSchedule.effectiveDate) $ until (TimeGte $ periodicSchedule.terminationDate) $ when creditEvent $ payoff]
+    creditEventClaims = [when (TimeGte $ periodicSchedule.effectiveDate) $ until (TimeGte $ periodicSchedule.terminationDate) $ when creditEvent payoff]
   prepareAndTagClaims creditEventClaims "Credit event payment"
 
 -- FLOATING_RATE_BOND_COUPON_CLAIMS_BEGIN

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
@@ -3,7 +3,7 @@
 
 module Daml.Finance.Instrument.Generic.Util where
 
-import ContingentClaims.Claim (Claim(..), Inequality(..), one, scale, when)
+import ContingentClaims.Claim (Claim(..), Inequality(..), one, scale, when, until)
 import ContingentClaims.Observation (Observation(..))
 import DA.Date
 import DA.Record (HasField)
@@ -61,6 +61,26 @@ createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf coup
     couponClaims = zipWith (\d a -> when (TimeGte $ d) $ scale (Const weightMultiplier * Const a) $ one cashInstrumentCid) couponDatesAdjusted couponAmounts
   prepareAndTagClaims couponClaims "Fix rate payment"
 -- FIXED_RATE_BOND_COUPON_CLAIMS_END
+
+-- | Calculate a fix rate amount (if a credit event has not yet happened) for each payment date and create claims.
+createConditionalCreditFixRatePaymentClaims : Applicative f => [SchedulePeriod] -> PeriodicSchedule -> Bool -> Decimal -> Decimal -> DayCountConventionEnum -> Deliverable -> Observable -> f [TaggedClaim]
+createConditionalCreditFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf couponRate weightMultiplier dayCountConvention cashInstrumentCid defaultProbabilityReferenceId = do
+  let
+    creditEvent = Lte (Const 1.0, Observe defaultProbabilityReferenceId)
+    couponDatesAdjusted = map (.adjustedEndDate) schedule
+    couponAmounts = map (\p -> couponRate * (calcPeriodDcf dayCountConvention p useAdjustedDatesForDcf periodicSchedule.terminationDate periodicSchedule.frequency)) schedule
+    couponClaims = zipWith (\d a -> until creditEvent $ when (TimeGte $ d) $ scale (Const weightMultiplier * Const a) $ one cashInstrumentCid) couponDatesAdjusted couponAmounts
+  prepareAndTagClaims couponClaims "Fix rate payment (unless credit event has occurred)"
+
+-- | Calculate a (1-recoveryRate) payment if a credit event just happened and create claims.
+createCreditEventPaymentClaims : Applicative f => Decimal -> Deliverable -> Observable -> Observable -> Date -> f [TaggedClaim]
+createCreditEventPaymentClaims weightMultiplier cashInstrumentCid defaultProbabilityReferenceId recoveryRateReferenceId issueDate = do
+  let
+    creditEvent = Lte (Const 1.0, Observe defaultProbabilityReferenceId)
+    payoff = scale (Const weightMultiplier * (Const 1.0 - Observe recoveryRateReferenceId)) $ one cashInstrumentCid
+    creditEventClaims = [until creditEvent $ when (TimeGte $ issueDate) $ when creditEvent $ payoff]
+    -- todo: add check that instrument is not expired (passed expiry date)
+  prepareAndTagClaims creditEventClaims "Credit event payment"
 
 -- FLOATING_RATE_BOND_COUPON_CLAIMS_BEGIN
 -- | Calculate a floating rate amount for each payment date and create claims.
@@ -137,6 +157,7 @@ processClockUpdate settler eventCid _ self instrument observableCids = do
   -- BOND_PROCESS_CLOCK_UPDATE_LIFECYCLE_BEGIN
   -- Lifecycle
   (remaining, pending) <- lifecycleClaims observableCids acquisitionTime claims [timeEvent v.eventTime]
+  debug remaining
   let (consumed, produced) = splitPending pending
   if remaining == claims && null pending then
     pure (self, [])

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
@@ -156,7 +156,6 @@ processClockUpdate settlers eventCid _ self instrument observableCids = do
   -- BOND_PROCESS_CLOCK_UPDATE_LIFECYCLE_BEGIN
   -- Lifecycle
   (remaining, pending) <- lifecycleClaims observableCids acquisitionTime claims [timeEvent v.eventTime]
-  debug remaining
   let (consumed, produced) = splitPending pending
   if remaining == claims && null pending then
     pure (self, [])

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
@@ -73,13 +73,12 @@ createConditionalCreditFixRatePaymentClaims schedule periodicSchedule useAdjuste
   prepareAndTagClaims couponClaims "Fix rate payment (unless credit event has occurred)"
 
 -- | Calculate a (1-recoveryRate) payment if a credit event just happened and create claims.
-createCreditEventPaymentClaims : Applicative f => Decimal -> Deliverable -> Observable -> Observable -> Date -> f [TaggedClaim]
-createCreditEventPaymentClaims weightMultiplier cashInstrumentCid defaultProbabilityReferenceId recoveryRateReferenceId issueDate = do
+createCreditEventPaymentClaims : Applicative f => Decimal -> Deliverable -> Observable -> Observable -> PeriodicSchedule -> f [TaggedClaim]
+createCreditEventPaymentClaims weightMultiplier cashInstrumentCid defaultProbabilityReferenceId recoveryRateReferenceId periodicSchedule = do
   let
     creditEvent = Lte (Const 1.0, Observe defaultProbabilityReferenceId)
     payoff = scale (Const weightMultiplier * (Const 1.0 - Observe recoveryRateReferenceId)) $ one cashInstrumentCid
-    creditEventClaims = [until creditEvent $ when (TimeGte $ issueDate) $ when creditEvent $ payoff]
-    -- todo: add check that instrument is not expired (passed expiry date)
+    creditEventClaims = [until (TimeGte $ periodicSchedule.terminationDate) $ until creditEvent $ when (TimeGte $ periodicSchedule.effectiveDate) $ when creditEvent $ payoff]
   prepareAndTagClaims creditEventClaims "Credit event payment"
 
 -- FLOATING_RATE_BOND_COUPON_CLAIMS_BEGIN

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
@@ -80,7 +80,8 @@ createCreditEventPaymentClaims weightMultiplier cashInstrumentCid defaultProbabi
     creditEvent = Lte (Const 1.0, Observe defaultProbabilityReferenceId)
     payoff = scale (Const weightMultiplier * (Const 1.0 - Observe recoveryRateReferenceId)) $ one cashInstrumentCid
     --creditEventClaims = [until (TimeGte $ periodicSchedule.terminationDate) $ until creditEvent $ when (TimeGte $ periodicSchedule.effectiveDate) $ when creditEvent $ payoff]
-    creditEventClaims = [when (TimeGte $ periodicSchedule.effectiveDate) $ until (TimeGte $ periodicSchedule.terminationDate) $ when creditEvent $ until creditEvent $ payoff]
+    --creditEventClaims = [when (TimeGte $ periodicSchedule.effectiveDate) $ until (TimeGte $ periodicSchedule.terminationDate) $ when creditEvent $ until creditEvent $ payoff]
+    creditEventClaims = [when (TimeGte $ periodicSchedule.effectiveDate) $ until (TimeGte $ periodicSchedule.terminationDate) $ when creditEvent $ payoff]
   prepareAndTagClaims creditEventClaims "Credit event payment"
 
 -- FLOATING_RATE_BOND_COUPON_CLAIMS_BEGIN

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
@@ -69,8 +69,9 @@ createConditionalCreditFixRatePaymentClaims schedule periodicSchedule useAdjuste
     creditEvent = Lte (Const 1.0, Observe defaultProbabilityReferenceId)
     couponDatesAdjusted = map (.adjustedEndDate) schedule
     couponAmounts = map (\p -> couponRate * (calcPeriodDcf dayCountConvention p useAdjustedDatesForDcf periodicSchedule.terminationDate periodicSchedule.frequency)) schedule
-    couponClaims = zipWith (\d a -> until creditEvent $ when (TimeGte $ d) $ scale (Const weightMultiplier * Const a) $ one cashInstrumentCid) couponDatesAdjusted couponAmounts
-  prepareAndTagClaims couponClaims "Fix rate payment (unless credit event has occurred)"
+    couponClaims = zipWith (\d a -> when (TimeGte $ d) $ scale (Const weightMultiplier * Const a) $ one cashInstrumentCid) couponDatesAdjusted couponAmounts
+    couponClaimsUntilCreditEvent = [until creditEvent $ mconcat couponClaims]
+  prepareAndTagClaims couponClaimsUntilCreditEvent "Fix rate payment (unless credit event has occurred)"
 
 -- | Calculate a (1-recoveryRate) payment if a credit event just happened and create claims.
 createCreditEventPaymentClaims : Applicative f => Decimal -> Deliverable -> Observable -> Observable -> PeriodicSchedule -> f [TaggedClaim]
@@ -78,7 +79,8 @@ createCreditEventPaymentClaims weightMultiplier cashInstrumentCid defaultProbabi
   let
     creditEvent = Lte (Const 1.0, Observe defaultProbabilityReferenceId)
     payoff = scale (Const weightMultiplier * (Const 1.0 - Observe recoveryRateReferenceId)) $ one cashInstrumentCid
-    creditEventClaims = [until (TimeGte $ periodicSchedule.terminationDate) $ until creditEvent $ when (TimeGte $ periodicSchedule.effectiveDate) $ when creditEvent $ payoff]
+    --creditEventClaims = [until (TimeGte $ periodicSchedule.terminationDate) $ until creditEvent $ when (TimeGte $ periodicSchedule.effectiveDate) $ when creditEvent $ payoff]
+    creditEventClaims = [when (TimeGte $ periodicSchedule.effectiveDate) $ until (TimeGte $ periodicSchedule.terminationDate) $ when creditEvent $ until creditEvent $ payoff]
   prepareAndTagClaims creditEventClaims "Credit event payment"
 
 -- FLOATING_RATE_BOND_COUPON_CLAIMS_BEGIN

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
@@ -46,14 +46,14 @@ rollPaymentSchedule periodicSchedule holidayCalendarIds issuer calendarDataAgenc
   pure $ createSchedule cals periodicSchedule
 
 -- | Convert the claims to UTCTime and tag them.
-prepareAndTagClaims : Applicative f => [Claim Date Decimal Deliverable Observable] -> Text -> f [TaggedClaim]
+prepareAndTagClaims : [Claim Date Decimal Deliverable Observable] -> Text -> TaggedClaim
 prepareAndTagClaims cs tag = do
   let claim = mapClaimToUTCTime $ mconcat cs
-  pure [TaggedClaim with tag; claim]
+  TaggedClaim with tag; claim
 
 -- FIXED_RATE_BOND_COUPON_CLAIMS_BEGIN
 -- | Calculate a fix rate amount for each payment date and create claims.
-createFixRatePaymentClaims : Applicative f => [SchedulePeriod] -> PeriodicSchedule -> Bool -> Decimal -> Decimal -> DayCountConventionEnum -> Deliverable -> f [TaggedClaim]
+createFixRatePaymentClaims : [SchedulePeriod] -> PeriodicSchedule -> Bool -> Decimal -> Decimal -> DayCountConventionEnum -> Deliverable -> TaggedClaim
 createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf couponRate weightMultiplier dayCountConvention cashInstrumentCid = do
   let
     couponDatesAdjusted = map (.adjustedEndDate) schedule
@@ -63,7 +63,7 @@ createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf coup
 -- FIXED_RATE_BOND_COUPON_CLAIMS_END
 
 -- | Calculate a fix rate amount (if a credit event has not yet happened) for each payment date and create claims.
-createConditionalCreditFixRatePaymentClaims : Applicative f => [SchedulePeriod] -> PeriodicSchedule -> Bool -> Decimal -> Decimal -> DayCountConventionEnum -> Deliverable -> Observable -> f [TaggedClaim]
+createConditionalCreditFixRatePaymentClaims : [SchedulePeriod] -> PeriodicSchedule -> Bool -> Decimal -> Decimal -> DayCountConventionEnum -> Deliverable -> Observable -> TaggedClaim
 createConditionalCreditFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf couponRate weightMultiplier dayCountConvention cashInstrumentCid defaultProbabilityReferenceId = do
   let
     creditEvent = Lte (Const 1.0, Observe defaultProbabilityReferenceId)
@@ -74,7 +74,7 @@ createConditionalCreditFixRatePaymentClaims schedule periodicSchedule useAdjuste
   prepareAndTagClaims couponClaimsUntilCreditEvent "Fix rate payment (unless credit event has occurred)"
 
 -- | Calculate a (1-recoveryRate) payment if a credit event just happened and create claims.
-createCreditEventPaymentClaims : Applicative f => Decimal -> Deliverable -> Observable -> Observable -> PeriodicSchedule -> f [TaggedClaim]
+createCreditEventPaymentClaims : Decimal -> Deliverable -> Observable -> Observable -> PeriodicSchedule -> TaggedClaim
 createCreditEventPaymentClaims weightMultiplier cashInstrumentCid defaultProbabilityReferenceId recoveryRateReferenceId periodicSchedule = do
   let
     creditEvent = Lte (Const 1.0, Observe defaultProbabilityReferenceId)
@@ -87,7 +87,7 @@ createCreditEventPaymentClaims weightMultiplier cashInstrumentCid defaultProbabi
 -- The floating rate is always observed on the first day of each payment period and used for the corresponding payment on the last day of that payment period.
 -- This means that the calculation agent needs to provide such an Observable, irrespective of
 -- the kind of reference rate used (e.g. a forward looking LIBOR or a backward looking SOFR-COMPOUND).
-createFloatingRatePaymentClaims : Applicative f => [SchedulePeriod] -> PeriodicSchedule -> Bool -> Decimal -> Decimal -> DayCountConventionEnum -> Deliverable -> Observable -> f [TaggedClaim]
+createFloatingRatePaymentClaims : [SchedulePeriod] -> PeriodicSchedule -> Bool -> Decimal -> Decimal -> DayCountConventionEnum -> Deliverable -> Observable -> TaggedClaim
 createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf floatingRateSpread weightMultiplier dayCountConvention cashInstrumentCid referenceRateId = do
   let
     couponClaims = map (\p ->
@@ -98,14 +98,14 @@ createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf
 
 -- FIXED_RATE_BOND_REDEMPTION_CLAIM_BEGIN
 -- | Create a redemption claim.
-createRedemptionClaim : Applicative f => Deliverable -> Date -> f [TaggedClaim]
+createRedemptionClaim : Deliverable -> Date -> TaggedClaim
 createRedemptionClaim cashInstrumentCid maturityDate = do
   let redemptionClaim = [when (TimeGte $ maturityDate) $ one cashInstrumentCid]
   prepareAndTagClaims redemptionClaim "Redemption payment"
 -- FIXED_RATE_BOND_REDEMPTION_CLAIM_END
 
 -- | Create an FX leg claim.
-createFxLegPrincipalClaim : Applicative f => Decimal -> Decimal -> Deliverable -> Date -> f [TaggedClaim]
+createFxLegPrincipalClaim : Decimal -> Decimal -> Deliverable -> Date -> TaggedClaim
 createFxLegPrincipalClaim weightMultiplier fxRateMultiplier cashInstrumentCid valueDate = do
   let fxLegClaim = [when (TimeGte $ valueDate) $ scale (Const weightMultiplier * Const fxRateMultiplier) $ one cashInstrumentCid]
   prepareAndTagClaims fxLegClaim "FX leg payment"

--- a/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault.daml
@@ -1,0 +1,144 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Daml.Finance.Instrument.Swap.CreditDefault where
+
+import DA.Set (singleton)
+import Daml.Finance.Instrument.Generic.Util
+import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, View(..))
+import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (GetCid(..), HasImplementation, I, K, R, View(..), createReference, disclosureUpdateReference)
+import Daml.Finance.Interface.Instrument.Swap.CreditDefault qualified as CreditDefaultSwap (Create(..), Factory, HasImplementation, Remove(..), View(..))
+import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Evolve(..), View(..))
+import Daml.Finance.Interface.Types.Common (Id(..), InstrumentKey(..), PartiesMap)
+import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
+import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..))
+import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, SetObservers(..), View(..), flattenObservers)
+import Prelude hiding (key)
+
+-- | Type synonym for `Instrument`.
+type T = Instrument
+
+instance Instrument.HasImplementation T
+
+-- | This template models a credit default swap.
+-- In case of a credit default event it pays (1-recoveryRate), in exchange for a fix rate at the end of every payment period.
+-- For example: 2.5% fix vs (1-recoveryRate) if TSLA defaults on a bond payment
+template Instrument
+  with
+    depository : Party
+      -- ^ The depository of the instrument.
+    issuer : Party
+      -- ^ The issuer of the instrument.
+    id : Id
+      -- ^ An identifier of the instrument.
+    version : Text
+      -- ^ The instrument's version.
+    description : Text
+      -- ^ A description of the instrument.
+    defaultProbabilityReferenceId : Text
+      -- ^ The reference ID of the default probability observable. For example, in case of protection against a "TSLA a bond payment default" this should be a valid reference to the "TSLA default probability".
+    recoveryRateReferenceId : Text
+      -- ^ The reference ID of the recovery rate observable. For example, in case of a "TSLA a bond payment default with a 60% recovery rate" this should be a valid reference to the "TSLA bond recovery rate".
+    issuerPaysFix : Bool
+      -- ^ Indicate whether the issuer of the instrument pays the fix rate leg or the default protection leg of the swap.
+    fixRate : Decimal
+      -- ^ The interest rate of the fix leg. For example, in case of "2.5% fix" this should be 0.025.
+    periodicSchedule : PeriodicSchedule
+      -- ^ The schedule for the periodic swap payments.
+    holidayCalendarIds : [Text]
+      -- ^ The identifier of the holiday calendar to be used for the swap payment schedule.
+    calendarDataProvider : Party
+      -- ^ The reference data provider to use for the holiday calendar.
+    dayCountConvention : DayCountConventionEnum
+      -- ^ The day count convention used to calculate day count fractions. For example: Act360.
+    currency : Instrument.K
+      -- ^ The currency of the swap. For example, if the swap pays in USD this should be a USD cash instrument.
+    observers : PartiesMap
+      -- ^ The observers of the instrument.
+    lastEventTimestamp : Time
+      -- ^ (Market) time of the last recorded lifecycle event. If no event has occurred yet, the time of creation should be used.
+  where
+    signatory depository, issuer
+    observer Disclosure.flattenObservers observers
+
+    let instrumentKey = InstrumentKey with depository; issuer; id; version
+
+    interface instance Claim.I for Instrument where
+      view = Claim.View with acquisitionTime = dateToDateClockTime periodicSchedule.effectiveDate
+      getClaims = do
+        -- get the initial claims tree (as of the swap's acquisition time)
+        schedule <- rollPaymentSchedule periodicSchedule holidayCalendarIds issuer calendarDataProvider
+        let
+          useAdjustedDatesForDcf = True
+          fixLegWeight = if issuerPaysFix then 1.0 else -1.0
+          creditLegWeight = -fixLegWeight
+        fixClaims <- createConditionalCreditFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf fixRate fixLegWeight dayCountConvention currency defaultProbabilityReferenceId
+        creditDefaultClaims <- createCreditEventPaymentClaims creditLegWeight currency defaultProbabilityReferenceId recoveryRateReferenceId periodicSchedule.effectiveDate
+        pure $ mconcat [fixClaims, creditDefaultClaims]
+
+    interface instance Instrument.I for Instrument where
+      asDisclosure = toInterface @Disclosure.I this
+      view = Instrument.View with depository; issuer; id; version; description; validAsOf = lastEventTimestamp
+      getKey = instrumentKey
+
+    interface instance Lifecycle.I for Instrument where
+      view = Lifecycle.View with lifecycler = issuer
+      evolve Lifecycle.Evolve{ruleName; settler; eventCid; clockCid; observableCids} self =
+        case ruleName of
+          "Time" -> processClockUpdate settler eventCid clockCid self this observableCids
+          other -> abort $ "Unknown lifecycle rule " <> other
+
+    interface instance Disclosure.I for Instrument where
+      view = Disclosure.View with disclosureControllers = singleton issuer; observers
+      setObservers Disclosure.SetObservers{newObservers} = do
+        cid <- toInterfaceContractId <$> create this with observers = newObservers
+        Instrument.disclosureUpdateReference newObservers instrumentKey cid
+      archive' self = archive (coerceContractId self : ContractId Instrument)
+
+instance CreditDefaultSwap.HasImplementation Factory
+
+-- | Factory template for instrument creation.
+template Factory
+  with
+    provider : Party
+      -- ^ The factory's provider.
+    observers : PartiesMap
+      -- ^ The factory's observers.
+  where
+    signatory provider
+    observer Disclosure.flattenObservers observers
+
+    interface instance CreditDefaultSwap.Factory for Factory where
+      asDisclosure = toInterface @Disclosure.I this
+      view = CreditDefaultSwap.View with provider
+      create' CreditDefaultSwap.Create{instrument; description; defaultProbabilityReferenceId; recoveryRateReferenceId; issuerPaysFix; fixRate; periodicSchedule; holidayCalendarIds; calendarDataProvider; dayCountConvention; currency; lastEventTimestamp; observers} = do
+        cid <- toInterfaceContractId <$> create Instrument
+          with
+            depository = instrument.depository
+            issuer = instrument.issuer
+            issuerPaysFix
+            id = instrument.id
+            version = instrument.version
+            description
+            defaultProbabilityReferenceId
+            recoveryRateReferenceId
+            fixRate
+            periodicSchedule
+            holidayCalendarIds
+            calendarDataProvider
+            dayCountConvention
+            currency
+            lastEventTimestamp
+            observers
+        Instrument.createReference instrument.depository cid
+        pure cid
+      remove CreditDefaultSwap.Remove{instrument} = do
+        (refCid, ref) <- fetchByKey @Instrument.R instrument
+        instrumentCid <- exercise refCid Instrument.GetCid with viewer = instrument.depository
+        archive $ fromInterfaceContractId @Instrument instrumentCid
+        archive refCid
+
+    interface instance Disclosure.I for Factory where
+      view = Disclosure.View with disclosureControllers = singleton provider; observers
+      setObservers Disclosure.SetObservers{newObservers} = toInterfaceContractId <$> create this with observers = newObservers
+      archive' self = archive (coerceContractId self : ContractId Instrument)

--- a/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault.daml
@@ -83,9 +83,9 @@ template Instrument
 
     interface instance Lifecycle.I for Instrument where
       view = Lifecycle.View with lifecycler = issuer
-      evolve Lifecycle.Evolve{ruleName; settler; eventCid; clockCid; observableCids} self =
+      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; clockCid; observableCids} self =
         case ruleName of
-          "Time" -> processClockUpdate settler eventCid clockCid self this observableCids
+          "Time" -> processClockUpdate settlers eventCid clockCid self this observableCids
           other -> abort $ "Unknown lifecycle rule " <> other
 
     interface instance Disclosure.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault.daml
@@ -73,7 +73,7 @@ template Instrument
           fixLegWeight = if issuerPaysFix then 1.0 else -1.0
           creditLegWeight = -fixLegWeight
         fixClaims <- createConditionalCreditFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf fixRate fixLegWeight dayCountConvention currency defaultProbabilityReferenceId
-        creditDefaultClaims <- createCreditEventPaymentClaims creditLegWeight currency defaultProbabilityReferenceId recoveryRateReferenceId periodicSchedule.effectiveDate
+        creditDefaultClaims <- createCreditEventPaymentClaims creditLegWeight currency defaultProbabilityReferenceId recoveryRateReferenceId periodicSchedule
         pure $ mconcat [fixClaims, creditDefaultClaims]
 
     interface instance Instrument.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault.daml
@@ -20,7 +20,7 @@ type T = Instrument
 
 instance Instrument.HasImplementation T
 
--- | This template models a credit default swap.
+-- | This template models a cash-settled credit default swap.
 -- In case of a credit default event it pays (1-recoveryRate), in exchange for a fix rate at the end of every payment period.
 -- For example: 2.5% fix vs (1-recoveryRate) if TSLA defaults on a bond payment
 template Instrument

--- a/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault.daml
@@ -72,9 +72,9 @@ template Instrument
           useAdjustedDatesForDcf = True
           fixLegWeight = if issuerPaysFix then 1.0 else -1.0
           creditLegWeight = -fixLegWeight
-        fixClaims <- createConditionalCreditFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf fixRate fixLegWeight dayCountConvention currency defaultProbabilityReferenceId
-        creditDefaultClaims <- createCreditEventPaymentClaims creditLegWeight currency defaultProbabilityReferenceId recoveryRateReferenceId periodicSchedule
-        pure $ mconcat [fixClaims, creditDefaultClaims]
+          fixClaims = createConditionalCreditFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf fixRate fixLegWeight dayCountConvention currency defaultProbabilityReferenceId
+          creditDefaultClaims = createCreditEventPaymentClaims creditLegWeight currency defaultProbabilityReferenceId recoveryRateReferenceId periodicSchedule
+        pure $ [fixClaims, creditDefaultClaims]
 
     interface instance Instrument.I for Instrument where
       asDisclosure = toInterface @Disclosure.I this

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Currency.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Currency.daml
@@ -79,9 +79,9 @@ template Instrument
           baseLegWeight = if issuerPaysBase then 1.0 else -1.0
           foreignLegWeight = -baseLegWeight
           foreignRateInclFxPrincipalAdjustmentFactor = foreignRate * fxRate
-        baseLegClaims <- createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf baseRate baseLegWeight dayCountConvention baseCurrency
-        foreignLegClaims <- createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf foreignRateInclFxPrincipalAdjustmentFactor foreignLegWeight dayCountConvention foreignCurrency
-        pure $ mconcat [baseLegClaims, foreignLegClaims]
+          baseLegClaims = createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf baseRate baseLegWeight dayCountConvention baseCurrency
+          foreignLegClaims = createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf foreignRateInclFxPrincipalAdjustmentFactor foreignLegWeight dayCountConvention foreignCurrency
+        pure $ [baseLegClaims, foreignLegClaims]
 
     interface instance Instrument.I for Instrument where
       asDisclosure = toInterface @Disclosure.I this

--- a/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange.daml
@@ -63,11 +63,12 @@ template Instrument
       view = Claim.View with acquisitionTime = dateToDateClockTime issueDate
       getClaims = do
         -- get the initial claims tree (as of the swap's acquisition time)
-        baseCurrencyFirstPayment <- createFxLegPrincipalClaim (-1.0) 1.0 baseCurrency firstPaymentDate
-        foreignCurrencyFirstPayment <- createFxLegPrincipalClaim 1.0 firstFxRate foreignCurrency firstPaymentDate
-        baseCurrencyFinalPayment <- createFxLegPrincipalClaim 1.0 1.0 baseCurrency maturityDate
-        foreignCurrencyFinalPayment <- createFxLegPrincipalClaim (-1.0) finalFxRate foreignCurrency maturityDate
-        pure $ mconcat [baseCurrencyFirstPayment, foreignCurrencyFirstPayment, baseCurrencyFinalPayment, foreignCurrencyFinalPayment]
+        let
+          baseCurrencyFirstPayment = createFxLegPrincipalClaim (-1.0) 1.0 baseCurrency firstPaymentDate
+          foreignCurrencyFirstPayment = createFxLegPrincipalClaim 1.0 firstFxRate foreignCurrency firstPaymentDate
+          baseCurrencyFinalPayment = createFxLegPrincipalClaim 1.0 1.0 baseCurrency maturityDate
+          foreignCurrencyFinalPayment = createFxLegPrincipalClaim (-1.0) finalFxRate foreignCurrency maturityDate
+        pure $ [baseCurrencyFirstPayment, foreignCurrencyFirstPayment, baseCurrencyFinalPayment, foreignCurrencyFinalPayment]
 
     interface instance Instrument.I for Instrument where
       asDisclosure = toInterface @Disclosure.I this

--- a/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate.daml
@@ -71,9 +71,9 @@ template Instrument
           useAdjustedDatesForDcf = True
           fixLegWeight = if issuerPaysFix then 1.0 else -1.0
           floatingLegWeight = -fixLegWeight
-        fixClaims <- createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf fixRate fixLegWeight dayCountConvention currency
-        floatingClaims <- createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf 0.0 floatingLegWeight dayCountConvention currency referenceRateId
-        pure $ mconcat [fixClaims, floatingClaims]
+          fixClaims = createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf fixRate fixLegWeight dayCountConvention currency
+          floatingClaims = createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf 0.0 floatingLegWeight dayCountConvention currency referenceRateId
+        pure $ [fixClaims, floatingClaims]
 
     interface instance Instrument.I for Instrument where
       asDisclosure = toInterface @Disclosure.I this

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/CreditDefault.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/CreditDefault.daml
@@ -22,7 +22,7 @@ data View = View
       -- ^ The provider of the `Factory`.
   deriving (Eq, Ord, Show)
 
--- | Interface that allows implementing templates to create interest rate swaps.
+-- | Interface that allows implementing templates to create credit default swaps.
 interface Factory where
   viewtype V
 

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/CreditDefault.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/CreditDefault.daml
@@ -1,0 +1,82 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Daml.Finance.Interface.Instrument.Swap.CreditDefault where
+
+import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (I, K)
+import Daml.Finance.Interface.Types.Common (InstrumentKey(..), PartiesMap)
+import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
+import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..))
+import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, Implementation)
+
+-- | Type synonym for `Factory`.
+type F = Factory
+
+-- | Type synonym for `View`.
+type V = View
+
+-- | View of `Factory`.
+data View = View
+  with
+    provider : Party
+      -- ^ The provider of the `Factory`.
+  deriving (Eq, Ord, Show)
+
+-- | Interface that allows implementing templates to create interest rate swaps.
+interface Factory where
+  viewtype V
+
+  asDisclosure : Disclosure.I
+    -- ^ Conversion to `Disclosure` interface.
+  create' : Create -> Update (ContractId Instrument.I)
+    -- ^ Implementation of `Create` choice.
+  remove : Remove -> Update ()
+    -- ^ Implementation of `Remove` choice.
+
+  nonconsuming choice Create : ContractId Instrument.I
+    -- ^ Create a new instrument.
+    with
+      instrument : InstrumentKey
+        -- ^ The instrument's key.
+      description : Text
+        -- ^ The description of the swap.
+      defaultProbabilityReferenceId : Text
+        -- ^ The reference ID of the default probability observable. For example, in case of protection against a "TSLA a bond payment default" this should be a valid reference to the "TSLA default probability".
+      recoveryRateReferenceId : Text
+        -- ^ The reference ID of the recovery rate observable. For example, in case of a "TSLA a bond payment default with a 60% recovery rate" this should be a valid reference to the "TSLA bond recovery rate".
+      issuerPaysFix : Bool
+        -- ^ Indicate whether the issuer of the instrument pays the fix or the floating leg of the swap.
+      fixRate : Decimal
+        -- ^ The interest rate of the fix leg. For example, in case of "3M Euribor vs 2.5% fix" this should be 0.025.
+      periodicSchedule : PeriodicSchedule
+        -- ^ The schedule for the periodic swap payments.
+      holidayCalendarIds : [Text]
+        -- ^ The identifier of the holiday calendar to be used for the swap payment schedule.
+      calendarDataProvider : Party
+        -- ^ The reference data provider to use for the holiday calendar.
+      dayCountConvention : DayCountConventionEnum
+        -- ^ The day count convention used to calculate day count fractions. For example: Act360.
+      currency : Instrument.K
+        -- ^ The currency of the swap. For example, if the swap pays in USD this should be a USD cash instrument.
+      lastEventTimestamp : Time
+        -- ^ (Market) time of the last recorded lifecycle event. If no event has occurred yet, the time of creation should be used.
+      observers : PartiesMap
+        -- ^ The instrument's observers.
+    controller instrument.depository, instrument.issuer
+    do
+      create' this arg
+
+  nonconsuming choice Remove : ()
+    -- ^ Archive an instrument.
+    with
+      instrument : InstrumentKey
+        -- ^ The instrument's key.
+    controller instrument.depository, instrument.issuer
+      do
+        remove this arg
+
+-- | Type constraint for requiring templates to implement `Factory` along with `Disclosure`.
+type Implementation t = (HasToInterface t Factory, Disclosure.Implementation t)
+instance HasToInterface Factory Disclosure.I where _toInterface = asDisclosure
+class (Implementation t) => HasImplementation t
+instance HasImplementation Factory

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/CreditDefault.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/CreditDefault.daml
@@ -45,9 +45,9 @@ interface Factory where
       recoveryRateReferenceId : Text
         -- ^ The reference ID of the recovery rate observable. For example, in case of a "TSLA a bond payment default with a 60% recovery rate" this should be a valid reference to the "TSLA bond recovery rate".
       issuerPaysFix : Bool
-        -- ^ Indicate whether the issuer of the instrument pays the fix or the floating leg of the swap.
+        -- ^ Indicate whether the issuer of the instrument pays the fix rate leg or the default protection leg of the swap.
       fixRate : Decimal
-        -- ^ The interest rate of the fix leg. For example, in case of "3M Euribor vs 2.5% fix" this should be 0.025.
+        -- ^ The interest rate of the fix leg. For example, in case of "2.5% fix" this should be 0.025.
       periodicSchedule : PeriodicSchedule
         -- ^ The schedule for the periodic swap payments.
       holidayCalendarIds : [Text]

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/ZeroCoupon.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/ZeroCoupon.daml
@@ -86,7 +86,7 @@ run = script do
   -- Distribute commercial-bank cash
   now <- getTime
   let observers = [("PublicParty", singleton publicParty)]
-  cashInstrumentCid <- Instrument.originate depository issuer "USD" "United States Doller" observers now
+  cashInstrumentCid <- Instrument.originate depository issuer "USD" "United States Dollar" observers now
 
   -- Create and distribute bond
   -- Zero coupon bond example

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
@@ -53,7 +53,7 @@ run = script do
   clockCid <- toInterfaceContractId <$> submit issuer do createCmd DateClock with u = Unit $ toDateUTC now; id = Id (show now); provider = issuer; observers = M.empty
 
   -- Originate instruments
-  cashInstrument <- originate cb cb "USD" "United States Doller" pp now
+  cashInstrument <- originate cb cb "USD" "United States Dollar" pp now
   cumEquityInstrument <- originateEquity issuer issuer "EQUITY-INST-1" "0" "APPL" pp now
   exEquityInstrument <- originateEquity issuer issuer "EQUITY-INST-1" "1" "APPL" [] now
 

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
@@ -79,7 +79,7 @@ run = script do
   -- Distribute cash
   now <- getTime
   let pp = [("PublicParty", singleton publicParty)]
-  cashInstrumentCid <- Instrument.originate centralBank centralBank "USD" "United States Doller" pp now
+  cashInstrumentCid <- Instrument.originate centralBank centralBank "USD" "United States Dollar" pp now
   bankCashTransferableCouponCid <- Account.credit [publicParty] cashInstrumentCid 1_000.0 bankAccount
   bankCashTransferablePrincipalCid <- Account.credit [publicParty] cashInstrumentCid 100_000.0 bankAccount
 

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/EuropeanOption.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/EuropeanOption.daml
@@ -83,7 +83,7 @@ run = script do
   -- Distribute cash
   now <- getTime
   let pp = [("PublicParty", singleton publicParty)]
-  cashInstrumentCid <- Instrument.originate centralBank centralBank "USD" "United States Doller" pp now
+  cashInstrumentCid <- Instrument.originate centralBank centralBank "USD" "United States Dollar" pp now
   bankCashTransferableCid <- Account.credit [publicParty] cashInstrumentCid 25_000.0 bankAccount
 
   -- Create observable for the underlying fixing

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardCash.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardCash.daml
@@ -59,7 +59,7 @@ run = script do
   -- Distribute cash
   now <- getTime
   let pp = [("PublicParty", singleton publicParty)]
-  cashInstrument <- Instrument.originate centralBank centralBank "USD" "United States Doller" pp now
+  cashInstrument <- Instrument.originate centralBank centralBank "USD" "United States Dollar" pp now
   bankCashTransferableCid <- Account.credit [publicParty] cashInstrument 50_000.0 bankOwnAccount
 
   -- Create observable

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardPhysical.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardPhysical.daml
@@ -63,7 +63,7 @@ run = script do
   let pp = [("PublicParty", singleton publicParty)]
   equityInstrument <- Instrument.originate bank equityIssuer "AAPL" "Apple Inc." pp now
   bankEquityTransferableCid <- Account.credit [publicParty] equityInstrument 1_000.0 bankOwnAccount
-  cashInstrument <- Instrument.originate centralBank centralBank "USD" "United States Doller" pp now
+  cashInstrument <- Instrument.originate centralBank centralBank "USD" "United States Dollar" pp now
   investorCashTransferableCid <- Account.credit [publicParty] cashInstrument 200_000.0 investorAccount
 
   -- Create and distribute a generic derivative

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
@@ -105,7 +105,7 @@ run = script do
   -- Distribute central-bank cash
   now <- getTime
   let pp = [("PublicParty", singleton publicParty)]
-  cashInstrument <- BaseInstrument.originate centralBank centralBank "USD" "United States Doller" pp now
+  cashInstrument <- BaseInstrument.originate centralBank centralBank "USD" "United States Dollar" pp now
   issuerCashTransferableCid <- Account.credit [publicParty] cashInstrument 20_000.0 issuerCashAccount
 
   -- CREATE_CC_INSTRUMENT_VARIABLES_BEGIN

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/CreditDefault.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/CreditDefault.daml
@@ -1,0 +1,106 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Daml.Finance.Instrument.Swap.Test.CreditDefault where
+
+import DA.Date
+import DA.Map qualified as M (empty, fromList)
+import DA.Set (singleton)
+import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
+import Daml.Finance.Instrument.Generic.Util
+import Daml.Finance.Instrument.Swap.Test.Util
+import Daml.Finance.Interface.Types.Common (Id(..))
+import Daml.Finance.Interface.Types.Date.Calendar
+import Daml.Finance.Interface.Types.Date.DayCount
+import Daml.Finance.Interface.Types.Date.RollConvention
+import Daml.Finance.Data.Reference.HolidayCalendar
+import Daml.Finance.Data.Observable.Observation (Observation(..))
+import Daml.Finance.Test.Util.Account qualified as Account (createAccount, createFactory, credit)
+import Daml.Finance.Test.Util.Common (createParties)
+import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
+import Daml.Script
+
+-- Calculate interest rate payment on an interest rate swap, including lifecycling and creation of new instrument version
+run : Script ()
+run = script do
+  [custodian, issuer, investor, calendarDataProvider, publicParty] <-
+    createParties ["Custodian", "Issuer", "Investor", "Calendar Data Provider", "PublicParty"]
+
+  -- Account and holding factory
+  let fp = [("FactoryProvider", singleton publicParty)]
+  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory custodian fp
+  holdingFactoryCid <- toInterfaceContractId <$> submitMulti [custodian] [] do
+    createCmd Fungible.Factory with provider = custodian; observers = M.fromList fp
+
+  -- Create accounts
+  [custodianAccount, investorAccount] <- mapA (Account.createAccount "Default Account" [publicParty] accountFactoryCid holdingFactoryCid [] custodian) [custodian, investor]
+
+  -- Distribute commercial-bank cash
+  now <- getTime
+  let observers = [("PublicParty", singleton publicParty)]
+  cashInstrumentCid <- Instrument.originate custodian issuer "USD" "US Dollars" observers now
+
+  -- Create and distribute swap
+  -- Fix vs floating interest rate swap: Libor 3M vs 2.01% p.a. payment every 3M
+  let
+    issueDate = date 2019 Jan 16
+    firstPaymentDate = date 2019 Feb 15
+    maturityDate = date 2019 May 15
+    defaultProbabilityReferenceId = "TSLA-DEFAULT-PROB"
+    recoveryRateReferenceId = "TSLA-RECOVERY-RATE"
+    issuerPaysFix = False
+    fixRate : Decimal = 0.0201
+    paymentPeriod = M
+    paymentPeriodMultiplier = 3
+    dayCountConvention = Act360
+    businessDayConvention = ModifiedFollowing
+    firstFixPaymentAmount : Decimal= 1675.0
+    secondFixPaymentAmount : Decimal= 4969.1667
+    creditEventPaymentAmount : Decimal= 400000.0
+    principalAmount : Decimal= 1_000_000.0
+    creditEventDate = date 2019 Mar 15
+    probIfNoCreditEvent : Decimal = 0.2
+    probIfCreditEvent : Decimal = 1.0
+    recoveryRate : Decimal = 0.6
+    defaultProbabilityObservations = M.fromList [(dateToDateClockTime (subtractDays firstPaymentDate 1), probIfNoCreditEvent), (dateToDateClockTime firstPaymentDate, probIfNoCreditEvent), (dateToDateClockTime (addDays firstPaymentDate 1), probIfNoCreditEvent), (dateToDateClockTime creditEventDate, probIfCreditEvent)]
+    recoveryRateObservations = M.fromList [(dateToDateClockTime issueDate, recoveryRate), (dateToDateClockTime firstPaymentDate, recoveryRate), (dateToDateClockTime creditEventDate, recoveryRate)]
+    holidayCalendarId = ["USD"]
+    cal =
+      HolidayCalendarData with
+        id = "USD"
+        weekend = [Saturday, Sunday]
+        holidays = [date 2019 Dec 19]
+
+  -- A reference data provider publishes the holiday calendar on the ledger
+  calendarCid <- submitMulti [calendarDataProvider] [] do
+    createCmd HolidayCalendar with
+      agency = calendarDataProvider
+      entity = cal.id
+      calendar = cal
+      observers = M.fromList fp
+
+  observableDefaultProbabilityCid <- coerceContractId <$> submitMulti [issuer] [] do createCmd Observation with provider = issuer; id = Id defaultProbabilityReferenceId; observations = defaultProbabilityObservations; observers = M.empty
+  observableRecoveryRateCid <- coerceContractId <$> submitMulti [issuer] [] do createCmd Observation with provider = issuer; id = Id recoveryRateReferenceId; observations = recoveryRateObservations; observers = M.empty
+  let observableCids = [observableDefaultProbabilityCid, observableRecoveryRateCid]
+
+  swapInstrument <- originateCreditDefaultSwap custodian issuer "SwapTest1" "Credit default swap" fp now issueDate holidayCalendarId calendarDataProvider firstPaymentDate maturityDate dayCountConvention businessDayConvention fixRate paymentPeriod paymentPeriodMultiplier cashInstrumentCid defaultProbabilityReferenceId recoveryRateReferenceId issuerPaysFix
+  investorSwapTransferableCid <- Account.credit [publicParty] swapInstrument principalAmount investorAccount
+
+  -- One day before the first payment date: try to lifecycle and verify that there are no lifecycle effects.
+  verifyNoLifecycleEffects [publicParty] (subtractDays firstPaymentDate 1) swapInstrument custodian issuer observableCids
+
+  -- First payment date: Lifecycle and verify that there are lifecycle effects for the fix payment.
+  investorCashForFixPaymentTransferableCid <- Account.credit [publicParty] cashInstrumentCid firstFixPaymentAmount investorAccount
+  (swapInstrumentAfterFirstPayment, investorSwapTransferableCid) <- lifecycleAndVerifyCreditDefaultSwapPaymentEffectsAndSettlement [publicParty] firstPaymentDate swapInstrument custodian issuer investor investorSwapTransferableCid investorCashForFixPaymentTransferableCid custodianAccount investorAccount observers custodian observableCids
+
+  -- One day after the first payment date: try to lifecycle and verify that there are no lifecycle effects.
+  verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment custodian issuer observableCids
+
+  -- Credit event date: Lifecycle and verify that there is a lifecycle effect for the (1-recoveryRate) payment.
+  custodianCashForCreditEventPaymentTransferableCid <- Account.credit [publicParty] cashInstrumentCid creditEventPaymentAmount custodianAccount
+  lifecycleAndVerifyCreditDefaultFinalSwapPaymentEffects [publicParty] creditEventDate swapInstrumentAfterFirstPayment custodian issuer investor investorSwapTransferableCid custodianCashForCreditEventPaymentTransferableCid custodianAccount investorAccount observers custodian observableCids
+
+  -- One day after credit event date: try to lifecycle and verify that the instrument has automatically expired.
+  -- TODO: implement this after having included expire logic (of Until nodes) somewhere in the lifecycle process.
+
+  pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/CreditDefault.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/CreditDefault.daml
@@ -20,7 +20,7 @@ import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Script
 
--- Calculate interest rate payment on an interest rate swap, including lifecycling and creation of new instrument version
+-- Calculate credit default swap payments (test case with a credit event), including lifecycling and creation of new instrument version.
 run : Script ()
 run = script do
   [custodian, issuer, investor, calendarDataProvider, publicParty] <-
@@ -41,7 +41,6 @@ run = script do
   cashInstrumentCid <- Instrument.originate custodian issuer "USD" "US Dollars" observers now
 
   -- Create and distribute swap
-  -- Fix vs floating interest rate swap: Libor 3M vs 2.01% p.a. payment every 3M
   let
     issueDate = date 2019 Jan 16
     firstPaymentDate = date 2019 Feb 15
@@ -106,7 +105,7 @@ run = script do
 
   pure ()
 
--- Calculate interest rate payment on an interest rate swap, including lifecycling and creation of new instrument version
+-- Calculate credit default swap payments (test case without a credit event), including lifecycling and creation of new instrument version.
 runNoCreditEvent : Script ()
 runNoCreditEvent = script do
   [custodian, issuer, investor, calendarDataProvider, publicParty] <-
@@ -127,7 +126,6 @@ runNoCreditEvent = script do
   cashInstrumentCid <- Instrument.originate custodian issuer "USD" "US Dollars" observers now
 
   -- Create and distribute swap
-  -- Fix vs floating interest rate swap: Libor 3M vs 2.01% p.a. payment every 3M
   let
     issueDate = date 2019 Jan 16
     firstPaymentDate = date 2019 Feb 15
@@ -184,5 +182,7 @@ runNoCreditEvent = script do
 
   -- One day after the maturity: try to lifecycle and verify that there are no lifecycle effects.
   verifyNoLifecycleEffects [publicParty] (addDays maturityDate 1) swapInstrumentAfterSecondPayment settlers issuer observableCids
+
+  -- TODO: same as above, after having included expire logic (of Until nodes) somewhere in the lifecycle process, verify that the instrument automatically expires as expected.
 
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/CreditDefault.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/CreditDefault.daml
@@ -86,19 +86,21 @@ run = script do
   swapInstrument <- originateCreditDefaultSwap custodian issuer "SwapTest1" "Credit default swap" fp now issueDate holidayCalendarId calendarDataProvider firstPaymentDate maturityDate dayCountConvention businessDayConvention fixRate paymentPeriod paymentPeriodMultiplier cashInstrumentCid defaultProbabilityReferenceId recoveryRateReferenceId issuerPaysFix
   investorSwapTransferableCid <- Account.credit [publicParty] swapInstrument principalAmount investorAccount
 
+  let settlers = singleton custodian
+
   -- One day before the first payment date: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (subtractDays firstPaymentDate 1) swapInstrument custodian issuer observableCids
+  verifyNoLifecycleEffects [publicParty] (subtractDays firstPaymentDate 1) swapInstrument settlers issuer observableCids
 
   -- First payment date: Lifecycle and verify that there are lifecycle effects for the fix payment.
   investorCashForFixPaymentTransferableCid <- Account.credit [publicParty] cashInstrumentCid firstFixPaymentAmount investorAccount
-  (swapInstrumentAfterFirstPayment, investorSwapTransferableCid) <- lifecycleAndVerifyCreditDefaultSwapPaymentEffectsAndSettlement [publicParty] firstPaymentDate swapInstrument custodian issuer investor investorSwapTransferableCid investorCashForFixPaymentTransferableCid custodianAccount investorAccount observers custodian observableCids
+  (swapInstrumentAfterFirstPayment, investorSwapTransferableCid) <- lifecycleAndVerifyCreditDefaultSwapPaymentEffectsAndSettlement [publicParty] firstPaymentDate swapInstrument settlers issuer investor investorSwapTransferableCid investorCashForFixPaymentTransferableCid custodianAccount investorAccount observers custodian observableCids
 
   -- One day after the first payment date: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment custodian issuer observableCids
+  verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment settlers issuer observableCids
 
   -- Credit event date: Lifecycle and verify that there is a lifecycle effect for the (1-recoveryRate) payment.
   custodianCashForCreditEventPaymentTransferableCid <- Account.credit [publicParty] cashInstrumentCid creditEventPaymentAmount custodianAccount
-  lifecycleAndVerifyCreditDefaultFinalSwapPaymentEffects [publicParty] creditEventDate swapInstrumentAfterFirstPayment custodian issuer investor investorSwapTransferableCid custodianCashForCreditEventPaymentTransferableCid custodianAccount investorAccount observers custodian observableCids
+  lifecycleAndVerifyCreditDefaultFinalSwapPaymentEffects [publicParty] creditEventDate swapInstrumentAfterFirstPayment settlers issuer investor investorSwapTransferableCid custodianCashForCreditEventPaymentTransferableCid custodianAccount investorAccount observers custodian observableCids
 
   -- One day after credit event date: try to lifecycle and verify that the instrument has automatically expired.
   -- TODO: implement this after having included expire logic (of Until nodes) somewhere in the lifecycle process.

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/CreditDefault.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/CreditDefault.daml
@@ -49,20 +49,19 @@ run = script do
     defaultProbabilityReferenceId = "TSLA-DEFAULT-PROB"
     recoveryRateReferenceId = "TSLA-RECOVERY-RATE"
     issuerPaysFix = False
-    fixRate : Decimal = 0.0201
+    fixRate = 0.0201
     paymentPeriod = M
     paymentPeriodMultiplier = 3
     dayCountConvention = Act360
     businessDayConvention = ModifiedFollowing
-    firstFixPaymentAmount : Decimal= 1675.0
-    secondFixPaymentAmount : Decimal= 4969.1667
-    creditEventPaymentAmount : Decimal= 400000.0
-    principalAmount : Decimal= 1_000_000.0
+    firstFixPaymentAmount = 1675.0
+    creditEventPaymentAmount = 400000.0
+    principalAmount = 1_000_000.0
     creditEventDate = date 2019 Mar 15
-    probIfNoCreditEvent : Decimal = 0.2
-    probIfCreditEvent : Decimal = 1.0
-    recoveryRate : Decimal = 0.6
-    defaultProbabilityObservations = M.fromList [(dateToDateClockTime (subtractDays firstPaymentDate 1), probIfNoCreditEvent), (dateToDateClockTime firstPaymentDate, probIfNoCreditEvent), (dateToDateClockTime (addDays firstPaymentDate 1), probIfNoCreditEvent), (dateToDateClockTime creditEventDate, probIfCreditEvent)]
+    probIfNoCreditEvent = 0.2
+    probIfCreditEvent = 1.0
+    recoveryRate = 0.6
+    defaultProbabilityObservations = M.fromList [(dateToDateClockTime (subtractDays firstPaymentDate 1), probIfNoCreditEvent), (dateToDateClockTime firstPaymentDate, probIfNoCreditEvent), (dateToDateClockTime (addDays firstPaymentDate 1), probIfNoCreditEvent), (dateToDateClockTime creditEventDate, probIfCreditEvent), (dateToDateClockTime maturityDate, probIfNoCreditEvent)]
     recoveryRateObservations = M.fromList [(dateToDateClockTime issueDate, recoveryRate), (dateToDateClockTime firstPaymentDate, recoveryRate), (dateToDateClockTime creditEventDate, recoveryRate)]
     holidayCalendarId = ["USD"]
     cal =
@@ -104,5 +103,86 @@ run = script do
 
   -- One day after credit event date: try to lifecycle and verify that the instrument has automatically expired.
   -- TODO: implement this after having included expire logic (of Until nodes) somewhere in the lifecycle process.
+
+  pure ()
+
+-- Calculate interest rate payment on an interest rate swap, including lifecycling and creation of new instrument version
+runNoCreditEvent : Script ()
+runNoCreditEvent = script do
+  [custodian, issuer, investor, calendarDataProvider, publicParty] <-
+    createParties ["Custodian", "Issuer", "Investor", "Calendar Data Provider", "PublicParty"]
+
+  -- Account and holding factory
+  let fp = [("FactoryProvider", singleton publicParty)]
+  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory custodian fp
+  holdingFactoryCid <- toInterfaceContractId <$> submitMulti [custodian] [] do
+    createCmd Fungible.Factory with provider = custodian; observers = M.fromList fp
+
+  -- Create accounts
+  [custodianAccount, investorAccount] <- mapA (Account.createAccount "Default Account" [publicParty] accountFactoryCid holdingFactoryCid [] custodian) [custodian, investor]
+
+  -- Distribute commercial-bank cash
+  now <- getTime
+  let observers = [("PublicParty", singleton publicParty)]
+  cashInstrumentCid <- Instrument.originate custodian issuer "USD" "US Dollars" observers now
+
+  -- Create and distribute swap
+  -- Fix vs floating interest rate swap: Libor 3M vs 2.01% p.a. payment every 3M
+  let
+    issueDate = date 2019 Jan 16
+    firstPaymentDate = date 2019 Feb 15
+    maturityDate = date 2019 May 15
+    defaultProbabilityReferenceId = "TSLA-DEFAULT-PROB"
+    recoveryRateReferenceId = "TSLA-RECOVERY-RATE"
+    issuerPaysFix = False
+    fixRate = 0.0201
+    paymentPeriod = M
+    paymentPeriodMultiplier = 3
+    dayCountConvention = Act360
+    businessDayConvention = ModifiedFollowing
+    firstFixPaymentAmount = 1675.0
+    secondFixPaymentAmount = 4969.1667
+    principalAmount = 1_000_000.0
+    probIfNoCreditEvent = 0.2
+    defaultProbabilityObservations = M.fromList [(dateToDateClockTime (subtractDays firstPaymentDate 1), probIfNoCreditEvent), (dateToDateClockTime firstPaymentDate, probIfNoCreditEvent), (dateToDateClockTime (addDays firstPaymentDate 1), probIfNoCreditEvent), (dateToDateClockTime maturityDate, probIfNoCreditEvent), (dateToDateClockTime (addDays maturityDate 1), probIfNoCreditEvent)]
+    holidayCalendarId = ["USD"]
+    cal =
+      HolidayCalendarData with
+        id = "USD"
+        weekend = [Saturday, Sunday]
+        holidays = [date 2019 Dec 19]
+
+  -- A reference data provider publishes the holiday calendar on the ledger
+  calendarCid <- submitMulti [calendarDataProvider] [] do
+    createCmd HolidayCalendar with
+      agency = calendarDataProvider
+      entity = cal.id
+      calendar = cal
+      observers = M.fromList fp
+
+  observableDefaultProbabilityCid <- coerceContractId <$> submitMulti [issuer] [] do createCmd Observation with provider = issuer; id = Id defaultProbabilityReferenceId; observations = defaultProbabilityObservations; observers = M.empty
+  let observableCids = [observableDefaultProbabilityCid]
+
+  swapInstrument <- originateCreditDefaultSwap custodian issuer "SwapTest1" "Credit default swap" fp now issueDate holidayCalendarId calendarDataProvider firstPaymentDate maturityDate dayCountConvention businessDayConvention fixRate paymentPeriod paymentPeriodMultiplier cashInstrumentCid defaultProbabilityReferenceId recoveryRateReferenceId issuerPaysFix
+  investorSwapTransferableCid <- Account.credit [publicParty] swapInstrument principalAmount investorAccount
+
+  let settlers = singleton custodian
+
+  -- One day before the first payment date: try to lifecycle and verify that there are no lifecycle effects.
+  verifyNoLifecycleEffects [publicParty] (subtractDays firstPaymentDate 1) swapInstrument settlers issuer observableCids
+
+  -- First payment date: Lifecycle and verify that there are lifecycle effects for the fix payment.
+  investorCashForFixPaymentTransferableCid <- Account.credit [publicParty] cashInstrumentCid firstFixPaymentAmount investorAccount
+  (swapInstrumentAfterFirstPayment, investorSwapTransferableCid) <- lifecycleAndVerifyCreditDefaultSwapPaymentEffectsAndSettlement [publicParty] firstPaymentDate swapInstrument settlers issuer investor investorSwapTransferableCid investorCashForFixPaymentTransferableCid custodianAccount investorAccount observers custodian observableCids
+
+  -- One day after the first payment date: try to lifecycle and verify that there are no lifecycle effects.
+  verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment settlers issuer observableCids
+
+  -- Second payment date: Lifecycle and verify that there are lifecycle effects for the fix payment.
+  investorCashForFixPaymentTransferableCid <- Account.credit [publicParty] cashInstrumentCid secondFixPaymentAmount investorAccount
+  (swapInstrumentAfterSecondPayment, investorSwapTransferableCid) <- lifecycleAndVerifyCreditDefaultSwapPaymentEffectsAndSettlement [publicParty] maturityDate swapInstrumentAfterFirstPayment settlers issuer investor investorSwapTransferableCid investorCashForFixPaymentTransferableCid custodianAccount investorAccount observers custodian observableCids
+
+  -- One day after the maturity: try to lifecycle and verify that there are no lifecycle effects.
+  verifyNoLifecycleEffects [publicParty] (addDays maturityDate 1) swapInstrumentAfterSecondPayment settlers issuer observableCids
 
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -6,6 +6,7 @@ module Daml.Finance.Instrument.Swap.Test.Util where
 import DA.Date
 import DA.Map qualified as M
 import DA.Set (empty, singleton)
+import Daml.Finance.Instrument.Swap.CreditDefault qualified as CreditDefaultSwap (Instrument(..))
 import Daml.Finance.Instrument.Swap.Currency qualified as CurrencySwap (Instrument(..))
 import Daml.Finance.Instrument.Swap.ForeignExchange qualified as ForeignExchange (Instrument(..))
 import Daml.Finance.Instrument.Swap.InterestRate qualified as InterestRateSwap (Instrument(..))
@@ -67,6 +68,17 @@ originateInterestRateSwap depository issuer label description observers lastEven
   -- CREATE_INTEREST_RATE_SWAP_INSTRUMENT_BEGIN
   cid <- toInterfaceContractId <$> submitMulti [depository, issuer] [] do
     createCmd InterestRateSwap.Instrument with depository; issuer; id = Id label; version = "0"; description; observers = M.fromList observers; lastEventTimestamp; periodicSchedule; holidayCalendarIds; calendarDataProvider; dayCountConvention; issuerPaysFix; fixRate; referenceRateId; currency
+  -- CREATE_INTEREST_RATE_SWAP_INSTRUMENT_END
+  createReference cid depository issuer observers
+
+-- | Originate a credit default swap.
+originateCreditDefaultSwap : Party -> Party -> Text -> Text -> [(Text, Parties)] -> Time -> Date -> [Text] -> Party -> Date -> Date -> DayCountConventionEnum -> BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Text -> Text -> Bool -> Script Instrument.K
+originateCreditDefaultSwap depository issuer label description observers lastEventTimestamp issueDate holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention businessDayConvention fixRate couponPeriod couponPeriodMultiplier currency defaultProbabilityReferenceId recoveryRateReferenceId issuerPaysFix = do
+  let
+    periodicSchedule = createPaymentPeriodicSchedule firstCouponDate holidayCalendarIds businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate
+  -- CREATE_INTEREST_RATE_SWAP_INSTRUMENT_BEGIN
+  cid <- toInterfaceContractId <$> submitMulti [depository, issuer] [] do
+    createCmd CreditDefaultSwap.Instrument with depository; issuer; id = Id label; version = "0"; description; observers = M.fromList observers; lastEventTimestamp; periodicSchedule; holidayCalendarIds; calendarDataProvider; dayCountConvention; issuerPaysFix; fixRate; defaultProbabilityReferenceId; recoveryRateReferenceId; currency
   -- CREATE_INTEREST_RATE_SWAP_INSTRUMENT_END
   createReference cid depository issuer observers
 
@@ -207,3 +219,108 @@ lifecycleAndVerifyFinalSwapPaymentEffects readAs today swapInstrument settler is
   [investorCashTransferableFixLegCid, investorCashTransferableFloatingLegCid] <- submitMulti [settler] readAs do exerciseCmd result.batchCid Batch.Settle
 
   pure (newSwapInstrumentKey)
+
+-- | Verify the fix payments from a payment date of a credit default swap.
+lifecycleAndVerifyCreditDefaultSwapPaymentEffectsAndSettlement : [Party] -> Date -> Instrument.K -> Party -> Party -> Party -> ContractId Transferable.I -> ContractId Transferable.I -> AccountKey -> AccountKey -> [(Text, Parties)] -> Party -> [ContractId Observable.I] -> Script (Instrument.K, ContractId Transferable.I)
+lifecycleAndVerifyCreditDefaultSwapPaymentEffectsAndSettlement readAs today swapInstrument settler issuer investor investorSwapTransferableCid investorCashTransferableFixLegCid custodianAccount investorAccount obs custodian observableCids = do
+  (swapLifecycleCid, [effectCid]) <- lifecycleInstrument readAs today swapInstrument settler issuer observableCids
+
+  newSwapInstrumentKey <- submitMulti [issuer] [] do
+    Instrument.toKey <$> exerciseCmd @Instrument.I (coerceContractId swapLifecycleCid) Instrument.GetView with viewer = issuer
+
+  -- Create settlement factory
+  settlementFactoryCid <- submitMulti [investor] [] do createCmd Factory with provider = investor; observers = empty
+
+  -- Claim effect
+  lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [custodian, investor] [] do
+    createCmd Claim.Rule
+      with
+        custodian
+        owner = investor
+        claimers = singleton investor
+        settler
+        factoryCid = toInterfaceContractId settlementFactoryCid
+
+  result <- submitMulti [investor] readAs do
+    exerciseCmd lifecycleClaimRuleCid Claim.ClaimEffect with
+      claimer = investor
+      holdingCids = [toInterfaceContractId @Base.I investorSwapTransferableCid]
+      effectCid
+
+  let
+    Some [investorSwapHoldingCid] = result.newInstrumentHoldingCids
+    --[custodianCashInstructionFixLegCid, custodianCashInstructionFloatingLegCid] = result.instructionCids
+    [custodianCashInstructionFixLegCid] = result.instructionCids
+
+  -- Allocate instructions
+  (custodianCashInstructionFixLegCid, _) <- submitMulti [investor] readAs do exerciseCmd custodianCashInstructionFixLegCid Instruction.Allocate with allocation = Pledge investorCashTransferableFixLegCid
+  --(custodianCashInstructionFloatingLegCid, _) <- submitMulti [custodian] readAs do exerciseCmd custodianCashInstructionFloatingLegCid Instruction.Allocate with allocation = Pledge custodianCashTransferableFloatingLegCid
+
+  -- Approve instructions
+  investorCashInstructionFixLegCid <- submitMulti [custodian] [] do
+    exerciseCmd custodianCashInstructionFixLegCid Instruction.Approve with approval = TakeDelivery custodianAccount
+  --custodianCashInstructionFloatingLegCid <- submitMulti [investor] [] do
+  --  exerciseCmd custodianCashInstructionFloatingLegCid Instruction.Approve with approval = TakeDelivery investorAccount
+
+  -- Settle batch
+  [investorCashTransferableFixLegCid] <- submitMulti [settler] readAs do exerciseCmd result.batchCid Batch.Settle
+
+  -- Assert state
+  verifyOwnerOfHolding [(investor, investorSwapHoldingCid), (custodian, toInterfaceContractId investorCashTransferableFixLegCid)]
+
+  pure (newSwapInstrumentKey, coerceContractId investorSwapHoldingCid)
+
+-- | Verify the payments from the final payment date of an interest rate swap.
+lifecycleAndVerifyCreditDefaultFinalSwapPaymentEffects : [Party] -> Date -> Instrument.K -> Party -> Party -> Party -> ContractId Transferable.I  -> ContractId Transferable.I -> AccountKey -> AccountKey -> [(Text, Parties)] -> Party -> [ContractId Observable.I] -> Script (Instrument.K)
+lifecycleAndVerifyCreditDefaultFinalSwapPaymentEffects readAs today swapInstrument settler issuer investor investorSwapTransferableCid custodianCashTransferableFloatingLegCid custodianAccount investorAccount obs custodian observableCids = do
+  (swapLifecycleCid, [effectCid]) <- lifecycleInstrument readAs today swapInstrument settler issuer observableCids
+
+  newSwapInstrumentKey <- submitMulti [issuer] [] do
+    Instrument.toKey <$> exerciseCmd @Instrument.I (coerceContractId swapLifecycleCid) Instrument.GetView with viewer = issuer
+
+  -- Create settlement factory
+  settlementFactoryCid <- submitMulti [investor] [] do createCmd Factory with provider = investor; observers = empty
+
+  -- Claim effect
+  lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [custodian, investor] [] do
+    createCmd Claim.Rule
+      with
+        custodian
+        owner = investor
+        claimers = singleton investor
+        settler
+        factoryCid = toInterfaceContractId settlementFactoryCid
+
+  result <- submitMulti [investor] readAs do
+    exerciseCmd lifecycleClaimRuleCid Claim.ClaimEffect with
+      claimer = investor
+      holdingCids = [toInterfaceContractId @Base.I investorSwapTransferableCid]
+      effectCid
+
+  let
+    [custodianCashInstructionFixLegCid] = result.instructionCids
+
+  -- Allocate instructions
+  --(custodianCashInstructionFixLegCid, _) <- submitMulti [investor] readAs do exerciseCmd custodianCashInstructionFixLegCid Instruction.Allocate with allocation = Pledge investorCashTransferableFixLegCid
+  (custodianCashInstructionFloatingLegCid, _) <- submitMulti [custodian] readAs do exerciseCmd custodianCashInstructionFixLegCid Instruction.Allocate with allocation = Pledge custodianCashTransferableFloatingLegCid
+
+  -- Approve instructions
+  --investorCashInstructionFixLegCid <- submitMulti [custodian] [] do
+  --  exerciseCmd custodianCashInstructionFixLegCid Instruction.Approve with approval = TakeDelivery custodianAccount
+  custodianCashInstructionFloatingLegCid <- submitMulti [investor] [] do
+    exerciseCmd custodianCashInstructionFloatingLegCid Instruction.Approve with approval = TakeDelivery investorAccount
+
+  -- Settle batch
+  [investorCashTransferableFixLegCid] <- submitMulti [settler] readAs do exerciseCmd result.batchCid Batch.Settle
+
+  pure (newSwapInstrumentKey)
+
+-- | Verify a that there are no lifecycle effects of the instrument on this date. This is a general function that can be used for both bonds and swaps.
+verifyNoLifecycleEffectsAndReturnNewInstrument : [Party] -> Date -> Instrument.K -> Party -> Party -> [ContractId Observable.I] -> Script (Instrument.K)
+verifyNoLifecycleEffectsAndReturnNewInstrument readAs today instrument settler issuer observableCids = do
+  (swapLifecycleCid, effectCids) <- lifecycleInstrument readAs today instrument settler issuer observableCids
+  assertMsg ("There should be no lifecycle effects on " <> show today) (null effectCids)
+  newSwapInstrumentKey <- submitMulti [issuer] [] do
+    Instrument.toKey <$> exerciseCmd @Instrument.I (coerceContractId swapLifecycleCid) Instrument.GetView with viewer = issuer
+  pure newSwapInstrumentKey
+

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -270,7 +270,7 @@ lifecycleAndVerifyCreditDefaultSwapPaymentEffectsAndSettlement readAs today swap
 
   pure (newSwapInstrumentKey, coerceContractId investorSwapHoldingCid)
 
--- | Verify the payments from the final payment date of an interest rate swap.
+-- | Verify the credit default payment of a credit default swap.
 lifecycleAndVerifyCreditDefaultFinalSwapPaymentEffects : [Party] -> Date -> Instrument.K -> Parties -> Party -> Party -> ContractId Transferable.I  -> ContractId Transferable.I -> AccountKey -> AccountKey -> [(Text, Parties)] -> Party -> [ContractId Observable.I] -> Script (Instrument.K)
 lifecycleAndVerifyCreditDefaultFinalSwapPaymentEffects readAs today swapInstrument settlers issuer investor investorSwapTransferableCid custodianCashTransferableDefaultPaymentLegCid custodianAccount investorAccount obs custodian observableCids = do
   (swapLifecycleCid, [effectCid]) <- lifecycleInstrument readAs today swapInstrument settlers issuer observableCids

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -125,6 +125,7 @@ lifecycleInstrument readAs today instrument settlers issuer observableCids = do
 verifyNoLifecycleEffects : [Party] -> Date -> Instrument.K -> Parties -> Party -> [ContractId Observable.I] -> Script ()
 verifyNoLifecycleEffects readAs today instrument settlers issuer observableCids = do
   (bondLifecycleCid2, effectCids) <- lifecycleInstrument readAs today instrument settlers issuer observableCids
+  debug effectCids
   assertMsg ("There should be no lifecycle effects on " <> show today) (null effectCids)
 
 -- | Verify the payments from a payment date of an interest rate swap.
@@ -319,14 +320,3 @@ lifecycleAndVerifyCreditDefaultFinalSwapPaymentEffects readAs today swapInstrume
   [investorCashTransferableFixLegCid] <- submitMulti [settlerUsed] readAs do exerciseCmd result.batchCid Batch.Settle with actors = singleton settlerUsed
 
   pure (newSwapInstrumentKey)
-{-
--- | Verify a that there are no lifecycle effects of the instrument on this date. This is a general function that can be used for both bonds and swaps.
-verifyNoLifecycleEffectsAndReturnNewInstrument : [Party] -> Date -> Instrument.K -> Party -> Party -> [ContractId Observable.I] -> Script (Instrument.K)
-verifyNoLifecycleEffectsAndReturnNewInstrument readAs today instrument settler issuer observableCids = do
-  (swapLifecycleCid, effectCids) <- lifecycleInstrument readAs today instrument settler issuer observableCids
-  assertMsg ("There should be no lifecycle effects on " <> show today) (null effectCids)
-  newSwapInstrumentKey <- submitMulti [issuer] [] do
-    Instrument.toKey <$> exerciseCmd @Instrument.I (coerceContractId swapLifecycleCid) Instrument.GetView with viewer = issuer
-  pure newSwapInstrumentKey
-
- -}

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -224,9 +224,9 @@ lifecycleAndVerifyFinalSwapPaymentEffects readAs today swapInstrument settlers i
   pure (newSwapInstrumentKey)
 
 -- | Verify the fix payments from a payment date of a credit default swap.
-lifecycleAndVerifyCreditDefaultSwapPaymentEffectsAndSettlement : [Party] -> Date -> Instrument.K -> Party -> Party -> Party -> ContractId Transferable.I -> ContractId Transferable.I -> AccountKey -> AccountKey -> [(Text, Parties)] -> Party -> [ContractId Observable.I] -> Script (Instrument.K, ContractId Transferable.I)
-lifecycleAndVerifyCreditDefaultSwapPaymentEffectsAndSettlement readAs today swapInstrument settler issuer investor investorSwapTransferableCid investorCashTransferableFixLegCid custodianAccount investorAccount obs custodian observableCids = do
-  (swapLifecycleCid, [effectCid]) <- lifecycleInstrument readAs today swapInstrument settler issuer observableCids
+lifecycleAndVerifyCreditDefaultSwapPaymentEffectsAndSettlement : [Party] -> Date -> Instrument.K -> Parties -> Party -> Party -> ContractId Transferable.I -> ContractId Transferable.I -> AccountKey -> AccountKey -> [(Text, Parties)] -> Party -> [ContractId Observable.I] -> Script (Instrument.K, ContractId Transferable.I)
+lifecycleAndVerifyCreditDefaultSwapPaymentEffectsAndSettlement readAs today swapInstrument settlers issuer investor investorSwapTransferableCid investorCashTransferableFixLegCid custodianAccount investorAccount obs custodian observableCids = do
+  (swapLifecycleCid, [effectCid]) <- lifecycleInstrument readAs today swapInstrument settlers issuer observableCids
 
   newSwapInstrumentKey <- submitMulti [issuer] [] do
     Instrument.toKey <$> exerciseCmd @Instrument.I (coerceContractId swapLifecycleCid) Instrument.GetView with viewer = issuer
@@ -241,7 +241,7 @@ lifecycleAndVerifyCreditDefaultSwapPaymentEffectsAndSettlement readAs today swap
         custodian
         owner = investor
         claimers = singleton investor
-        settler
+        settlers
         factoryCid = toInterfaceContractId settlementFactoryCid
 
   result <- submitMulti [investor] readAs do
@@ -266,7 +266,8 @@ lifecycleAndVerifyCreditDefaultSwapPaymentEffectsAndSettlement readAs today swap
   --  exerciseCmd custodianCashInstructionFloatingLegCid Instruction.Approve with approval = TakeDelivery investorAccount
 
   -- Settle batch
-  [investorCashTransferableFixLegCid] <- submitMulti [settler] readAs do exerciseCmd result.batchCid Batch.Settle
+  let settlerUsed = head $ toList settlers
+  [investorCashTransferableFixLegCid] <- submitMulti [settlerUsed] readAs do exerciseCmd result.batchCid Batch.Settle with actors = singleton settlerUsed
 
   -- Assert state
   verifyOwnerOfHolding [(investor, investorSwapHoldingCid), (custodian, toInterfaceContractId investorCashTransferableFixLegCid)]
@@ -274,9 +275,9 @@ lifecycleAndVerifyCreditDefaultSwapPaymentEffectsAndSettlement readAs today swap
   pure (newSwapInstrumentKey, coerceContractId investorSwapHoldingCid)
 
 -- | Verify the payments from the final payment date of an interest rate swap.
-lifecycleAndVerifyCreditDefaultFinalSwapPaymentEffects : [Party] -> Date -> Instrument.K -> Party -> Party -> Party -> ContractId Transferable.I  -> ContractId Transferable.I -> AccountKey -> AccountKey -> [(Text, Parties)] -> Party -> [ContractId Observable.I] -> Script (Instrument.K)
-lifecycleAndVerifyCreditDefaultFinalSwapPaymentEffects readAs today swapInstrument settler issuer investor investorSwapTransferableCid custodianCashTransferableFloatingLegCid custodianAccount investorAccount obs custodian observableCids = do
-  (swapLifecycleCid, [effectCid]) <- lifecycleInstrument readAs today swapInstrument settler issuer observableCids
+lifecycleAndVerifyCreditDefaultFinalSwapPaymentEffects : [Party] -> Date -> Instrument.K -> Parties -> Party -> Party -> ContractId Transferable.I  -> ContractId Transferable.I -> AccountKey -> AccountKey -> [(Text, Parties)] -> Party -> [ContractId Observable.I] -> Script (Instrument.K)
+lifecycleAndVerifyCreditDefaultFinalSwapPaymentEffects readAs today swapInstrument settlers issuer investor investorSwapTransferableCid custodianCashTransferableFloatingLegCid custodianAccount investorAccount obs custodian observableCids = do
+  (swapLifecycleCid, [effectCid]) <- lifecycleInstrument readAs today swapInstrument settlers issuer observableCids
 
   newSwapInstrumentKey <- submitMulti [issuer] [] do
     Instrument.toKey <$> exerciseCmd @Instrument.I (coerceContractId swapLifecycleCid) Instrument.GetView with viewer = issuer
@@ -291,7 +292,7 @@ lifecycleAndVerifyCreditDefaultFinalSwapPaymentEffects readAs today swapInstrume
         custodian
         owner = investor
         claimers = singleton investor
-        settler
+        settlers
         factoryCid = toInterfaceContractId settlementFactoryCid
 
   result <- submitMulti [investor] readAs do
@@ -314,10 +315,11 @@ lifecycleAndVerifyCreditDefaultFinalSwapPaymentEffects readAs today swapInstrume
     exerciseCmd custodianCashInstructionFloatingLegCid Instruction.Approve with approval = TakeDelivery investorAccount
 
   -- Settle batch
-  [investorCashTransferableFixLegCid] <- submitMulti [settler] readAs do exerciseCmd result.batchCid Batch.Settle
+  let settlerUsed = head $ toList settlers
+  [investorCashTransferableFixLegCid] <- submitMulti [settlerUsed] readAs do exerciseCmd result.batchCid Batch.Settle with actors = singleton settlerUsed
 
   pure (newSwapInstrumentKey)
-
+{-
 -- | Verify a that there are no lifecycle effects of the instrument on this date. This is a general function that can be used for both bonds and swaps.
 verifyNoLifecycleEffectsAndReturnNewInstrument : [Party] -> Date -> Instrument.K -> Party -> Party -> [ContractId Observable.I] -> Script (Instrument.K)
 verifyNoLifecycleEffectsAndReturnNewInstrument readAs today instrument settler issuer observableCids = do
@@ -327,3 +329,4 @@ verifyNoLifecycleEffectsAndReturnNewInstrument readAs today instrument settler i
     Instrument.toKey <$> exerciseCmd @Instrument.I (coerceContractId swapLifecycleCid) Instrument.GetView with viewer = issuer
   pure newSwapInstrumentKey
 
+ -}

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -125,7 +125,6 @@ lifecycleInstrument readAs today instrument settlers issuer observableCids = do
 verifyNoLifecycleEffects : [Party] -> Date -> Instrument.K -> Parties -> Party -> [ContractId Observable.I] -> Script ()
 verifyNoLifecycleEffects readAs today instrument settlers issuer observableCids = do
   (bondLifecycleCid2, effectCids) <- lifecycleInstrument readAs today instrument settlers issuer observableCids
-  debug effectCids
   assertMsg ("There should be no lifecycle effects on " <> show today) (null effectCids)
 
 -- | Verify the payments from a payment date of an interest rate swap.
@@ -253,18 +252,14 @@ lifecycleAndVerifyCreditDefaultSwapPaymentEffectsAndSettlement readAs today swap
 
   let
     Some [investorSwapHoldingCid] = result.newInstrumentHoldingCids
-    --[custodianCashInstructionFixLegCid, custodianCashInstructionFloatingLegCid] = result.instructionCids
     [custodianCashInstructionFixLegCid] = result.instructionCids
 
   -- Allocate instructions
   (custodianCashInstructionFixLegCid, _) <- submitMulti [investor] readAs do exerciseCmd custodianCashInstructionFixLegCid Instruction.Allocate with allocation = Pledge investorCashTransferableFixLegCid
-  --(custodianCashInstructionFloatingLegCid, _) <- submitMulti [custodian] readAs do exerciseCmd custodianCashInstructionFloatingLegCid Instruction.Allocate with allocation = Pledge custodianCashTransferableFloatingLegCid
 
   -- Approve instructions
   investorCashInstructionFixLegCid <- submitMulti [custodian] [] do
     exerciseCmd custodianCashInstructionFixLegCid Instruction.Approve with approval = TakeDelivery custodianAccount
-  --custodianCashInstructionFloatingLegCid <- submitMulti [investor] [] do
-  --  exerciseCmd custodianCashInstructionFloatingLegCid Instruction.Approve with approval = TakeDelivery investorAccount
 
   -- Settle batch
   let settlerUsed = head $ toList settlers
@@ -277,7 +272,7 @@ lifecycleAndVerifyCreditDefaultSwapPaymentEffectsAndSettlement readAs today swap
 
 -- | Verify the payments from the final payment date of an interest rate swap.
 lifecycleAndVerifyCreditDefaultFinalSwapPaymentEffects : [Party] -> Date -> Instrument.K -> Parties -> Party -> Party -> ContractId Transferable.I  -> ContractId Transferable.I -> AccountKey -> AccountKey -> [(Text, Parties)] -> Party -> [ContractId Observable.I] -> Script (Instrument.K)
-lifecycleAndVerifyCreditDefaultFinalSwapPaymentEffects readAs today swapInstrument settlers issuer investor investorSwapTransferableCid custodianCashTransferableFloatingLegCid custodianAccount investorAccount obs custodian observableCids = do
+lifecycleAndVerifyCreditDefaultFinalSwapPaymentEffects readAs today swapInstrument settlers issuer investor investorSwapTransferableCid custodianCashTransferableDefaultPaymentLegCid custodianAccount investorAccount obs custodian observableCids = do
   (swapLifecycleCid, [effectCid]) <- lifecycleInstrument readAs today swapInstrument settlers issuer observableCids
 
   newSwapInstrumentKey <- submitMulti [issuer] [] do
@@ -306,14 +301,11 @@ lifecycleAndVerifyCreditDefaultFinalSwapPaymentEffects readAs today swapInstrume
     [custodianCashInstructionFixLegCid] = result.instructionCids
 
   -- Allocate instructions
-  --(custodianCashInstructionFixLegCid, _) <- submitMulti [investor] readAs do exerciseCmd custodianCashInstructionFixLegCid Instruction.Allocate with allocation = Pledge investorCashTransferableFixLegCid
-  (custodianCashInstructionFloatingLegCid, _) <- submitMulti [custodian] readAs do exerciseCmd custodianCashInstructionFixLegCid Instruction.Allocate with allocation = Pledge custodianCashTransferableFloatingLegCid
+  (custodianCashInstructionDefaultPaymentCid, _) <- submitMulti [custodian] readAs do exerciseCmd custodianCashInstructionFixLegCid Instruction.Allocate with allocation = Pledge custodianCashTransferableDefaultPaymentLegCid
 
   -- Approve instructions
-  --investorCashInstructionFixLegCid <- submitMulti [custodian] [] do
-  --  exerciseCmd custodianCashInstructionFixLegCid Instruction.Approve with approval = TakeDelivery custodianAccount
-  custodianCashInstructionFloatingLegCid <- submitMulti [investor] [] do
-    exerciseCmd custodianCashInstructionFloatingLegCid Instruction.Approve with approval = TakeDelivery investorAccount
+  custodianCashInstructionDefaultPaymentLegCid <- submitMulti [investor] [] do
+    exerciseCmd custodianCashInstructionDefaultPaymentCid Instruction.Approve with approval = TakeDelivery investorAccount
 
   -- Settle batch
   let settlerUsed = head $ toList settlers

--- a/src/test/daml/Daml/Finance/Settlement/Test/Batch.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Batch.daml
@@ -60,7 +60,7 @@ run settleCashOnLedger = script do
   -- Originate instruments
   now <- getTime
   equityInstrument <- Instrument.originate csd issuer "AAPL" "Apple Inc." [] now
-  cashInstrument <- Instrument.originate cb cb "USD" "United States Doller" [] now
+  cashInstrument <- Instrument.originate cb cb "USD" "United States Dollar" [] now
 
   -- Custody accounts
   [buyerCustodyAccount, sellerCustodyAccount] <- mapA (Account.createAccount "Custody Account" [] accountFactoryCid holdingFactoryCid [] bank) [buyer, seller]

--- a/src/test/daml/Daml/Finance/Settlement/Test/BatchWithIntermediaries.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/BatchWithIntermediaries.daml
@@ -81,7 +81,7 @@ run settleWithOwnAccount = script do
   now <- getTime
   equityInstrument <- Instrument.originate csd issuer "AAPL" "Apple Inc." [] now
   equityTransferableCid <- Account.credit [] equityInstrument 1_000.0 sellerSecurityAccount
-  cashInstrument <- Instrument.originate cb cb "USD" "United States Doller" [] now
+  cashInstrument <- Instrument.originate cb cb "USD" "United States Dollar" [] now
   buyerCashTransferableCid <- Account.credit [] cashInstrument 200_000.0 buyerCashAccount
 
   -- Instruct settlement (by first creating a settlement factory with intermediaries from Buyer to Seller)

--- a/src/test/daml/Daml/Finance/Settlement/Test/Intermediated.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Intermediated.daml
@@ -106,7 +106,7 @@ run useDelegatee = script do
   -- Distribute
   -- cash
   now <- getTime
-  cashInstrument <- Instrument.originate cb cb "USD" "United States Doller" [] now
+  cashInstrument <- Instrument.originate cb cb "USD" "United States Dollar" [] now
   [buyerCashCid] <- mapA (Account.credit [publicParty] cashInstrument 200_000.0) [buyerCashAccount]
 
   -- assets

--- a/src/test/daml/Daml/Finance/Settlement/Test/Transfer.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Transfer.daml
@@ -62,7 +62,7 @@ run = script do
 
   -- Distribute asset
   now <- getTime
-  cashInstrument <- Instrument.originate cb cb "USD" "United States Doller" [] now
+  cashInstrument <- Instrument.originate cb cb "USD" "United States Dollar" [] now
   transferableCid <- coerceContractId <$> Account.credit [publicParty] cashInstrument 200_000.0 senderAccount
 
   -- Create settlement factory
@@ -117,7 +117,7 @@ run2 = script do
 
   -- Distribute asset
   now <- getTime
-  cashInstrument <- Instrument.originate cb cb "USD" "United States Doller" [] now
+  cashInstrument <- Instrument.originate cb cb "USD" "United States Dollar" [] now
   transferableCid1 <- coerceContractId <$> Account.credit [publicParty] cashInstrument 100_000.0 senderAccount
   transferableCid2 <- coerceContractId <$> Account.credit [publicParty] cashInstrument 200_000.0 senderAccount
   transferableCid3 <- coerceContractId <$> Account.credit [publicParty] cashInstrument 300_000.0 senderAccount


### PR DESCRIPTION
I have created a first version of credit default swaps: https://github.com/digital-asset/daml-finance/issues/143

This uses the `until` node in contingent claims. I noticed that this is not currently pruned automatically in the lifecycle code. I have tracked here: https://github.com/digital-asset/daml-finance/issues/166
I would like to discuss that when Matteo is back and solve any follow-up work as part of a separate PR.

In order to more easily evaluate different scenarios, I implemented two different test cases:

1. a CDS which has a credit event during the lifetime
2. a CDS which does not have a credit event during the lifetime

I added two utility functions for creating the claims. I also found an extra possibility for improvement, tracked here: https://github.com/digital-asset/daml-finance/issues/149

