### PR TITLE
Switch to unit test for fx swaps

### DIFF
--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/ForeignExchange.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/ForeignExchange.daml
@@ -8,7 +8,8 @@ import DA.Map qualified as M (fromList)
 import DA.Set (singleton)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Instrument.Swap.Test.Util
-import Daml.Finance.Test.Util.Account qualified as Account (createAccount, createFactory, credit)
+import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
+import Daml.Finance.Test.Util.Account qualified as Account (createAccount, createFactory)
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Script
@@ -31,6 +32,7 @@ run = script do
   -- Distribute commercial-bank cash
   now <- getTime
   let observers = [("PublicParty", singleton publicParty)]
+
   -- CREATE_FX_SWAP_CASH_INSTRUMENTS_BEGIN
   cashInstrumentCid <- Instrument.originate custodian issuer "USD" "US Dollars" observers now
   foreignCashInstrumentCid <- Instrument.originate custodian issuer "EUR" "Euro" observers now
@@ -43,27 +45,23 @@ run = script do
     issueDate = date 2019 Jan 16
     firstPaymentDate = date 2019 Feb 15
     maturityDate = date 2019 May 15
+    fxRateSameCurrency = 1.0
     firstFxRate = 1.1
     finalFxRate = 1.2
     -- CREATE_FX_SWAP_VARIABLES_END
-    firstForeignPaymentAmount = 1_100_000.0
-    firstBasePaymentAmount = 1_000_000.0
-    secondForeignPaymentAmount = 1_200_000.0
-    secondBasePaymentAmount = 1_000_000.0
-    principalAmount = 1_000_000.0
 
   swapInstrument <- originateForeignExchangeSwap custodian issuer "SwapTest1" "Foreign exchange swap" fp now issueDate firstPaymentDate maturityDate cashInstrumentCid foreignCashInstrumentCid firstFxRate finalFxRate
-  investorSwapTransferableCid <- Account.credit [publicParty] swapInstrument principalAmount investorAccount
 
   let settlers = singleton custodian
 
   -- One day before the first payment date: try to lifecycle and verify that there are no lifecycle effects.
   verifyNoLifecycleEffects [publicParty] (subtractDays firstPaymentDate 1) swapInstrument settlers issuer []
 
-  -- First payment date: Lifecycle and verify that there are lifecycle effects for the fx payments.
-  investorCashForBasePaymentTransferableCid <- Account.credit [publicParty] cashInstrumentCid firstBasePaymentAmount investorAccount
-  custodianCashForForeignPaymentTransferableCid <- Account.credit [publicParty] foreignCashInstrumentCid firstForeignPaymentAmount custodianAccount
-  (swapInstrumentAfterFirstPayment, investorSwapTransferableCid) <- lifecycleAndVerifySwapPaymentEffectsAndSettlement [publicParty] firstPaymentDate swapInstrument settlers issuer investor investorSwapTransferableCid investorCashForBasePaymentTransferableCid custodianCashForForeignPaymentTransferableCid custodianAccount investorAccount observers custodian []
+  -- First payment date: Lifecycle and verify the lifecycle effects for the fx payments.
+  let
+    expectedConsumedQuantities = [Instrument.qty fxRateSameCurrency cashInstrumentCid]
+    expectedProducedQuantities = [Instrument.qty firstFxRate foreignCashInstrumentCid]
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer investor observers custodian [] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the first payment date: try to lifecycle and verify that there are no lifecycle effects.
   verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment settlers issuer []
@@ -71,9 +69,10 @@ run = script do
   -- One day before expiry: try to lifecycle and verify that there are no lifecycle effects.
   verifyNoLifecycleEffects [publicParty] (subtractDays maturityDate 1) swapInstrumentAfterFirstPayment settlers issuer []
 
-  -- Lifecycle on the second payment date, which is also the expiry date. Verify that there are lifecycle effects for the fx payments.
-  investorCashForForeignPaymentTransferableCid <- Account.credit [publicParty] foreignCashInstrumentCid secondForeignPaymentAmount investorAccount
-  custodianCashForBasePaymentTransferableCid <- Account.credit [publicParty] cashInstrumentCid secondBasePaymentAmount custodianAccount
-  lifecycleAndVerifyFinalSwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment settlers issuer investor investorSwapTransferableCid investorCashForForeignPaymentTransferableCid custodianCashForBasePaymentTransferableCid custodianAccount investorAccount observers custodian []
+  -- Lifecycle on the second payment date, which is also the expiry date. Verify the lifecycle effects for the fx payments.
+  let
+    expectedConsumedQuantities = [Instrument.qty finalFxRate foreignCashInstrumentCid]
+    expectedProducedQuantities = [Instrument.qty fxRateSameCurrency cashInstrumentCid]
+  lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment settlers issuer investor observers custodian [] expectedConsumedQuantities expectedProducedQuantities
 
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -4,7 +4,7 @@
 module Daml.Finance.Instrument.Swap.Test.Util where
 
 import DA.Date
-import DA.List (head)
+import DA.List (head, sort)
 import DA.Map qualified as M (fromList)
 import DA.Set qualified as S (empty, fromList, singleton, toList)
 import Daml.Finance.Instrument.Swap.Asset.Instrument qualified as AssetSwap (Instrument(..))
@@ -15,8 +15,8 @@ import Daml.Finance.Instrument.Swap.InterestRate.Instrument qualified as Interes
 import Daml.Finance.Interface.Data.Observable qualified as Observable (I)
 import Daml.Finance.Interface.Holding.Base qualified as Base (I)
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I)
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (GetView(..), K, I, toKey)
-import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (I)
+import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (GetView(..), K, I, Q, toKey)
+import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (I, GetView(..))
 import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), I)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Evolve(..))
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
@@ -135,6 +135,24 @@ verifyNoLifecycleEffects : [Party] -> Date -> Instrument.K -> Parties -> Party -
 verifyNoLifecycleEffects readAs today instrument settlers issuer observableCids = do
   (bondLifecycleCid2, effectCids) <- lifecycleInstrument readAs today instrument settlers issuer observableCids
   assertMsg ("There should be no lifecycle effects on " <> show today) (null effectCids)
+
+-- | Verify the payments from a payment date of a swap (excluding settlement)
+lifecycleAndVerifySwapPaymentEffects : [Party] -> Date -> Instrument.K -> Parties -> Party -> Party -> [(Text, Parties)] -> Party -> [ContractId Observable.I] -> [Instrument.Q] -> [Instrument.Q] -> Script Instrument.K
+lifecycleAndVerifySwapPaymentEffects readAs today swapInstrument settlers issuer investor obs custodian observableCids expectedConsumedQuantities expectedProducedQuantities = do
+  (swapLifecycleCid, [effectCid]) <- lifecycleInstrument readAs today swapInstrument settlers issuer observableCids
+
+  newSwapInstrumentKey <- submit issuer do
+    Instrument.toKey <$> exerciseCmd @Instrument.I (coerceContractId swapLifecycleCid) Instrument.GetView with viewer = issuer
+
+  -- Get the effect
+  effectView <- submitMulti [investor] readAs do
+    exerciseCmd effectCid Effect.GetView with viewer = investor
+
+  -- Verify that the consumed/produced quantities match the expected ones
+  assertMsg "The consumed quantities do not match the expected ones" (sort expectedConsumedQuantities == sort effectView.consumed)
+  assertMsg "The produced quantities do not match the expected ones" (sort expectedProducedQuantities == sort effectView.produced)
+
+  pure newSwapInstrumentKey
 
 -- | Verify the payments from a payment date of an interest rate swap.
 lifecycleAndVerifySwapPaymentEffectsAndSettlement : [Party] -> Date -> Instrument.K -> Parties -> Party -> Party -> ContractId Transferable.I -> ContractId Transferable.I -> ContractId Transferable.I -> AccountKey -> AccountKey -> [(Text, Parties)] -> Party -> [ContractId Observable.I] -> Script (Instrument.K, ContractId Transferable.I)


### PR DESCRIPTION
I have changed the type of test we use for FX swaps, as described here: https://github.com/digital-asset/daml-finance/issues/171

We used to have the end-to-end type test, including settlement.
Now, I have introduced more of a unit-test style, where the content of the `Effect` is probed directly.

Once this has been discussed/approved, I will move on to change the tests for the other swaps (and bonds as well), including removing lots of code no longer needed.