### PR TITLE
Settlement interfaces

### DIFF
--- a/daml.yaml
+++ b/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance
 source: src/test/daml
-version: 0.1.4
+version: 0.1.5
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-instrument-bond
 source: daml
-version: 0.1.4
+version: 0.1.5
 dependencies:
   - daml-prim
   - daml-stdlib
@@ -12,17 +12,12 @@ data-dependencies:
   - .lib/contingent-claims/v3.0.0.20220721.1/contingent-claims-3.0.0.20220721.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.4/daml-finance-interface-types-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.4/daml-finance-interface-util-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.4/daml-finance-interface-data-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.4/daml-finance-interface-instrument-base-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/0.1.4/daml-finance-interface-instrument-token-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.4/daml-finance-interface-lifecycle-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.4/daml-finance-interface-settlement-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.4/daml-finance-interface-instrument-generic-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.5/daml-finance-interface-lifecycle-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.5/daml-finance-interface-instrument-generic-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/0.1.4/daml-finance-interface-instrument-bond-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.4/daml-finance-interface-claims-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.4/daml-finance-instrument-generic-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Data/0.1.4/daml-finance-data-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.5/daml-finance-instrument-generic-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Util/0.1.4/daml-finance-util-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.4/daml-finance-lifecycle-0.1.4.dar
 build-options:
   - --target=1.15

--- a/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-instrument-equity
 source: daml
-version: 0.1.4
+version: 0.1.5
 dependencies:
   - daml-prim
   - daml-stdlib
@@ -12,9 +12,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.4/daml-finance-interface-types-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.4/daml-finance-interface-util-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.4/daml-finance-interface-instrument-base-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/0.1.4/daml-finance-interface-instrument-token-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.4/daml-finance-interface-lifecycle-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.1.4/daml-finance-interface-instrument-equity-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.4/daml-finance-lifecycle-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.1.5/daml-finance-interface-instrument-equity-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.5/daml-finance-lifecycle-0.1.5.dar
 build-options:
   - --target=1.15

--- a/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-instrument-generic
 source: daml
-version: 0.1.4
+version: 0.1.5
 dependencies:
   - daml-prim
   - daml-stdlib
@@ -15,12 +15,11 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.4/daml-finance-interface-data-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.4/daml-finance-interface-holding-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.4/daml-finance-interface-instrument-base-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/0.1.4/daml-finance-interface-instrument-token-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.4/daml-finance-interface-claims-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.4/daml-finance-interface-lifecycle-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.4/daml-finance-interface-instrument-generic-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.5/daml-finance-interface-lifecycle-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.5/daml-finance-interface-instrument-generic-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Data/0.1.4/daml-finance-data-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Util/0.1.4/daml-finance-util-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.4/daml-finance-lifecycle-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.5/daml-finance-lifecycle-0.1.5.dar
 build-options:
   - --target=1.15

--- a/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
@@ -4,19 +4,19 @@
 sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-instrument-swap
 source: daml
-version: 0.1.4
+version: 0.1.5
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
   - .lib/contingent-claims/v3.0.0.20220721.1/contingent-claims-3.0.0.20220721.1.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.4/daml-finance-instrument-generic-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.5/daml-finance-instrument-generic-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.4/daml-finance-interface-types-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.4/daml-finance-interface-util-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.4/daml-finance-interface-instrument-base-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.4/daml-finance-interface-claims-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.4/daml-finance-interface-lifecycle-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.4/daml-finance-interface-instrument-generic-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.5/daml-finance-interface-lifecycle-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.5/daml-finance-interface-instrument-generic-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.1.4/daml-finance-interface-instrument-swap-0.1.4.dar
 build-options:
   - --target=1.15

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-interface-instrument-equity
 source: daml
-version: 0.1.4
+version: 0.1.5
 dependencies:
   - daml-prim
   - daml-stdlib
@@ -12,6 +12,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.4/daml-finance-interface-types-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.4/daml-finance-interface-util-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.4/daml-finance-interface-instrument-base-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.4/daml-finance-interface-lifecycle-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.5/daml-finance-interface-lifecycle-0.1.5.dar
 build-options:
   - --target=1.15

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-interface-instrument-generic
 source: daml
-version: 0.1.4
+version: 0.1.5
 dependencies:
   - daml-prim
   - daml-stdlib
@@ -15,6 +15,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.4/daml-finance-interface-claims-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.4/daml-finance-interface-data-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.4/daml-finance-interface-instrument-base-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.4/daml-finance-interface-lifecycle-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.5/daml-finance-interface-lifecycle-0.1.5.dar
 build-options:
   - --target=1.15

--- a/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-interface-lifecycle
 source: daml
-version: 0.1.4
+version: 0.1.5
 dependencies:
   - daml-prim
   - daml-stdlib
@@ -13,6 +13,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.4/daml-finance-interface-data-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.4/daml-finance-interface-holding-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.4/daml-finance-interface-instrument-base-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.4/daml-finance-interface-settlement-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.5/daml-finance-interface-settlement-0.1.5.dar
 build-options:
   - --target=1.15

--- a/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-interface-settlement
 source: daml
-version: 0.1.4
+version: 0.1.5
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-lifecycle
 source: daml
-version: 0.1.4
+version: 0.1.5
 dependencies:
   - daml-prim
   - daml-stdlib
@@ -13,7 +13,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.4/daml-finance-interface-util-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.4/daml-finance-interface-holding-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.4/daml-finance-interface-instrument-base-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.4/daml-finance-interface-settlement-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.4/daml-finance-interface-lifecycle-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.5/daml-finance-interface-settlement-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.5/daml-finance-interface-lifecycle-0.1.5.dar
 build-options:
   - --target=1.15

--- a/package/main/daml/Daml.Finance.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Settlement/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-settlement
 source: daml
-version: 0.1.4
+version: 0.1.5
 dependencies:
   - daml-prim
   - daml-stdlib
@@ -12,7 +12,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.4/daml-finance-interface-types-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.4/daml-finance-interface-util-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.4/daml-finance-interface-holding-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.4/daml-finance-interface-settlement-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.5/daml-finance-interface-settlement-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Util/0.1.4/daml-finance-util-0.1.4.dar
 build-options:
   - --target=1.15

--- a/package/test/daml/Daml.Finance.Data.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Data.Test/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-data-test
 source: daml
-version: 0.1.4
+version: 0.1.5
 dependencies:
   - daml-prim
   - daml-stdlib
@@ -13,6 +13,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.4/daml-finance-interface-types-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.4/daml-finance-interface-util-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Data/0.1.4/daml-finance-data-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/0.1.4/daml-finance-test-util-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/0.1.5/daml-finance-test-util-0.1.5.dar
 build-options:
   - --target=1.15

--- a/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-holding-test
 source: daml
-version: 0.1.4
+version: 0.1.5
 dependencies:
   - daml-prim
   - daml-stdlib
@@ -14,6 +14,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.4/daml-finance-interface-util-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.4/daml-finance-interface-holding-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Holding/0.1.4/daml-finance-holding-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/0.1.4/daml-finance-test-util-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/0.1.5/daml-finance-test-util-0.1.5.dar
 build-options:
   - --target=1.15

--- a/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-instrument-bond-test
 source: daml
-version: 0.1.4
+version: 0.1.5
 dependencies:
   - daml-prim
   - daml-stdlib
@@ -16,15 +16,15 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.4/daml-finance-interface-holding-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.4/daml-finance-interface-instrument-base-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.4/daml-finance-interface-claims-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.4/daml-finance-interface-settlement-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.4/daml-finance-interface-lifecycle-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.4/daml-finance-interface-instrument-generic-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.4/daml-finance-instrument-generic-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.5/daml-finance-interface-settlement-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.5/daml-finance-interface-lifecycle-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.5/daml-finance-interface-instrument-generic-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.5/daml-finance-instrument-generic-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Holding/0.1.4/daml-finance-holding-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/0.1.4/daml-finance-settlement-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.4/daml-finance-lifecycle-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/0.1.5/daml-finance-settlement-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.5/daml-finance-lifecycle-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Data/0.1.4/daml-finance-data-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Bond/0.1.4/daml-finance-instrument-bond-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/0.1.4/daml-finance-test-util-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Bond/0.1.5/daml-finance-instrument-bond-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/0.1.5/daml-finance-test-util-0.1.5.dar
 build-options:
   - --target=1.15

--- a/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-instrument-equity-test
 source: daml
-version: 0.1.4
+version: 0.1.5
 dependencies:
   - daml-prim
   - daml-stdlib
@@ -13,14 +13,14 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.4/daml-finance-interface-types-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.4/daml-finance-interface-util-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.4/daml-finance-interface-instrument-base-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.4/daml-finance-interface-settlement-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.4/daml-finance-interface-lifecycle-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.1.4/daml-finance-interface-instrument-equity-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.5/daml-finance-interface-settlement-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.5/daml-finance-interface-lifecycle-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.1.5/daml-finance-interface-instrument-equity-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Holding/0.1.4/daml-finance-holding-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/0.1.4/daml-finance-settlement-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.4/daml-finance-lifecycle-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/0.1.5/daml-finance-settlement-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.5/daml-finance-lifecycle-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Data/0.1.4/daml-finance-data-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Equity/0.1.4/daml-finance-instrument-equity-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/0.1.4/daml-finance-test-util-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Equity/0.1.5/daml-finance-instrument-equity-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/0.1.5/daml-finance-test-util-0.1.5.dar
 build-options:
   - --target=1.15

--- a/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-instrument-generic-test
 source: daml
-version: 0.1.4
+version: 0.1.5
 dependencies:
   - daml-prim
   - daml-stdlib
@@ -16,14 +16,14 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.4/daml-finance-interface-holding-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.4/daml-finance-interface-instrument-base-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.4/daml-finance-interface-claims-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.4/daml-finance-interface-settlement-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.4/daml-finance-interface-lifecycle-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.4/daml-finance-interface-instrument-generic-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.5/daml-finance-interface-settlement-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.5/daml-finance-interface-lifecycle-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.5/daml-finance-interface-instrument-generic-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Holding/0.1.4/daml-finance-holding-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/0.1.4/daml-finance-settlement-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.4/daml-finance-lifecycle-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/0.1.5/daml-finance-settlement-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.5/daml-finance-lifecycle-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Data/0.1.4/daml-finance-data-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.4/daml-finance-instrument-generic-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/0.1.4/daml-finance-test-util-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.5/daml-finance-instrument-generic-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/0.1.5/daml-finance-test-util-0.1.5.dar
 build-options:
   - --target=1.15

--- a/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
@@ -4,26 +4,26 @@
 sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-instrument-swap-test
 source: daml
-version: 0.1.4
+version: 0.1.5
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.4/daml-finance-instrument-generic-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.5/daml-finance-instrument-generic-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.4/daml-finance-interface-types-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.4/daml-finance-interface-data-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.4/daml-finance-interface-util-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.4/daml-finance-interface-holding-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.4/daml-finance-interface-instrument-base-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.4/daml-finance-interface-settlement-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.4/daml-finance-interface-lifecycle-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.4/daml-finance-interface-instrument-generic-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.5/daml-finance-interface-settlement-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.5/daml-finance-interface-lifecycle-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.5/daml-finance-interface-instrument-generic-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Holding/0.1.4/daml-finance-holding-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/0.1.4/daml-finance-settlement-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.4/daml-finance-lifecycle-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/0.1.5/daml-finance-settlement-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.5/daml-finance-lifecycle-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Data/0.1.4/daml-finance-data-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Swap/0.1.4/daml-finance-instrument-swap-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/0.1.4/daml-finance-test-util-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Swap/0.1.5/daml-finance-instrument-swap-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/0.1.5/daml-finance-test-util-0.1.5.dar
 build-options:
   - --target=1.15

--- a/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-settlement-test
 source: daml
-version: 0.1.4
+version: 0.1.5
 dependencies:
   - daml-prim
   - daml-stdlib
@@ -14,9 +14,9 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.4/daml-finance-interface-util-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.4/daml-finance-interface-holding-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.4/daml-finance-interface-instrument-base-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.4/daml-finance-interface-settlement-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.5/daml-finance-interface-settlement-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Holding/0.1.4/daml-finance-holding-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/0.1.4/daml-finance-settlement-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/0.1.4/daml-finance-test-util-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/0.1.5/daml-finance-settlement-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/0.1.5/daml-finance-test-util-0.1.5.dar
 build-options:
   - --target=1.15

--- a/package/test/daml/Daml.Finance.Test.Util/daml.yaml
+++ b/package/test/daml/Daml.Finance.Test.Util/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.4.0-snapshot.20220830.10494.0.4622de48
 name: daml-finance-test-util
 source: daml
-version: 0.1.4
+version: 0.1.5
 dependencies:
   - daml-prim
   - daml-stdlib
@@ -14,9 +14,9 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.4/daml-finance-interface-util-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.4/daml-finance-interface-holding-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.4/daml-finance-interface-instrument-base-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.4/daml-finance-interface-lifecycle-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.5/daml-finance-interface-lifecycle-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Holding/0.1.4/daml-finance-holding-0.1.4.dar
   - .lib/daml-finance/Daml.Finance.Instrument.Token/0.1.4/daml-finance-instrument-token-0.1.4.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.4/daml-finance-lifecycle-0.1.4.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.5/daml-finance-lifecycle-0.1.5.dar
 build-options:
   - --target=1.15

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Rule/Claim.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Rule/Claim.daml
@@ -6,7 +6,9 @@ module Daml.Finance.Interface.Lifecycle.Rule.Claim where
 import Daml.Finance.Interface.Holding.Base qualified as Base (I)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (I)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (I)
+import Daml.Finance.Interface.Settlement.Factory qualified as Factory (I)
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (I)
+import Daml.Finance.Interface.Types.Common (Id, Parties)
 
 -- | Type synonym for `Claim`.
 type I = Claim
@@ -15,7 +17,17 @@ type I = Claim
 type V = View
 
 -- | View for `Settlement`.
-data View = View {} deriving (Eq, Ord, Show)
+data View = View
+  with
+    providers : Parties
+      -- ^ Providers of the claim rule. Together with the actors of the `ClaimEffect` choice the authorization requirements to upgrade the holdings being claimed have to be met.
+    claimers : Parties
+      -- ^ Any of the parties can claim an effect.
+    settlers : Parties
+      -- ^ Any of the parties can trigger settlement of the resulting batch.
+    settlementFactoryCid : ContractId Factory.I
+      -- ^ Settlement factory contract used to create a `Batch` of `Instruction`\s.
+  deriving (Eq, Ord, Show)
 
 -- | Data type wrapping the results of `Claim`ing an `Effect`.
 data ClaimResult = ClaimResult
@@ -50,9 +62,11 @@ interface Claim where
       claimer : Party
         -- ^ The party claiming the effect.
       holdingCids : [ContractId Base.I]
-        -- ^ The positions to process as part of the claim.
+        -- ^ The holdings to process.
       effectCid : ContractId Effect.I
-        -- ^ The effect to settle.
+        -- ^ The effect to process.
+      batchId : Id
+        -- ^ Identifier used for the generated settlement batch.
     controller claimer
     do
       claimEffect this arg

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Batch.daml
@@ -16,14 +16,16 @@ type V = View
 -- | View for `Batch`.
 data View = View
   with
+    requestors : Parties
+      -- ^ Parties requesting the settlement.
     settlers : Parties
       -- ^ Parties that can trigger the final settlement.
-    steps : [Step]
-      -- ^ Settlement steps.
     id : Id
       -- ^ Batch identifier.
     description : Text
       -- ^ Batch description.
+    steps : [Step]
+      -- ^ Settlement steps.
   deriving (Eq, Show)
 
 -- | An interface for atomically settling `Transferable`\s.

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Batch.daml
@@ -24,6 +24,8 @@ data View = View
       -- ^ Batch identifier.
     description : Text
       -- ^ Batch description.
+    contextId : Optional Id
+      -- ^ Identifier to link a batch to a context (eg. the `Effect` it originated from).
     steps : [Step]
       -- ^ Settlement steps.
   deriving (Eq, Show)

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Factory.daml
@@ -50,6 +50,8 @@ interface Factory where
         -- ^ Factory identifier.
       description : Text
         -- ^ Batch description.
+      contextId : Optional Id
+        -- ^ Identifier to link a batch to a context (eg. the `Effect` it originated from).
       steps : [Step]
         -- ^ Settlement steps to instruct.
     controller instructors

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Instruction.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Instruction.daml
@@ -17,12 +17,22 @@ type V = View
 -- | View for `Instruction`.
 data View = View
   with
+    requestors : Parties
+      -- ^ Parties that instructed settlement.
     settlers : Parties
       -- ^ Parties that can execute the Instruction.
-    step : Step
-      -- ^ Instruction details to execute.
+    signed : Parties
+      -- ^ Additional signatories, used to collect authorization.
+    batchId : Id
+      -- ^ Batch identifier.
     id : Id
       -- ^ Instruction identifier.
+    step : Step
+      -- ^ Instruction details to execute.
+    allocation : Allocation
+      -- ^ Allocation from the sender.
+    approval : Approval
+      -- ^ Approval from the receiver.
   deriving (Eq, Show)
 
 -- | An interface for providing a single instruction to transfer an asset.

--- a/src/main/daml/Daml/Finance/Lifecycle/Rule/Claim.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Rule/Claim.daml
@@ -77,5 +77,12 @@ template Rule
         newInstrumentHoldingCids <- fmap sequence . mapA updateInstrumentHolding $ zip holdings holdingCids
 
         -- Generate settlement instructions for other instruments
-        (batchCid, instructionCids) <- exercise settlementFactoryCid Factory.Instruct with instructors = providers; settlers; id = batchId; description = effectView.description; steps
+        (batchCid, instructionCids) <- exercise settlementFactoryCid Factory.Instruct
+          with
+            instructors = providers
+            settlers
+            id = batchId
+            description = effectView.description
+            contextId = Some effectView.id
+            steps
         pure Claim.ClaimResult with newInstrumentHoldingCids; batchCid; instructionCids

--- a/src/main/daml/Daml/Finance/Lifecycle/Rule/Claim.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Rule/Claim.daml
@@ -4,8 +4,7 @@
 module Daml.Finance.Lifecycle.Rule.Claim where
 
 import DA.Foldable (forA_)
-import DA.Set (fromList, member)
-import DA.Text (sha256)
+import DA.Set (member)
 import Daml.Finance.Interface.Holding.Account qualified as Account (exerciseInterfaceByKey, Debit(..), Credit(..), I)
 import Daml.Finance.Interface.Holding.Util (getAccount, getAmount, getCustodian, getInstrument, getOwner)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
@@ -13,7 +12,7 @@ import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (CalculationR
 import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimResult(..), ClaimEffect(..), HasImplementation(..), I, View(..))
 import Daml.Finance.Interface.Settlement.Factory qualified as Factory (I, Instruct(..))
 import Daml.Finance.Interface.Settlement.Types (Step(..))
-import Daml.Finance.Interface.Types.Common (Id(..), Parties)
+import Daml.Finance.Interface.Types.Common (Parties)
 
 -- | Type synonym for `Rule`.
 type T = Rule
@@ -23,30 +22,27 @@ instance Claim.HasImplementation Rule
 -- | Rule contract that allows an actor to claim effects, returning settlement instructions.
 template Rule
   with
-    custodian : Party
-      -- ^ Custodian of the holding upon which an effect can be claimed.
-    owner : Party
-      -- ^ Owner of the holding upon which an effect can be claimed.
+    providers : Parties
+      -- ^ Providers of the claim rule. Together with the actors of the `ClaimEffect` choice the authorization requirements to upgrade the holdings being claimed have to be met.
     claimers : Parties
-      -- ^ Parties granted the ability to claim an effect.
-    factoryCid : ContractId Factory.I
-      -- ^ Factory contract used to create a `Batch` of `Instruction`\s.
+      -- ^ Any of the parties can claim an effect.
     settlers : Parties
-      -- ^ Any of the parties can trigger the settlement of the instructions.
+      -- ^ Any of the parties can trigger settlement of the resulting batch.
+    settlementFactoryCid : ContractId Factory.I
+      -- ^ Settlement factory contract used to create a `Batch` of `Instruction`\s.
   where
-    signatory custodian, owner
+    signatory providers
 
     interface instance Claim.I for Rule where
-      view = Claim.View {}
-      claimEffect Claim.ClaimEffect{claimer; holdingCids; effectCid} = do
-        assertMsg "Effect can only be claimed by authorized parties." $ claimer `member` claimers
+      view = Claim.View with providers; claimers; settlers; settlementFactoryCid
+      claimEffect Claim.ClaimEffect{claimer; holdingCids; effectCid; batchId} = do
+        assertMsg "Effect can only be claimed by authorized parties." $ claimer `member` this.claimers
         effectView <- exercise effectCid Effect.GetView with viewer = claimer
         holdings <- mapA fetch holdingCids
         forA_ holdings \h -> do
           assertMsg "The provided holding does not reference the expected instrument." $ getInstrument h == effectView.targetInstrument
-          assertMsg "The settlement rule is missing the signature of the holding custodian" $ getCustodian h == custodian
-          assertMsg "The settlement rule is missing the signature of the holding owner" $ getOwner h == owner
-          -- These checks ^ effectively prevent the holding owner or custodian from single-handedly choosing the settlement vehicle.
+          assertMsg "The settlement rule is missing the signature of a holding custodian" $ getCustodian h `member` providers
+          assertMsg "The settlement rule is missing the signature of a holding owner" $ getOwner h `member` providers
 
         -- Calculate settlement steps
         let
@@ -81,6 +77,5 @@ template Rule
         newInstrumentHoldingCids <- fmap sequence . mapA updateInstrumentHolding $ zip holdings holdingCids
 
         -- Generate settlement instructions for other instruments
-        let id = Id . sha256 $ show effectView.id <> partyToText custodian <> partyToText owner
-        (batchCid, instructionCids) <- exercise factoryCid Factory.Instruct with instructors = fromList [custodian, owner]; settlers; id; description = effectView.description; steps
+        (batchCid, instructionCids) <- exercise settlementFactoryCid Factory.Instruct with instructors = providers; settlers; id = batchId; description = effectView.description; steps
         pure Claim.ClaimResult with newInstrumentHoldingCids; batchCid; instructionCids

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -41,6 +41,9 @@ template Batch
     signatory requestors
     observer settlers
 
+    key (requestors, id) : (Parties, Id)
+    maintainer fst key
+
     let
       (steps, instructionIds) = unzip stepsWithInstructionId
       undiscloseA actors = Account.undisclose (show id, settlers) (head $ toList actors) actors

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -35,6 +35,8 @@ template Batch
       -- ^ Batch identifier.
     description : Text
       -- ^ Batch description.
+    contextId : Optional Id
+      -- ^ Identifier to link a batch to a context (eg. the `Effect` it originated from).
     stepsWithInstructionId : [(Step, Id)]
       -- ^ The settlement `Step`\s and the identifiers of the corresponding `Instruction`\s.
   where
@@ -50,7 +52,7 @@ template Batch
       undiscloseT actors = undisclose @Transferable.I (show id, actors) actors
 
     interface instance Batch.I for Batch where
-      view = Batch.View with requestors; settlers; id; description; steps
+      view = Batch.View with requestors; settlers; id; description; contextId; steps
       settle Batch.Settle{actors} = do
         (_, instructionsWithDisclosureInfo) <- foldrA
           (\(step, instructionId) acc ->

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -1,10 +1,7 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Daml.Finance.Settlement.Batch
-  ( Batch(..)
-  , T
-  ) where
+module Daml.Finance.Settlement.Batch where
 
 import DA.Action (foldrA)
 import DA.Foldable (forA_)
@@ -50,7 +47,7 @@ template Batch
       undiscloseT actors = undisclose @Transferable.I (show id, actors) actors
 
     interface instance Batch.I for Batch where
-      view = Batch.View with id; description; settlers; steps
+      view = Batch.View with requestors; settlers; id; description; steps
       settle Batch.Settle{actors} = do
         (_, instructionsWithDisclosureInfo) <- foldrA
           (\(step, instructionId) acc ->

--- a/src/main/daml/Daml/Finance/Settlement/Factory.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Factory.daml
@@ -35,7 +35,7 @@ template Factory
       instruct Factory.Instruct{instructors; settlers; id; description; steps} = do
         let
           createInstruction step index =
-            Instruction with requestors = instructors; signed = empty; settlers; step; allocation = Unallocated; approval = Unapproved; tradeId = id; id = Id (show index); observers = M.fromList [(show id, settlers)]
+            Instruction with requestors = instructors; signed = empty; settlers; step; allocation = Unallocated; approval = Unapproved; batchId = id; id = Id (show index); observers = M.fromList [(show id, settlers)]
           instructions = mapWithIndex createInstruction steps
           instructionIds = map (.id) instructions
         instructionCids <- mapA (fmap toInterfaceContractId . create) instructions
@@ -70,7 +70,7 @@ template FactoryWithIntermediaries
             ) $ groupOn (.quantity.unit) steps
           -- For each step, generate instructions and ids.
           createInstruction step index =
-            Instruction with requestors = instructors; signed = empty; settlers; step; allocation = Unallocated; approval = Unapproved; tradeId = id; id = Id (show index); observers = M.fromList [(show id, settlers)]
+            Instruction with requestors = instructors; signed = empty; settlers; step; allocation = Unallocated; approval = Unapproved; batchId = id; id = Id (show index); observers = M.fromList [(show id, settlers)]
           instructions = mapWithIndex createInstruction groupedSteps
           instructionIds = map (.id) instructions
         instructionCids <- mapA (fmap toInterfaceContractId . create) instructions

--- a/src/main/daml/Daml/Finance/Settlement/Factory.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Factory.daml
@@ -28,14 +28,14 @@ template Factory
 
     interface instance Factory.I for Factory where
       view = Factory.View with provider; observers
-      instruct Factory.Instruct{instructors; settlers; id; description; steps} = do
+      instruct Factory.Instruct{instructors; settlers; id; description; contextId; steps} = do
         let
           createInstruction step index =
             Instruction with requestors = instructors; signed = empty; settlers; step; allocation = Unallocated; approval = Unapproved; batchId = id; id = Id (show index); observers = M.fromList [(show id, settlers)]
           instructions = mapWithIndex createInstruction steps
           instructionIds = map (.id) instructions
         instructionCids <- mapA (fmap toInterfaceContractId . create) instructions
-        batchCid <- toInterfaceContractId <$> create Batch with requestors = instructors; settlers; id; description; stepsWithInstructionId = zip steps instructionIds
+        batchCid <- toInterfaceContractId <$> create Batch with requestors = instructors; settlers; id; description; contextId; stepsWithInstructionId = zip steps instructionIds
         pure (batchCid, instructionCids)
 
 -- | Factory template that implements the `Factory` interface.
@@ -56,7 +56,7 @@ template FactoryWithIntermediaries
 
     interface instance Factory.I for FactoryWithIntermediaries where
       view = Factory.View with provider; observers
-      instruct Factory.Instruct{instructors; settlers; id; description; steps} = do
+      instruct Factory.Instruct{instructors; settlers; id; description; contextId; steps} = do
         let
           -- Group steps by instrument. For each group, lookup corresponding paths and expand steps according to the corresponding settlement route.
           groupedSteps = mconcat $ fromSomeNote "Could not find path or route." $ mapA (\steps -> do
@@ -70,7 +70,7 @@ template FactoryWithIntermediaries
           instructions = mapWithIndex createInstruction groupedSteps
           instructionIds = map (.id) instructions
         instructionCids <- mapA (fmap toInterfaceContractId . create) instructions
-        batchCid <- toInterfaceContractId <$> create Batch with requestors = instructors; settlers; id; description; stepsWithInstructionId = zip groupedSteps instructionIds
+        batchCid <- toInterfaceContractId <$> create Batch with requestors = instructors; settlers; id; description; contextId; stepsWithInstructionId = zip groupedSteps instructionIds
         pure (batchCid, instructionCids)
 
 -- | Data type that describes a hierarchical account structure between two parties for holdings on an instrument.

--- a/src/main/daml/Daml/Finance/Settlement/Factory.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Factory.daml
@@ -1,11 +1,7 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Daml.Finance.Settlement.Factory
-  ( Factory(..)
-  , FactoryWithIntermediaries(..)
-  , Path(..)
-  ) where
+module Daml.Finance.Settlement.Factory where
 
 import DA.List (groupOn, head, isSuffixOf, stripSuffix, tails)
 import DA.Map qualified as M (Map, fromList, lookup)

--- a/src/main/daml/Daml/Finance/Settlement/Instruction.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Instruction.daml
@@ -28,10 +28,10 @@ template Instruction
   with
     requestors : Parties
       -- ^ Parties requesting the settlement.
-    signed : Parties
-      -- ^ Additional signatories, used to collect authorization.
     settlers : Parties
       -- ^ Any of the parties can trigger the settlement.
+    signed : Parties
+      -- ^ Additional signatories, used to collect authorization.
     batchId : Id
       -- ^ Trade identifier.
     id : Id
@@ -39,9 +39,9 @@ template Instruction
     step : Step
       -- ^ Settlement step.
     allocation : Allocation
-      -- ^ Allocated holding and its template type rep text representation.
+      -- ^ Allocation from the sender.
     approval : Approval
-      -- ^ Receiving account.
+      -- ^ Approval from the receiver.
     observers : PartiesMap
       -- ^ Observers.
   where
@@ -65,7 +65,7 @@ template Instruction
 
     interface instance Instruction.I for Instruction where
       asDisclosure = toInterface @Disclosure.I this
-      view = Instruction.View with id; step; settlers
+      view = Instruction.View with requestors; settlers; signed; batchId; id; step; allocation; approval
       allocate Instruction.Allocate{allocation} = do
         assertMsg ("allocation must be new" <> messageSuffix) $ allocation /= this.allocation
         -- clean up if previously allocated

--- a/src/main/daml/Daml/Finance/Settlement/Instruction.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Instruction.daml
@@ -32,7 +32,7 @@ template Instruction
       -- ^ Additional signatories, used to collect authorization.
     settlers : Parties
       -- ^ Any of the parties can trigger the settlement.
-    tradeId : Id
+    batchId : Id
       -- ^ Trade identifier.
     id : Id
       -- ^ Instruction identifier.
@@ -48,15 +48,15 @@ template Instruction
     signatory requestors, signed
     observer step.sender, step.receiver, settlers, Disclosure.flattenObservers observers
 
-    key (requestors, tradeId, id) : (Parties, Id, Id)
+    key (requestors, batchId, id) : (Parties, Id, Id)
     maintainer fst3 key
 
     let
       messageSuffix = " / instruction id = " <> show id
-      discloseA account = Account.disclose (show tradeId, settlers) account.owner (singleton account.owner) account
-      undiscloseA account = Account.undisclose (show tradeId, settlers) account.owner (singleton account.owner) account
-      discloseT discloser settlers cid = disclose @Transferable.I (show tradeId, settlers) discloser (singleton discloser) cid
-      undiscloseT discloser settlers cid = undisclose @Transferable.I (show tradeId, settlers) (singleton discloser) cid
+      discloseA account = Account.disclose (show batchId, settlers) account.owner (singleton account.owner) account
+      undiscloseA account = Account.undisclose (show batchId, settlers) account.owner (singleton account.owner) account
+      discloseT discloser settlers cid = disclose @Transferable.I (show batchId, settlers) discloser (singleton discloser) cid
+      undiscloseT discloser settlers cid = undisclose @Transferable.I (show batchId, settlers) (singleton discloser) cid
 
     interface instance Disclosure.I for Instruction where
       view = Disclosure.View with disclosureControllers = fromList [step.sender, step.receiver]; observers

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
@@ -5,8 +5,8 @@ module Daml.Finance.Instrument.Bond.Test.Util where
 
 import DA.Date
 import DA.List (head)
-import DA.Map (fromList)
-import DA.Set (empty, singleton, toList)
+import DA.Map qualified as M (fromList)
+import DA.Set (empty, fromList, singleton, toList)
 import Daml.Finance.Instrument.Bond.FixedRate.Instrument qualified as FixedRate (Instrument(..))
 import Daml.Finance.Instrument.Bond.FloatingRate.Instrument qualified as FloatingRate (Instrument(..))
 import Daml.Finance.Instrument.Bond.InflationLinked.Instrument qualified as InflationLinked (Instrument(..))
@@ -67,7 +67,7 @@ originateFixedRateBond depository issuer label description observers lastEventTi
     periodicSchedule = createPaymentPeriodicSchedule firstCouponDate holidayCalendarIds businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate
   -- CREATE_FIXED_RATE_BOND_INSTRUMENT_BEGIN
   cid <- toInterfaceContractId @Instrument.I <$> submitMulti [depository, issuer] [] do
-    createCmd FixedRate.Instrument with depository; issuer; id = Id label; version = "0"; description; observers = fromList observers; lastEventTimestamp; periodicSchedule; holidayCalendarIds; calendarDataProvider; dayCountConvention; couponRate; currency
+    createCmd FixedRate.Instrument with depository; issuer; id = Id label; version = "0"; description; observers = M.fromList observers; lastEventTimestamp; periodicSchedule; holidayCalendarIds; calendarDataProvider; dayCountConvention; couponRate; currency
   -- CREATE_FIXED_RATE_BOND_INSTRUMENT_END
   createReference cid depository issuer observers
 
@@ -75,7 +75,7 @@ originateZeroCouponBond : Party -> Party -> Text -> Text -> [(Text, Parties)] ->
 originateZeroCouponBond depository issuer label description observers lastEventTimestamp issueDate maturityDate currency = do
   -- CREATE_ZERO_COUPON_BOND_INSTRUMENT_BEGIN
   cid <- toInterfaceContractId <$> submitMulti [depository, issuer] [] do
-    createCmd ZeroCoupon.Instrument with depository; issuer; id = Id label; version = "0"; description; observers = fromList observers; lastEventTimestamp; issueDate; maturityDate; currency
+    createCmd ZeroCoupon.Instrument with depository; issuer; id = Id label; version = "0"; description; observers = M.fromList observers; lastEventTimestamp; issueDate; maturityDate; currency
   -- CREATE_ZERO_COUPON_BOND_INSTRUMENT_END
   createReference cid depository issuer observers
 
@@ -85,7 +85,7 @@ originateFloatingRateBond depository issuer label description observers lastEven
     periodicSchedule = createPaymentPeriodicSchedule firstCouponDate holidayCalendarIds businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate
   -- CREATE_FLOATING_RATE_BOND_INSTRUMENT_BEGIN
   cid <- toInterfaceContractId <$> submitMulti [depository, issuer] [] do
-    createCmd FloatingRate.Instrument with depository; issuer; id = Id label; version = "0"; description; observers = fromList observers; lastEventTimestamp; periodicSchedule; holidayCalendarIds; calendarDataProvider; dayCountConvention; couponSpread=couponRate; referenceRateId; currency
+    createCmd FloatingRate.Instrument with depository; issuer; id = Id label; version = "0"; description; observers = M.fromList observers; lastEventTimestamp; periodicSchedule; holidayCalendarIds; calendarDataProvider; dayCountConvention; couponSpread=couponRate; referenceRateId; currency
   -- CREATE_FLOATING_RATE_BOND_INSTRUMENT_END
   createReference cid depository issuer observers
 
@@ -95,7 +95,7 @@ originateInflationLinkedBond depository issuer label description observers lastE
     periodicSchedule = createPaymentPeriodicSchedule firstCouponDate holidayCalendarIds businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate
   -- CREATE_INFLATION_LINKED_BOND_INSTRUMENT_BEGIN
   cid <- toInterfaceContractId <$> submitMulti [depository, issuer] [] do
-    createCmd InflationLinked.Instrument with depository; issuer; id = Id label; version = "0"; description; observers = fromList observers; lastEventTimestamp; periodicSchedule; holidayCalendarIds; calendarDataProvider; dayCountConvention; couponRate; inflationIndexId; currency; inflationIndexBaseValue
+    createCmd InflationLinked.Instrument with depository; issuer; id = Id label; version = "0"; description; observers = M.fromList observers; lastEventTimestamp; periodicSchedule; holidayCalendarIds; calendarDataProvider; dayCountConvention; couponRate; inflationIndexId; currency; inflationIndexBaseValue
   -- CREATE_INFLATION_LINKED_BOND_INSTRUMENT_END
   createReference cid depository issuer observers
 
@@ -126,12 +126,12 @@ lifecycleAndVerifyCouponEffectsAndSettlement : [Party] -> Date -> Instrument.K -
 lifecycleAndVerifyCouponEffectsAndSettlement readAs today instrument settlers issuer investor investorBondTransferableCid custodianCashTransferableCid custodianAccount investorAccount obs custodian observableCids = do
   (lifecycleCid, [effectCid]) <- lifecycleInstrument readAs today instrument settlers issuer observableCids
 
-  newBondInstrumentKey <- submitMulti [issuer] [] do
+  newBondInstrumentKey <- submit issuer do
     Instrument.toKey <$> exerciseCmd @Instrument.I (coerceContractId lifecycleCid) Instrument.GetView with viewer = issuer
 
   -- CREATE_SETTLEMENT_FACTORY_BOND_BEGIN
   -- Create settlement factory
-  settlementFactoryCid <- submitMulti [investor] [] do createCmd Factory with provider = investor; observers = empty
+  settlementFactoryCid <- toInterfaceContractId <$> submit investor do createCmd Factory with provider = investor; observers = empty
   -- CREATE_SETTLEMENT_FACTORY_BOND_END
 
   -- CLAIM_EFFECT_BOND_BEGIN
@@ -139,17 +139,17 @@ lifecycleAndVerifyCouponEffectsAndSettlement readAs today instrument settlers is
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [custodian, investor] [] do
     createCmd Claim.Rule
       with
-        custodian
-        owner = investor
+        providers = fromList [custodian, investor]
         claimers = singleton investor
         settlers
-        factoryCid = toInterfaceContractId settlementFactoryCid
+        settlementFactoryCid
 
   result <- submitMulti [investor] readAs do
     exerciseCmd lifecycleClaimRuleCid Claim.ClaimEffect with
       claimer = investor
       holdingCids = [toInterfaceContractId @Base.I investorBondTransferableCid]
       effectCid
+      batchId = Id "CouponSettlement"
   -- CLAIM_EFFECT_BOND_END
 
   -- ALLOCATE_APPROVE_SETTLE_INSTRUCTIONS_BOND_BEGIN
@@ -179,27 +179,27 @@ lifecycleAndVerifyRedemptionEffectsAndSettlement : [Party] -> Date -> Instrument
 lifecycleAndVerifyRedemptionEffectsAndSettlement readAs today instrument settlers issuer investor investorBondTransferableCid custodianCashCouponTransferableCid custodianCashRedemptionTransferableCid custodianAccount investorAccount obs custodian observableCids = do
   (lifecycleCid, [effectCid]) <- lifecycleInstrument readAs today instrument settlers issuer observableCids
 
-  newBondInstrumentKey <- submitMulti [issuer] [] do
+  newBondInstrumentKey <- submit issuer do
     Instrument.toKey <$> exerciseCmd @Instrument.I (coerceContractId lifecycleCid) Instrument.GetView with viewer = issuer
 
   -- Create settlement factory
-  settlementFactoryCid <- submitMulti [investor] [] do createCmd Factory with provider = investor; observers = empty
+  settlementFactoryCid <- toInterfaceContractId <$> submit investor do createCmd Factory with provider = investor; observers = empty
 
   -- Claim effect
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [custodian, investor] [] do
     createCmd Claim.Rule
       with
-        custodian
-        owner = investor
+        providers = fromList [custodian, investor]
         claimers = singleton investor
         settlers
-        factoryCid = toInterfaceContractId settlementFactoryCid
+        settlementFactoryCid
 
   result <- submitMulti [investor] readAs do
     exerciseCmd lifecycleClaimRuleCid Claim.ClaimEffect with
       claimer = investor
       holdingCids = [toInterfaceContractId @Base.I investorBondTransferableCid]
       effectCid
+      batchId = Id "RedemptionSettlement"
 
   let [custodianCouponInstructionCid, custodianRedemptionInstructionCid] = result.instructionCids
 

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/ZeroCoupon.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/ZeroCoupon.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Instrument.Bond.Test.ZeroCoupon where
 
 import DA.Date
 import DA.Map qualified as M (fromList)
-import DA.Set (empty, singleton, toList)
+import DA.Set (empty, fromList, singleton, toList)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Instrument.Bond.Test.Util (lifecycleInstrument, originateZeroCouponBond, verifyNoLifecycleEffects)
 import Daml.Finance.Instrument.Bond.ZeroCoupon.Instrument qualified as ZeroCoupon (Instrument)
@@ -15,7 +15,7 @@ import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffe
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..))
-import Daml.Finance.Interface.Types.Common (AccountKey, Parties)
+import Daml.Finance.Interface.Types.Common (AccountKey, Id(..), Parties)
 import Daml.Finance.Lifecycle.Rule.Claim (Rule(..))
 import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Test.Util.Account qualified as Account (createAccount, createFactory, credit)
@@ -33,23 +33,23 @@ lifecycleAndVerifyRedemptionEffectsAndSettlement readAs today bondInstrument set
   let newBondInstrumentKey = Instrument.getKey $ toInterface newBondInstrument
 
   -- Create settlement factory
-  settlementFactoryCid <- submitMulti [investor] [] do createCmd Factory with provider = investor; observers = empty
+  settlementFactoryCid <- toInterfaceContractId <$> submit investor do createCmd Factory with provider = investor; observers = empty
 
   -- Claim effect
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [custodian, investor] [] do
     createCmd Rule
       with
-        custodian
-        owner = investor
+        providers = fromList [custodian, investor]
         claimers = singleton investor
         settlers
-        factoryCid = toInterfaceContractId settlementFactoryCid
+        settlementFactoryCid
 
   result <- submitMulti [investor] readAs do
     exerciseCmd lifecycleClaimRuleCid Claim.ClaimEffect with
       claimer = investor
       holdingCids = [toInterfaceContractId investorBondTransferableCid]
       effectCid
+      batchId = Id "RedemptionSettlement"
 
   let [custodianRedemptionInstructionCid] = result.instructionCids
 

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Instrument.Equity.Test.Dividend where
 
 import DA.Date (toDateUTC)
 import DA.Map qualified as M (fromList)
-import DA.Set (empty, singleton)
+import DA.Set (empty, fromList, singleton)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Instrument.Equity.Test.Util (originateEquity)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
@@ -46,7 +46,13 @@ run = script do
 
   -- Create lifecycle rules
   distributionRuleCid <- toInterfaceContractId @Lifecycle.I <$> submit issuer do createCmd Distribution.Rule with provider = singleton issuer; lifecycler = issuer; observers = singleton public
-  lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [issuer, investor] [] do createCmd Claim.Rule with custodian = issuer; owner = investor; claimers = singleton investor; settlers = singleton investor; factoryCid = settlementFactoryCid
+  claimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [issuer, investor] [] do
+    createCmd Claim.Rule
+      with
+        providers = fromList [issuer, investor]
+        claimers = singleton investor
+        settlers = singleton investor
+        settlementFactoryCid
 
   -- Create clock
   now <- getTime
@@ -74,7 +80,13 @@ run = script do
   (_, [effectCid]) <- submit issuer do exerciseCmd distributionRuleCid Lifecycle.Evolve with ruleName = "Dividend"; settlers = singleton investor; observableCids = []; eventCid = distributionEventCid; clockCid
 
   -- Claim effect
-  result <- submitMulti [investor] [public] do exerciseCmd lifecycleClaimRuleCid Claim.ClaimEffect with claimer = investor; holdingCids = [investorEquityCid]; effectCid
+  result <- submitMulti [investor] [public] do
+    exerciseCmd claimRuleCid Claim.ClaimEffect
+      with
+        claimer = investor
+        holdingCids = [investorEquityCid]
+        effectCid
+        batchId = Id "DividendSettlement"
 
   let
     Some [investorEquityTransferableCid] = result.newInstrumentHoldingCids

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Merger.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Merger.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Instrument.Equity.Test.Merger where
 
 import DA.Date (toDateUTC)
 import DA.Map qualified as M (fromList)
-import DA.Set (singleton)
+import DA.Set (fromList, singleton)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Instrument.Equity.Test.Util (originateEquity)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
@@ -45,7 +45,13 @@ run = script do
 
   -- Create lifecycle rules
   replacementRuleCid <- toInterfaceContractId @Lifecycle.I <$> submit merging do createCmd Replacement.Rule with providers = singleton merging; lifecycler = merging; observers = singleton public
-  lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [custodian, investor] [] do createCmd Claim.Rule with custodian; owner = investor; claimers = singleton investor; settlers = singleton investor; factoryCid = settlementFactoryCid
+  lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [custodian, investor] [] do
+    createCmd Claim.Rule
+      with
+        providers = fromList [custodian, investor]
+        claimers = singleton investor
+        settlers = singleton investor
+        settlementFactoryCid
 
   -- Create clock
   now <- getTime
@@ -71,7 +77,13 @@ run = script do
   (_, [effectCid]) <- submitMulti [merging] [public] do exerciseCmd replacementRuleCid Lifecycle.Evolve with ruleName = "Merger"; settlers = singleton investor; eventCid = replacementEventCid; observableCids = []; clockCid
 
   -- Claim effect
-  result <- submitMulti [investor] [public] do exerciseCmd lifecycleClaimRuleCid Claim.ClaimEffect with claimer = investor; holdingCids = [investorEquityCid]; effectCid
+  result <- submitMulti [investor] [public] do
+    exerciseCmd lifecycleClaimRuleCid Claim.ClaimEffect
+      with
+        claimer = investor
+        holdingCids = [investorEquityCid]
+        effectCid
+        batchId = Id "MergerSettlement"
 
   -- Allocate instructions
   let [instructionCid] = result.instructionCids

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/StockSplit.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/StockSplit.daml
@@ -4,8 +4,8 @@
 module Daml.Finance.Instrument.Equity.Test.StockSplit where
 
 import DA.Date (toDateUTC)
-import DA.Map (fromList)
-import DA.Set (singleton)
+import DA.Map qualified as M (fromList)
+import DA.Set (fromList, singleton)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Instrument.Equity.Test.Util (originateEquity)
 import Daml.Finance.Interface.Instrument.Equity.Instrument qualified as Equity (DeclareStockSplit(..), I)
@@ -34,7 +34,7 @@ run = script do
   -- Create factories
   let pp = [("Public", singleton public)]
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory issuer pp
-  holdingFactoryCid <- toInterfaceContractId <$> submit issuer do createCmd Fungible.Factory with provider = issuer; observers = fromList pp
+  holdingFactoryCid <- toInterfaceContractId <$> submit issuer do createCmd Fungible.Factory with provider = issuer; observers = M.fromList pp
   settlementFactoryCid <- toInterfaceContractId <$> submit issuer do createCmd Factory with provider = issuer; observers = singleton public
 
   -- Create accounts
@@ -43,7 +43,12 @@ run = script do
 
   -- Create lifecycle rules
   replacementRuleCid <- toInterfaceContractId @Lifecycle.I <$> submit issuer do createCmd Replacement.Rule with providers = singleton issuer; lifecycler = issuer; observers = singleton public
-  lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [issuer, investor] [] do createCmd Claim.Rule with custodian = issuer; owner = investor; claimers = singleton investor; settlers = singleton investor; factoryCid = settlementFactoryCid
+  lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [issuer, investor] [] do
+    createCmd Claim.Rule with
+      providers = fromList [issuer, investor]
+      claimers = singleton investor
+      settlers = singleton investor
+      settlementFactoryCid
 
   -- Create clock
   now <- getTime
@@ -70,7 +75,13 @@ run = script do
   (_, [effectCid]) <- submit issuer do exerciseCmd replacementRuleCid Lifecycle.Evolve with ruleName = "Dividend"; settlers = singleton investor; observableCids = []; eventCid = replacementEventCid; clockCid
 
   -- Claim effect
-  result <- submitMulti [investor] [public] do exerciseCmd lifecycleClaimRuleCid Claim.ClaimEffect with claimer = investor; holdingCids = [investorEquityCid]; effectCid
+  result <- submitMulti [investor] [public] do
+    exerciseCmd lifecycleClaimRuleCid Claim.ClaimEffect
+      with
+        claimer = investor
+        holdingCids = [investorEquityCid]
+        effectCid
+        batchId = Id "StockSplitSettlement"
 
   -- Allocate instructions
   let [instructionCid] = result.instructionCids

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
@@ -7,8 +7,8 @@ import ContingentClaims.Claim (and, at, give, one, or, scale, when)
 import ContingentClaims.Observation (Observation(..))
 import DA.Assert ((===))
 import DA.Date as D (Month(..), date)
-import DA.Map (fromList)
-import DA.Set (empty, singleton, toList)
+import DA.Map qualified as M (fromList)
+import DA.Set (empty, fromList, singleton, toList)
 import DA.Time (time)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..), T)
 import Daml.Finance.Instrument.Generic.Election (CreateElection(..), ElectionFactory(..))
@@ -71,7 +71,7 @@ run = script do
   let fp = [("FactoryProvider", singleton publicParty)]
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank fp
   holdingFactoryCid <- toInterfaceContractId <$> submit bank do
-    createCmd Fungible.Factory with provider = bank; observers = fromList fp
+    createCmd Fungible.Factory with provider = bank; observers = M.fromList fp
 
   -- Create accounts
   [bankAccount, investorAccount] <- mapA (Account.createAccount "Default Account" [publicParty] accountFactoryCid holdingFactoryCid [] bank) [bank, investor]
@@ -128,7 +128,7 @@ run = script do
       amount = 1.0
 
   -- Apply election to generate new instrument version + effects
-  (_, [effectCid]) <- submitMulti [issuer] [] do
+  (_, [effectCid]) <- submit issuer do
     exerciseCmd callBondCid Election.Apply
       with
         clockCid
@@ -136,16 +136,15 @@ run = script do
         observableCids = []
 
   -- Create settlement factory
-  settlementFactoryCid <- submitMulti [bank] [] do createCmd Factory with provider = bank; observers = empty
+  settlementFactoryCid <- toInterfaceContractId <$> submit bank do createCmd Factory with provider = bank; observers = empty
 
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [bank, investor] [] do
     createCmd Claim.Rule
       with
-        custodian = bank
-        owner = investor
+        providers = fromList [bank, investor]
         claimers = singleton bank
         settlers
-        factoryCid = toInterfaceContractId settlementFactoryCid
+        settlementFactoryCid
 
   -- Claim effect
   result <- submitMulti [bank] [publicParty] do
@@ -153,6 +152,7 @@ run = script do
       claimer = bank
       holdingCids = [investorGenericTransferableCid]
       effectCid
+      batchId = Id "BondCallSettlement"
 
   let [bankCashInstructionCouponCid, bankCashInstructionPrincipalCid] = result.instructionCids
 

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/EuropeanOption.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/EuropeanOption.daml
@@ -10,7 +10,7 @@ import DA.Assert ((===))
 import DA.Date (addDays, toDateUTC)
 import DA.List (head)
 import DA.Map qualified as M (empty, fromList)
-import DA.Set (empty, singleton, toList)
+import DA.Set (empty, fromList, singleton, toList)
 import DA.Text (sha256)
 import Daml.Finance.Data.Observable.Observation (Observation(..))
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..), T)
@@ -144,7 +144,7 @@ run = script do
       amount = 500.0
 
   -- Apply election to generate new instrument version + effects
-  (_, [effectCid]) <- submitMulti [broker] [] do
+  (_, [effectCid]) <- submit broker do
     exerciseCmd exerciseOptionCid Election.Apply
       with
         clockCid
@@ -152,17 +152,16 @@ run = script do
         observableCids = [observableCid]
 
   -- Create settlement factory
-  settlementFactoryCid <- submitMulti [investor1] [] do createCmd Factory with provider = investor1; observers = empty
+  settlementFactoryCid <- toInterfaceContractId <$> submit investor1 do createCmd Factory with provider = investor1; observers = empty
 
   -- Claim effect
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [bank, investor1] [] do
     createCmd Claim.Rule
       with
-        custodian = bank
-        owner = investor1
+        providers = fromList [bank, investor1]
         claimers = singleton investor1
         settlers
-        factoryCid = toInterfaceContractId settlementFactoryCid
+        settlementFactoryCid
 
   -- Cannot claim effect for a different amount than what was elected
   submitMultiMustFail [investor1] [publicParty] do
@@ -170,6 +169,7 @@ run = script do
       claimer = investor1
       holdingCids = [toInterfaceContractId investor1GenericTransferableCid]
       effectCid
+      batchId = Id "OptionExerciseSettlement"
 
   -- Split fungible in order to claim with the right amount
   let fungibleCid : ContractId Fungible.I = coerceContractId investor1GenericTransferableCid
@@ -180,6 +180,7 @@ run = script do
       claimer = investor1
       holdingCids = [coerceContractId splitCid]
       effectCid
+      batchId = Id "OptionExerciseSettlement"
 
   let [bankCashInstructionCid] = result.instructionCids
 
@@ -208,7 +209,7 @@ run = script do
       holdingCid = investor2GenericTransferableCid
       amount = 1000.0
 
-  (_, [effectCid]) <- submitMulti [broker] [] do
+  (_, [effectCid]) <- submit broker do
     exerciseCmd expireOptionCid Election.Apply
       with
         clockCid
@@ -216,16 +217,15 @@ run = script do
         observableCids = [observableCid]
 
   -- Create settlement factory
-  settlementFactoryCid <- submitMulti [investor2] [] do createCmd Factory with provider = investor2; observers = empty
+  settlementFactoryCid <- toInterfaceContractId <$> submit investor2 do createCmd Factory with provider = investor2; observers = empty
 
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [bank, investor2] [] do
     createCmd Claim.Rule
       with
-        custodian = bank
-        owner = investor2
+        providers = fromList [bank, investor2]
         claimers = singleton investor2
         settlers
-        factoryCid = toInterfaceContractId settlementFactoryCid
+        settlementFactoryCid
 
   -- Investor 1 cannot claim an effect for an election made by Investor 2
   submitMultiMustFail [investor1] [publicParty] do
@@ -233,6 +233,7 @@ run = script do
       claimer = investor1
       holdingCids = [toInterfaceContractId investor1GenericTransferableCid]
       effectCid
+      batchId = Id "OptionExpirySettlement"
 
   -- Claim effect
   result <- submitMulti [investor2] [publicParty] do
@@ -240,6 +241,7 @@ run = script do
       claimer = investor2
       holdingCids = [toInterfaceContractId investor2GenericTransferableCid]
       effectCid
+      batchId = Id "OptionExpirySettlement"
 
   -- Settle (empty) batch
   submitMulti [head $ toList settlers] [] do exerciseCmd result.batchCid Batch.Settle with actors = settlers

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardCash.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardCash.daml
@@ -7,7 +7,7 @@ import ContingentClaims.Claim (Inequality(..), one, scale, when)
 import ContingentClaims.Observation (Observation(..))
 import DA.Date (addDays, toDateUTC)
 import DA.Map qualified as M (empty, fromList)
-import DA.Set (empty, singleton, toList)
+import DA.Set (empty, fromList, singleton, toList)
 import Daml.Finance.Data.Observable.Observation (Observation(..))
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Instrument.Generic.Test.Util (originateGeneric, dateToDateClockTime)
@@ -82,23 +82,23 @@ run = script do
   (_, [effectCid]) <- Instrument.submitExerciseInterfaceByKeyCmd @Lifecycle.I [broker] [] genericInstrument Lifecycle.Evolve with settlers; eventCid = clockEventCid; observableCids = [observableCid]; ruleName = "Time"; clockCid
 
   -- Create settlement factory
-  settlementFactoryCid <- submitMulti [investor] [] do createCmd Factory with provider = investor; observers = empty
+  settlementFactoryCid <- toInterfaceContractId <$> submit investor do createCmd Factory with provider = investor; observers = empty
 
   -- Claim effect
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [bank, investor] [] do
     createCmd Claim.Rule
       with
-        custodian = bank
-        owner = investor
+        providers = fromList [bank, investor]
         claimers = singleton investor
         settlers
-        factoryCid = toInterfaceContractId settlementFactoryCid
+        settlementFactoryCid
 
   result <- submitMulti [investor] [publicParty] do
     exerciseCmd lifecycleClaimRuleCid Claim.ClaimEffect with
       claimer = investor
       holdingCids = [coerceContractId investorGenericTransferableCid]
       effectCid
+      batchId = Id "ForwardCashSettlement"
 
   let [bankCashInstructionCid] = result.instructionCids
 

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardPhysical.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardPhysical.daml
@@ -6,8 +6,8 @@ module Daml.Finance.Instrument.Generic.Test.ForwardPhysical where
 import ContingentClaims.Claim (Inequality(..), and, give, one, scale, when)
 import ContingentClaims.Observation (Observation(..))
 import DA.Date (addDays, toDateUTC)
-import DA.Map (fromList)
-import DA.Set (empty, singleton, toList)
+import DA.Map qualified as M (fromList)
+import DA.Set (empty, fromList, singleton, toList)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Instrument.Generic.Test.Util (originateGeneric, dateToDateClockTime)
 import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), I)
@@ -15,7 +15,7 @@ import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (E
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..))
-import Daml.Finance.Interface.Types.Common (Parties)
+import Daml.Finance.Interface.Types.Common (Id(..), Parties)
 import Daml.Finance.Lifecycle.Rule.Claim (Rule(..))
 import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Test.Util.Account qualified as Account (createAccount, createFactory, credit)
@@ -53,7 +53,7 @@ run = script do
   let fp = [("FactoryProvider", singleton publicParty)]
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank fp
   holdingFactoryCid <- toInterfaceContractId <$> submit bank do
-    createCmd Fungible.Factory with provider = bank; observers = fromList fp
+    createCmd Fungible.Factory with provider = bank; observers = M.fromList fp
 
   -- Create accounts
   [bankOwnAccount, investorAccount] <- mapA (Account.createAccount "Default Account" [publicParty] accountFactoryCid holdingFactoryCid [] bank) [bank, investor]
@@ -82,23 +82,23 @@ run = script do
   (_, [effectCid]) <- Instrument.submitExerciseInterfaceByKeyCmd @Lifecycle.I [broker] [] genericInstrument Lifecycle.Evolve with settlers; eventCid = clockEventCid; observableCids = []; ruleName = "Time"; clockCid
 
   -- Create settlement factory
-  settlementFactoryCid <- submitMulti [investor] [] do createCmd Factory with provider = investor; observers = empty
+  settlementFactoryCid <- toInterfaceContractId <$> submitMulti [investor] [] do createCmd Factory with provider = investor; observers = empty
 
   -- Claim effect
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [bank, investor] [] do
     createCmd Rule
       with
-        custodian = bank
-        owner = investor
+        providers = fromList [bank, investor]
         claimers = singleton investor
         settlers
-        factoryCid = toInterfaceContractId settlementFactoryCid
+        settlementFactoryCid
 
   result <- submitMulti [investor] [publicParty] do
     exerciseCmd lifecycleClaimRuleCid Claim.ClaimEffect with
       claimer = investor
       holdingCids = [coerceContractId investorGenericTransferableCid]
       effectCid
+      batchId = Id "ForwardPhysicalSettlement"
 
   let [investorCashInstructionCid, bankEquityInstructionCid] = result.instructionCids
 

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
@@ -135,7 +135,6 @@ run = script do
   -- Lifecycle bond
   (genericLifecycleCid2, [effectCid]) <- BaseInstrument.submitExerciseInterfaceByKeyCmd @Lifecycle.I [issuer] [] genericInstrument Lifecycle.Evolve with settlers; eventCid = clockEventCid; observableCids = []; ruleName = "Time"; clockCid
 
-  -- setup settlement contract between issuer and CSD
   -- Setup settlement contract between issuer and CSD
   -- In order for the workflow to be successful, we need to disclose the CSD's cash account to the Issuer.
   Account.submitExerciseInterfaceByKeyCmd @Disclosure.I [csd] [] csdCashAccount Disclosure.AddObservers with disclosers = singleton csd; observersToAdd = ("Issuer", singleton issuer)
@@ -163,8 +162,8 @@ run = script do
   -- Define settlement routes from CSD to Investor and create batch factory
   let routes = [("USD" , Path with senderPath = [csd, centralBank]; receiverPath = [investor, bank, centralBank])]
 
-  factoryWithIntermediariesCid <- submit csd do
-    createCmd FactoryWithIntermediaries
+  settlementFactoryCid <- submit csd do
+    toInterfaceContractId <$> createCmd FactoryWithIntermediaries
       with
         provider = csd
         paths = M.fromList routes
@@ -173,17 +172,17 @@ run = script do
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [csd, investor] [] do
     createCmd Claim.Rule
       with
-        custodian = csd
-        owner = investor
+        providers = fromList [csd, investor]
         claimers = singleton investor
         settlers
-        factoryCid = toInterfaceContractId factoryWithIntermediariesCid
+        settlementFactoryCid
 
   result <- submitMulti [investor] [publicParty] do
     exerciseCmd lifecycleClaimRuleCid Claim.ClaimEffect with
       claimer = investor
       holdingCids = [investorGenericTransferableCid]
       effectCid
+      batchId = Id "CouponSettlement"
 
   let
     Some [investorGenericTransferableCid] = result.newInstrumentHoldingCids
@@ -281,16 +280,16 @@ template EffectSettlementService
 
         lifecycleClaimRuleCid <- create Claim.Rule
           with
-            custodian = issuer
-            owner = csd
+            providers = fromList [issuer, csd]
             claimers = singleton csd
             settlers = singleton csd
-            factoryCid = toInterfaceContractId settlementFactoryCid
+            settlementFactoryCid = toInterfaceContractId settlementFactoryCid
 
         result <- exercise (toInterfaceContractId @Claim.I lifecycleClaimRuleCid) Claim.ClaimEffect with
           claimer = csd
           holdingCids = [toInterfaceContractId instrumentHoldingCid]
           effectCid
+          batchId = Id "EffectSettlement"
 
         archive settlementFactoryCid
         archive lifecycleClaimRuleCid

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -5,8 +5,8 @@ module Daml.Finance.Instrument.Swap.Test.Util where
 
 import DA.Date
 import DA.List (head)
-import DA.Map qualified as M
-import DA.Set (empty, singleton, toList)
+import DA.Map qualified as M (fromList)
+import DA.Set (empty, fromList, singleton, toList)
 import Daml.Finance.Instrument.Swap.CreditDefault.Instrument qualified as CreditDefaultSwap (Instrument(..))
 import Daml.Finance.Instrument.Swap.Currency.Instrument qualified as CurrencySwap (Instrument(..))
 import Daml.Finance.Instrument.Swap.ForeignExchange.Instrument qualified as ForeignExchange (Instrument(..))
@@ -129,27 +129,27 @@ lifecycleAndVerifySwapPaymentEffectsAndSettlement : [Party] -> Date -> Instrumen
 lifecycleAndVerifySwapPaymentEffectsAndSettlement readAs today swapInstrument settlers issuer investor investorSwapTransferableCid investorCashTransferableFixLegCid custodianCashTransferableFloatingLegCid custodianAccount investorAccount obs custodian observableCids = do
   (swapLifecycleCid, [effectCid]) <- lifecycleInstrument readAs today swapInstrument settlers issuer observableCids
 
-  newSwapInstrumentKey <- submitMulti [issuer] [] do
+  newSwapInstrumentKey <- submit issuer do
     Instrument.toKey <$> exerciseCmd @Instrument.I (coerceContractId swapLifecycleCid) Instrument.GetView with viewer = issuer
 
   -- Create settlement factory
-  settlementFactoryCid <- submitMulti [investor] [] do createCmd Factory with provider = investor; observers = empty
+  settlementFactoryCid <- toInterfaceContractId <$> submit investor do createCmd Factory with provider = investor; observers = empty
 
   -- Claim effect
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [custodian, investor] [] do
     createCmd Claim.Rule
       with
-        custodian
-        owner = investor
+        providers = fromList [custodian, investor]
         claimers = singleton investor
         settlers
-        factoryCid = toInterfaceContractId settlementFactoryCid
+        settlementFactoryCid
 
   result <- submitMulti [investor] readAs do
     exerciseCmd lifecycleClaimRuleCid Claim.ClaimEffect with
       claimer = investor
       holdingCids = [toInterfaceContractId @Base.I investorSwapTransferableCid]
       effectCid
+      batchId = Id "InterestSettlement"
 
   let
     Some [investorSwapHoldingCid] = result.newInstrumentHoldingCids
@@ -179,27 +179,27 @@ lifecycleAndVerifyFinalSwapPaymentEffects : [Party] -> Date -> Instrument.K -> P
 lifecycleAndVerifyFinalSwapPaymentEffects readAs today swapInstrument settlers issuer investor investorSwapTransferableCid investorCashTransferableFixLegCid custodianCashTransferableFloatingLegCid custodianAccount investorAccount obs custodian observableCids = do
   (swapLifecycleCid, [effectCid]) <- lifecycleInstrument readAs today swapInstrument settlers issuer observableCids
 
-  newSwapInstrumentKey <- submitMulti [issuer] [] do
+  newSwapInstrumentKey <- submit issuer do
     Instrument.toKey <$> exerciseCmd @Instrument.I (coerceContractId swapLifecycleCid) Instrument.GetView with viewer = issuer
 
   -- Create settlement factory
-  settlementFactoryCid <- submitMulti [investor] [] do createCmd Factory with provider = investor; observers = empty
+  settlementFactoryCid <- toInterfaceContractId <$> submit investor do createCmd Factory with provider = investor; observers = empty
 
   -- Claim effect
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [custodian, investor] [] do
     createCmd Claim.Rule
       with
-        custodian
-        owner = investor
+        providers = fromList [custodian, investor]
         claimers = singleton investor
         settlers
-        factoryCid = toInterfaceContractId settlementFactoryCid
+        settlementFactoryCid
 
   result <- submitMulti [investor] readAs do
     exerciseCmd lifecycleClaimRuleCid Claim.ClaimEffect with
       claimer = investor
       holdingCids = [toInterfaceContractId @Base.I investorSwapTransferableCid]
       effectCid
+      batchId = Id "FinalPaymentSettlement"
 
   let
     [custodianCashInstructionFixLegCid, custodianCashInstructionFloatingLegCid] = result.instructionCids
@@ -225,27 +225,27 @@ lifecycleAndVerifyCreditDefaultSwapPaymentEffectsAndSettlement : [Party] -> Date
 lifecycleAndVerifyCreditDefaultSwapPaymentEffectsAndSettlement readAs today swapInstrument settlers issuer investor investorSwapTransferableCid investorCashTransferableFixLegCid custodianAccount investorAccount obs custodian observableCids = do
   (swapLifecycleCid, [effectCid]) <- lifecycleInstrument readAs today swapInstrument settlers issuer observableCids
 
-  newSwapInstrumentKey <- submitMulti [issuer] [] do
+  newSwapInstrumentKey <- submit issuer do
     Instrument.toKey <$> exerciseCmd @Instrument.I (coerceContractId swapLifecycleCid) Instrument.GetView with viewer = issuer
 
   -- Create settlement factory
-  settlementFactoryCid <- submitMulti [investor] [] do createCmd Factory with provider = investor; observers = empty
+  settlementFactoryCid <- toInterfaceContractId <$> submit investor do createCmd Factory with provider = investor; observers = empty
 
   -- Claim effect
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [custodian, investor] [] do
     createCmd Claim.Rule
       with
-        custodian
-        owner = investor
+        providers = fromList [custodian, investor]
         claimers = singleton investor
         settlers
-        factoryCid = toInterfaceContractId settlementFactoryCid
+        settlementFactoryCid
 
   result <- submitMulti [investor] readAs do
     exerciseCmd lifecycleClaimRuleCid Claim.ClaimEffect with
       claimer = investor
       holdingCids = [toInterfaceContractId @Base.I investorSwapTransferableCid]
       effectCid
+      batchId = Id "InterestSettlement"
 
   let
     Some [investorSwapHoldingCid] = result.newInstrumentHoldingCids
@@ -272,27 +272,27 @@ lifecycleAndVerifyCreditDefaultFinalSwapPaymentEffects : [Party] -> Date -> Inst
 lifecycleAndVerifyCreditDefaultFinalSwapPaymentEffects readAs today swapInstrument settlers issuer investor investorSwapTransferableCid custodianCashTransferableDefaultPaymentLegCid custodianAccount investorAccount obs custodian observableCids = do
   (swapLifecycleCid, [effectCid]) <- lifecycleInstrument readAs today swapInstrument settlers issuer observableCids
 
-  newSwapInstrumentKey <- submitMulti [issuer] [] do
+  newSwapInstrumentKey <- submit issuer do
     Instrument.toKey <$> exerciseCmd @Instrument.I (coerceContractId swapLifecycleCid) Instrument.GetView with viewer = issuer
 
   -- Create settlement factory
-  settlementFactoryCid <- submitMulti [investor] [] do createCmd Factory with provider = investor; observers = empty
+  settlementFactoryCid <- toInterfaceContractId <$> submit investor do createCmd Factory with provider = investor; observers = empty
 
   -- Claim effect
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [custodian, investor] [] do
     createCmd Claim.Rule
       with
-        custodian
-        owner = investor
+        providers = fromList [custodian, investor]
         claimers = singleton investor
         settlers
-        factoryCid = toInterfaceContractId settlementFactoryCid
+        settlementFactoryCid
 
   result <- submitMulti [investor] readAs do
     exerciseCmd lifecycleClaimRuleCid Claim.ClaimEffect with
       claimer = investor
       holdingCids = [toInterfaceContractId @Base.I investorSwapTransferableCid]
       effectCid
+      batchId = Id "CreditDefaultSettlement"
 
   let
     [custodianCashInstructionFixLegCid] = result.instructionCids

--- a/src/test/daml/Daml/Finance/Settlement/Test/Batch.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Batch.daml
@@ -79,7 +79,7 @@ run settleCashOnLedger = script do
       ]
   settlementFactoryCid <- toInterfaceContractId @Factory.I <$> submitMulti [bank] [] do createCmd Factory with provider = bank; observers = empty
   (batchCid, [equityInstructionCid, cashInstructionCid]) <-
-    submitMulti [bank] [] do exerciseCmd settlementFactoryCid Factory.Instruct with instructors = singleton bank; settlers = singleton bank; id = Id "APPL 1000@200.0USD"; description = "DVP"; steps
+    submitMulti [bank] [] do exerciseCmd settlementFactoryCid Factory.Instruct with instructors = singleton bank; settlers = singleton bank; id = Id "APPL 1000@200.0USD"; description = "DVP"; contextId = None; steps
 
   -- Allocate and approve equity instruction
   (equityInstructionCid, _) <- submitMulti [seller] [] do exerciseCmd equityInstructionCid Instruction.Allocate with allocation = Pledge equityTransferableCid

--- a/src/test/daml/Daml/Finance/Settlement/Test/BatchWithIntermediaries.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/BatchWithIntermediaries.daml
@@ -101,7 +101,7 @@ run settleWithOwnAccount = script do
       , Step with sender = buyer; receiver = seller; quantity = Instrument.qty 200_000.0 cashInstrument
       ]
   (batchCid, [equityInstructionCid, cashInstruction1Cid, cashInstruction2Cid]) <-
-    submitMulti [buyer, seller] [] do exerciseCmd settlementFactoryCid Factory.Instruct with instructors = fromList [buyer, seller]; settlers = fromList [buyer, seller]; id = Id "APPL 1000@200.0USD"; description = "DVP"; steps
+    submitMulti [buyer, seller] [] do exerciseCmd settlementFactoryCid Factory.Instruct with instructors = fromList [buyer, seller]; settlers = fromList [buyer, seller]; id = Id "APPL 1000@200.0USD"; description = "DVP"; contextId = None; steps
 
   -- Allocate instructions
   (equityInstructionCid, _) <- submitMulti [seller] [] do exerciseCmd equityInstructionCid Instruction.Allocate with allocation = Pledge equityTransferableCid

--- a/src/test/daml/Daml/Finance/Settlement/Test/Intermediated.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Intermediated.daml
@@ -132,7 +132,7 @@ run useDelegatee = script do
 
   -- Instruct settlement
   (batchCid, [buyerInstructionCid, bank1InstructionCid, bank2InstructionCid, sellerInstructionCid, custodian1InstructionCid, custodian2InstructionCid]) <-
-    submitMulti [agent] [] do exerciseCmd settlementFactoryCid Factory.Instruct with instructors = singleton agent; settlers = singleton agent; id = Id "SHARE 200000.0@160.0USD DVP"; description = "Crosspayment"; steps
+    submitMulti [agent] [] do exerciseCmd settlementFactoryCid Factory.Instruct with instructors = singleton agent; settlers = singleton agent; id = Id "SHARE 200000.0@160.0USD DVP"; description = "Crosspayment"; contextId = None; steps
 
   -- Allocate and approve instructions
   (buyerInstructionCid, _) <-

--- a/src/test/daml/Daml/Finance/Settlement/Test/Transfer.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Transfer.daml
@@ -68,7 +68,7 @@ run = script do
 
   -- Instruct transfer
   let step = Step with sender; receiver; quantity = Instrument.qty 200_000.0 cashInstrument
-  (batchCid, [cashInstructionCid]) <- submitMulti [bank] [] do exerciseCmd settlementFactoryCid Factory.Instruct with instructors = singleton bank; settlers = singleton bank; id = Id "transfer 1"; description = "transfer of 200000.0 USD payment"; steps = [step]
+  (batchCid, [cashInstructionCid]) <- submitMulti [bank] [] do exerciseCmd settlementFactoryCid Factory.Instruct with instructors = singleton bank; settlers = singleton bank; id = Id "transfer 1"; description = "transfer of 200000.0 USD payment"; contextId = None; steps = [step]
 
   -- Allocate instruction
   (cashInstructionCid, _) <- submitMulti [sender] [publicParty] do exerciseCmd cashInstructionCid Instruction.Allocate with allocation = Pledge transferableCid
@@ -131,11 +131,11 @@ run2 = script do
     first = Step with sender; receiver; quantity = Instrument.qty 100_000.0 cashInstrument
     second = Step with sender; receiver; quantity = Instrument.qty 200_000.0 cashInstrument
     third = Step with sender; receiver; quantity = Instrument.qty 300_000.0 cashInstrument
-  (batchCid1, [cashInstructionCid1]) <- submitMulti [bank] [] do exerciseCmd settlementFactoryCid Factory.Instruct with instructors = singleton bank; settlers = singleton bank; id = id1; description = "transfer of 100000.0 USD payment"; steps = [first]
+  (batchCid1, [cashInstructionCid1]) <- submitMulti [bank] [] do exerciseCmd settlementFactoryCid Factory.Instruct with instructors = singleton bank; settlers = singleton bank; id = id1; description = "transfer of 100000.0 USD payment"; contextId = None; steps = [first]
   -- the id of the batch must be unique
-  submitMultiMustFail [bank] [] do exerciseCmd settlementFactoryCid Factory.Instruct with instructors = singleton bank; settlers = singleton bank; id = id1; description = "transfer of 200000.0 USD payment"; steps = [second]
-  (batchCid2, [cashInstructionCid2]) <- submitMulti [bank] [] do exerciseCmd settlementFactoryCid Factory.Instruct with instructors = singleton bank; settlers = singleton bank; id = id2; description = "transfer of 200000.0 USD payment"; steps = [second]
-  (batchCid3, [cashInstructionCid3]) <- submitMulti [bank] [] do exerciseCmd settlementFactoryCid Factory.Instruct with instructors = singleton bank; settlers = singleton bank; id = id3; description = "transfer of 300000.0 USD payment"; steps = [third]
+  submitMultiMustFail [bank] [] do exerciseCmd settlementFactoryCid Factory.Instruct with instructors = singleton bank; settlers = singleton bank; id = id1; description = "transfer of 200000.0 USD payment"; contextId = None; steps = [second]
+  (batchCid2, [cashInstructionCid2]) <- submitMulti [bank] [] do exerciseCmd settlementFactoryCid Factory.Instruct with instructors = singleton bank; settlers = singleton bank; id = id2; description = "transfer of 200000.0 USD payment"; contextId = None; steps = [second]
+  (batchCid3, [cashInstructionCid3]) <- submitMulti [bank] [] do exerciseCmd settlementFactoryCid Factory.Instruct with instructors = singleton bank; settlers = singleton bank; id = id3; description = "transfer of 300000.0 USD payment"; contextId = None; steps = [third]
 
   let verifyAccountDisclosureContexts owner ids = Account.verifyAccountDisclosureContexts [(M.fromList $ fmap (\id -> (show id, singleton bank)) ids)] owner
 
@@ -225,8 +225,14 @@ run3 = script do
   -- Instruct transfer
   let step = Step with sender; receiver; quantity = Instrument.qty 200_000.0 cashInstrument
   (batchCid, [cashInstructionCid]) <- submitMulti [bank] [] do
-    exerciseCmd settlementFactoryCid Factory.Instruct with
-      instructors = singleton bank; settlers = fromList [sender, receiver]; id = Id "transfer 1"; description = "transfer of 200000.0 USD payment"; steps = [step]
+    exerciseCmd settlementFactoryCid Factory.Instruct
+      with
+        instructors = singleton bank
+        settlers = fromList [sender, receiver]
+        id = Id "transfer 1"
+        description = "transfer of 200000.0 USD payment"
+        contextId = None
+        steps = [step]
 
   -- Allocate instruction
   (cashInstructionCid, _) <- submitMulti [sender] [publicParty] do exerciseCmd cashInstructionCid Instruction.Allocate with allocation = Pledge transferableCid
@@ -282,8 +288,14 @@ run4 = script do
     step1 = Step with sender; receiver; quantity = Instrument.qty 200_000.0 cashInstrument1
     step2 = Step with sender; receiver; quantity = Instrument.qty 100_000.0 cashInstrument1
   (batchCid, [cashInstructionCid1, cashInstructionCid2]) <- submitMulti [bank] [] do
-    exerciseCmd settlementFactoryCid Factory.Instruct with
-      instructors = singleton bank; settlers = fromList [sender, receiver]; id = Id "transfer 1"; description = "transfer of 200000.0 USD and 100000.0 CHF payment"; steps = [step1, step2]
+    exerciseCmd settlementFactoryCid Factory.Instruct
+      with
+        instructors = singleton bank
+        settlers = fromList [sender, receiver]
+        id = Id "transfer 1"
+        description = "transfer of 200000.0 USD and 100000.0 CHF payment"
+        contextId = None
+        steps = [step1, step2]
 
   -- Allocate instruction
   (cashInstructionCid1, _) <- submitMulti [sender] [publicParty] do exerciseCmd cashInstructionCid1 Instruction.Allocate with allocation = Pledge transferableCid1


### PR DESCRIPTION
- Adds missing fields to settlement interfaces
- Add `contextId` to `Batch`, to be able to link it to a context (eg. the effect it originated from)
- Rename `tradeId` to `batchId` on instruction
- Change `custodian` and `owner` to `providers` on claim rule