### PR TITLE
Remove unnecessary `Ord` derivations

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -87,7 +87,7 @@ This style guide details the formatting and styling of Daml and client-side code
         -- ^ Textual description of the account.
       owner : Party
         -- ^ Party owning this account.
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Show)
   ```
 
 - Add a `viewtype` definition to the interface with the `View` type:

--- a/src/main/daml/Daml/Finance/Data/Reference/HolidayCalendar.daml
+++ b/src/main/daml/Daml/Finance/Data/Reference/HolidayCalendar.daml
@@ -20,7 +20,7 @@ data HolidayCalendarKey = HolidayCalendarKey
       -- ^ The party maintaining the `HolidayCalendar`.
     entity : Text
       -- ^ A textual label identifying the calendar (e.g. "NYSE" for the New York Stock Exchange holiday calendar).
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Holiday calendar of an entity (typically an exchange or a currency).
 -- It is maintained by a reference data agency.

--- a/src/main/daml/Daml/Finance/Interface/Account/Account.daml
+++ b/src/main/daml/Daml/Finance/Interface/Account/Account.daml
@@ -32,7 +32,7 @@ data Controllers = Controllers
       -- ^ Parties instructing a transfer (outgoing).
     approvers : Parties
       -- ^ Parties approving a transfer (incoming).
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Exercise interface by key.
 -- This method can be used to exercise a choice on an `Account` given its `AccountKey`.

--- a/src/main/daml/Daml/Finance/Interface/Account/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Account/Factory.daml
@@ -19,7 +19,7 @@ data View = View
   with
     provider : Party
       -- ^ The provider of the `Factory`.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Interface that allows implementing templates to create accounts.
 interface Factory where

--- a/src/main/daml/Daml/Finance/Interface/Claims/Claim.daml
+++ b/src/main/daml/Daml/Finance/Interface/Claims/Claim.daml
@@ -31,7 +31,7 @@ data View = View
       -- ^ The instrument's key.
     acquisitionTime : Time
       -- ^ The claim's acquisition time.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Interface implemented by templates that can be represented as Contingent Claims.
 interface Claim where

--- a/src/main/daml/Daml/Finance/Interface/Data/Observable.daml
+++ b/src/main/daml/Daml/Finance/Interface/Data/Observable.daml
@@ -21,7 +21,7 @@ data View = View
       -- ^ Textual reference to the observable.
     observations : Map Time Decimal
       -- ^ The time-dependent values.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | An inferface to inspect some numerical values (e.g. a stock price or an interest rate) required when processing a lifecycle rule.
 interface Observable where

--- a/src/main/daml/Daml/Finance/Interface/Holding/Base.daml
+++ b/src/main/daml/Daml/Finance/Interface/Holding/Base.daml
@@ -21,7 +21,7 @@ data View = View
       -- ^ Key of the account holding the assets.
     amount : Decimal
       -- ^ Size of the holding.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Base interface for a holding.
 interface Base where

--- a/src/main/daml/Daml/Finance/Interface/Holding/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Holding/Factory.daml
@@ -18,7 +18,7 @@ data View = View
   with
     provider : Party
       -- ^ The provider of the `Factory`.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Holding factory contract used to create (credit) and archive (debit) holdings.
 interface Factory where

--- a/src/main/daml/Daml/Finance/Interface/Holding/Fungible.daml
+++ b/src/main/daml/Daml/Finance/Interface/Holding/Fungible.daml
@@ -29,7 +29,7 @@ data View = View
       -- ^ Size of the holding.
     modifiers : Parties
       -- ^ Parties which have the authorization to modify a fungible asset.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Result of a call to `Split`.
 data SplitResult = SplitResult

--- a/src/main/daml/Daml/Finance/Interface/Holding/Transferable.daml
+++ b/src/main/daml/Daml/Finance/Interface/Holding/Transferable.daml
@@ -24,7 +24,7 @@ data View = View
       -- ^ Key of the account holding the assets.
     amount : Decimal
       -- ^ Size of the holding.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | An interface respresenting a contract where ownership can be transferred to other parties.
 interface Transferable where

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Base/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Base/Instrument.daml
@@ -51,7 +51,7 @@ data View = View
       -- ^ A human readable description of the instrument.
     validAsOf : Time
       -- ^ Timestamp as of which the instrument is valid. This usually coincides with the timestamp of the event that creates the instrument. It usually does not coincide with ledger time.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Base interface for all instruments. This interface does not define any lifecycling logic.
 interface Instrument where

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Bond/FixedRate/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Bond/FixedRate/Factory.daml
@@ -19,7 +19,7 @@ data View = View
   with
     provider : Party
       -- ^ The provider of the `Factory`.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Interface that allows implementing templates to create fixed rate bonds.
 interface Factory where

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Bond/FloatingRate/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Bond/FloatingRate/Factory.daml
@@ -19,7 +19,7 @@ data View = View
   with
     provider : Party
       -- ^ The provider of the `Factory`.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Interface that allows implementing templates to create floating rate bonds.
 interface Factory where

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Bond/InflationLinked/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Bond/InflationLinked/Factory.daml
@@ -19,7 +19,7 @@ data View = View
   with
     provider : Party
       -- ^ The provider of the `Factory`.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Interface that allows implementing templates to create inflation linked bonds.
 interface Factory where

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Bond/ZeroCoupon/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Bond/ZeroCoupon/Factory.daml
@@ -19,7 +19,7 @@ data View = View
   with
     provider : Party
       -- ^ The provider of the `Factory`.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Interface that allows implementing templates to create zero coupon bonds.
 interface Factory where

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Equity/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Equity/Factory.daml
@@ -18,7 +18,7 @@ data View = View
   with
     provider : Party
       -- ^ The provider of the `Factory`.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Interface that allows implementing templates to create equity instruments.
 interface Factory where

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Equity/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Equity/Instrument.daml
@@ -20,7 +20,7 @@ data View = View
   with
     instrument : InstrumentKey
       -- ^ The instrument's key.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | An interface for a generic equity instrument.
 interface Instrument where

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Generic/Election.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Generic/Election.daml
@@ -98,7 +98,7 @@ data ExercisableView = ExercisableView
   with
     lifecycler : Party
       -- ^ Party processing the election.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Interface implemented by instruments that admit (claim-based) elections.
 interface Exercisable where

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Generic/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Generic/Factory.daml
@@ -19,7 +19,7 @@ data View = View
   with
     provider : Party
       -- ^ The provider of the `Factory`.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Interface that allows implementing templates to create generic instruments using Contingent Claims.
 interface Factory where

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Asset/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Asset/Factory.daml
@@ -19,7 +19,7 @@ data View = View
   with
     provider : Party
       -- ^ The provider of the `Factory`.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Interface that allows implementing templates to create asset swaps.
 interface Factory where

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/CreditDefault/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/CreditDefault/Factory.daml
@@ -19,7 +19,7 @@ data View = View
   with
     provider : Party
       -- ^ The provider of the `Factory`.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Interface that allows implementing templates to create credit default swaps.
 interface Factory where

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Currency/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Currency/Factory.daml
@@ -19,7 +19,7 @@ data View = View
   with
     provider : Party
       -- ^ The provider of the `Factory`.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Interface that allows implementing templates to create currency swaps.
 interface Factory where

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/ForeignExchange/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/ForeignExchange/Factory.daml
@@ -19,7 +19,7 @@ data View = View
   with
     provider : Party
       -- ^ The provider of the `Factory`.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Interface that allows implementing templates to create foreign exchange swaps.
 interface Factory where

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/InterestRate/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/InterestRate/Factory.daml
@@ -19,7 +19,7 @@ data View = View
   with
     provider : Party
       -- ^ The provider of the `Factory`.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Interface that allows implementing templates to create interest rate swaps.
 interface Factory where

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Token/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Token/Factory.daml
@@ -19,7 +19,7 @@ data View = View
   with
     provider : Party
       -- ^ The provider of the `Factory`.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Interface that allows implementing templates to create instruments.
 interface Factory where

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Clock.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Clock.daml
@@ -19,7 +19,7 @@ data View = View
       -- ^ The clock's identifier.
     clockTime : Time
       -- ^ The clock's time expressed in UTC time.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | A clock is a subdivision of the Time continuum into a countable set. For each element of this set, we can calculate the corresponding UTC time.
 interface Clock where

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Effect.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Effect.daml
@@ -34,7 +34,7 @@ data View = View
       -- ^ Consumed quantities (not including the target instrument).
     produced : [Instrument.Q]
       -- ^ Produced quantities (not including the produced instrument).
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Interface for contracts exposing effects of lifecycling processes.
 interface Effect where

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Event.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Event.daml
@@ -22,12 +22,11 @@ data View = View
       -- ^ A human readable description of the event.
     eventTime : Time
       -- ^ The time of the event. This allows ordering of events.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | A lifecycle event. These events are ordered based on the corresponding event time.
 interface Event where
   viewtype V
-
 
   nonconsuming choice GetView : View
     -- ^ Retrieves the interface view.

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Rule/Claim.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Rule/Claim.daml
@@ -27,7 +27,7 @@ data View = View
       -- ^ Any of the parties can trigger settlement of the resulting batch.
     settlementFactoryCid : ContractId Factory.I
       -- ^ Settlement factory contract used to create a `Batch` of `Instruction`\s.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Data type wrapping the results of `Claim`ing an `Effect`.
 data ClaimResult = ClaimResult

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Rule/Lifecycle.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Rule/Lifecycle.daml
@@ -20,7 +20,7 @@ data View = View
   with
     lifecycler : Party
       -- ^ Party performing the lifecycling.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Interface implemented by instruments that can be lifecycled.
 interface Lifecycle where

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Factory.daml
@@ -21,7 +21,7 @@ data View = View
       -- ^ Party providing the facility to create settlement instructions.
     observers : Parties
       -- ^ Observers.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | An interface used to generate settlement instructions.
 interface Factory where

--- a/src/main/daml/Daml/Finance/Interface/Util/Disclosure.daml
+++ b/src/main/daml/Daml/Finance/Interface/Util/Disclosure.daml
@@ -22,7 +22,7 @@ data View = View
       -- ^ Disjunction choice controllers.
     observers : PartiesMap
       -- ^ Observers with context.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | An interface for managing the visibility of contracts for non-authorizing parties.
 interface Disclosure where


### PR DESCRIPTION
Addresses https://github.com/digital-asset/daml-finance/issues/208

I removed derivations of the `Ord` typeclass where there is no natural notion of ordering arising from the data structure.

I did leave `Ord` in the account and instrument keys, as I see it likely that these types are used as keys in maps (which require `Ord`, see https://docs.daml.com/daml/stdlib/DA-Map.html)