### PR TITLE
Rename `Clock` to `TimeObservable` and `Observable` to `NumericObservable`

### DIFF
--- a/docs/source/concepts/lifecycling.rst
+++ b/docs/source/concepts/lifecycling.rst
@@ -23,7 +23,7 @@ Intrinsic events are contractual cash flows.
 The contract terms pre-define exactly what triggers these events, for example:
 
 - A certain date is reached, which results in a coupon payent of a bond. Time-based events are controlled using the ``DateClock`` template (not ledger time).
-- The price of a stock reaches a certain level, resulting in a barrier hit. The relevant stock price is defined in an ``Observable`` template.
+- The price of a stock reaches a certain level, resulting in a barrier hit. The relevant stock price is defined in an ``Observation`` template.
 
 Extrinsic
 =========

--- a/docs/source/packages/core-implementations.rst
+++ b/docs/source/packages/core-implementations.rst
@@ -40,7 +40,6 @@ Core Implementations
 
     - :ref:`Effect <module-daml-finance-lifecycle-effect-1975>`: A contract encoding the *consequences of a lifecycle event* for one unit of the target instrument
     - :ref:`ElectionEffect <module-daml-finance-lifecycle-electioneffect-99924>`: A contract encoding the *consequences of an election* for one unit of the target instrument
-    - :ref:`DateClock <module-daml-finance-lifecycle-dateclock-31311>`: A contract specifying what is the current local date. It is used to inject date information in lifecycle processing rules
     - :ref:`Rule.Claim <module-daml-finance-lifecycle-rule-claim-99318>`: Rule contract that allows an actor to process/claim effects, returning settlement instructions
     - :ref:`Rule.Distribution <module-daml-finance-lifecycle-rule-distribution-35531>`: Rule contract that defines the distribution of units of an instrument for each unit of a target instrument (e.g. share or cash dividends)
     - :ref:`Rule.Replacement <module-daml-finance-lifecycle-rule-replacement-6984>`: Rule contract that defines the replacement of units of an instrument with a basket of other instruments (e.g. stock merger)
@@ -55,10 +54,11 @@ Core Implementations
 
 - ``Daml.Finance.Data``
 
-    This package contains the *implementation* of observable or reference data related workflows. It contains the following modules:
+    This package implements templates containing reference data. It includes the following modules:
 
-    - :ref:`Observation <module-daml-finance-data-observable-observation-7524>`: An implementation of ``Observable`` that explicitly stores time-dependent numerical values (e.g. equity or rate fixings)
+    - :ref:`Observation <module-daml-finance-data-observable-observation-7524>`: An implementation of an ``Observation`` that explicitly stores time-dependent numerical values on the ledger. It can be used to e.g. store equity or rate fixings
     - :ref:`HolidayCalendar <module-daml-finance-data-reference-holidaycalendar-10773>`: Holiday calendar of an entity (typically an exchange or a currency)
+    - :ref:`DateClock <module-daml-finance-data-time-dateclock-65212>`: A contract specifying what is the current local date. It is used to inject date information in lifecycle processing rules
 
 - ``Daml.Finance.Util``
 

--- a/docs/source/packages/core-interfaces.rst
+++ b/docs/source/packages/core-interfaces.rst
@@ -41,15 +41,14 @@ Core Interfaces
 
     This package contains the *interface* for lifecycle related processes. It contains the following modules:
 
-    - :ref:`Event <module-daml-finance-interface-lifecycle-event-43586>`: Interface for a lifecycle event, for example that a bond will pay a coupon on a given date
+    - :ref:`Event <module-daml-finance-interface-lifecycle-event-43586>`: Interface for a lifecycle event. An event is any contract that triggers the processing of a lifecycle rule. Events can be e.g. dividend announcements or simply the passing of time.
     - :ref:`Effect <module-daml-finance-interface-lifecycle-effect-16050>`: Interface for contracts exposing effects of lifecycling processes, e.g. the payment resulting from a bond coupon
-    - :ref:`Clock <module-daml-finance-interface-lifecycle-clock-75180>`: Interface for a clock that is used to control time-based events
     - :ref:`Rule.Claim <module-daml-finance-interface-lifecycle-rule-claim-6739>`: Interface for contracts that allow holders to claim an ``Effect`` and generate settlement instructions
     - :ref:`Rule.Lifecycle <module-daml-finance-interface-lifecycle-rule-lifecycle-50431>`: Interface implemented by instruments that can be lifecycled
 
     The :doc:`Lifecycling <../concepts/lifecycling>` page contains an overview of the lifecycle process and explains the relationship between events, lifecycle rules and effects.
     Check out the :doc:`Lifecycling tutorial <../tutorials/getting-started/lifecycling>` for a description on how lifecycling works in practice.
-    There is also the tutorial :doc:`How to implement a Contingent Claims-based instrument <../tutorials/instrument-modeling/contingent-claims-instrument>`, which describes how claims are defined, how to use an ``Observable``, and how the ``Lifecycle`` interface is implemented for bonds.
+    There is also the tutorial :doc:`How to implement a Contingent Claims-based instrument <../tutorials/instrument-modeling/contingent-claims-instrument>`, which describes how claims are defined, how to use a ``NumericObservable``, and how the ``Lifecycle`` interface is implemented for bonds.
 
 - ``Daml.Finance.Interface.Types``
 
@@ -73,9 +72,10 @@ Core Interfaces
 
 - ``Daml.Finance.Interface.Data``
 
-    This package contains the *interface* for inspecting numerical values, used for lifecycling instruments. It contains the following module:
+    This package contains the *interface* for inspecting observables. These are used in the context of lifecycling. It contains the following modules:
 
-    - :ref:`Observable <module-daml-finance-interface-data-observable-1199>`: Inferface to inspect numerical values (e.g. a stock price or an interest rate) required when processing a lifecycle rule
+    - :ref:`NumericObservable <module-daml-finance-interface-data-numericobservable-76523>`: Interface to inspect time-dependent numerical values (e.g. a stock price or an interest rate fixing)
+    - :ref:`TimeObservable <module-daml-finance-interface-data-timeobservable-98854>`: Interface implemented by templates exposing time information
 
 - ``Daml.Finance.Interface.Util``
 

--- a/package/main/daml/Daml.Finance.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Data/daml.yaml
@@ -12,5 +12,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.5/daml-finance-interface-data-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.6/daml-finance-lifecycle-0.1.6.dar
 build-options:
   - --target=1.15

--- a/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
@@ -16,5 +16,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.5/daml-finance-interface-instrument-base-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.6/daml-finance-interface-settlement-0.1.6.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.6/daml-finance-interface-lifecycle-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.5/daml-finance-interface-data-0.1.5.dar
 build-options:
   - --target=1.15

--- a/package/test/daml/Daml.Finance.Test.Util/daml.yaml
+++ b/package/test/daml/Daml.Finance.Test.Util/daml.yaml
@@ -15,9 +15,11 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.5/daml-finance-interface-holding-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.0/daml-finance-interface-account-0.1.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.5/daml-finance-interface-instrument-base-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.5/daml-finance-interface-data-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.6/daml-finance-interface-lifecycle-0.1.6.dar
   - .lib/daml-finance/Daml.Finance.Holding/0.1.5/daml-finance-holding-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Account/0.1.0/daml-finance-account-0.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Data/0.1.5/daml-finance-data-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Instrument.Token/0.1.5/daml-finance-instrument-token-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.6/daml-finance-lifecycle-0.1.6.dar
 build-options:

--- a/src/main/daml/Daml/Finance/Data/Observable/Observation.daml
+++ b/src/main/daml/Daml/Finance/Data/Observable/Observation.daml
@@ -7,16 +7,16 @@ module Daml.Finance.Data.Observable.Observation
 
 import DA.Map as M (Map, lookup)
 import DA.Set (singleton)
-import Daml.Finance.Interface.Data.Observable qualified as Observable (HasImplementation, I, View(..))
+import Daml.Finance.Interface.Data.NumericObservable qualified as NumericObservable (HasImplementation, I, View(..))
 import Daml.Finance.Interface.Types.Common (Id, PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, SetObservers(..), View(..), flattenObservers)
 
 -- | Type synonym for `Observation`.
 type T = Observation
 
-instance Observable.HasImplementation T
+instance NumericObservable.HasImplementation T
 
--- | An implementation of `Observable` that explicitly stores time-dependent numerical values.
+-- | An implementation of `NumericObservable` that explicitly stores time-dependent numerical values.
 -- It can be used for e.g. equity or rate fixings.
 template Observation
   with
@@ -32,8 +32,8 @@ template Observation
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance Observable.I for Observation where
-      view = Observable.View with provider; id; observations
+    interface instance NumericObservable.I for Observation where
+      view = NumericObservable.View with provider; id; observations
       observe t =
         case M.lookup t observations of
           Some obs -> pure obs

--- a/src/main/daml/Daml/Finance/Data/Time/DateClock.daml
+++ b/src/main/daml/Daml/Finance/Data/Time/DateClock.daml
@@ -37,7 +37,7 @@ template DateClock
     maintainer key._1
 
     interface instance TimeObservable.I for DateClock where
-      view = TimeObservable.View with id; time = toUTCTime this; providers
+      view = TimeObservable.View with providers; id; time = toUTCTime this
 
     choice ToNext : (ContractId DateClock, ContractId DateClock.Event)
       -- ^ Moves the clock to the next date and spawns an update event.

--- a/src/main/daml/Daml/Finance/Data/Time/DateClock.daml
+++ b/src/main/daml/Daml/Finance/Data/Time/DateClock.daml
@@ -1,21 +1,23 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Daml.Finance.Lifecycle.DateClock where
+module Daml.Finance.Data.Time.DateClock where
 
 import DA.Date (addDays)
+import Daml.Finance.Interface.Data.TimeObservable qualified as TimeObservable (HasImplementation, I, View(..))
 import Daml.Finance.Interface.Types.Common (Id, Parties)
 import Daml.Finance.Interface.Types.Date.Classes (HasUTCTimeConversion(..))
-import Daml.Finance.Interface.Lifecycle.Clock qualified as Clock (HasImplementation, I, View(..))
 import Daml.Finance.Lifecycle.Event.DateClock qualified as DateClock (Event(..))
 import Daml.Finance.Lifecycle.Types (Unit(..))
 
 -- | Type synonym for `DateClock`.
 type T = DateClock
 
-instance Clock.HasImplementation DateClock
+instance TimeObservable.HasImplementation DateClock
 
--- | A clock where time is discretized into dates. Each date is mapped to UTC noon.
+-- | A `DateClock` is a subdivision of the Time continuum into dates.
+-- Each date is mapped to UTC noon.
+-- Updating the clock spawns a `ClockUpdateEvent`.
 template DateClock
   with
     providers : Parties
@@ -34,8 +36,8 @@ template DateClock
     key (providers, id) : (Parties, Id)
     maintainer key._1
 
-    interface instance Clock.I for DateClock where
-      view = Clock.View with id; clockTime = toUTCTime this
+    interface instance TimeObservable.I for DateClock where
+      view = TimeObservable.View with id; time = toUTCTime this; providers
 
     choice ToNext : (ContractId DateClock, ContractId DateClock.Event)
       -- ^ Moves the clock to the next date and spawns an update event.
@@ -57,4 +59,4 @@ instance HasUTCTimeConversion DateClock where
   toUTCTime clock = toUTCTime clock.date
 
 instance Ord DateClock where
-  compare x y = compare (toInterface x : Clock.I) (toInterface y)
+  compare x y = compare (toInterface x : TimeObservable.I) (toInterface y)

--- a/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate/Instrument.daml
@@ -86,9 +86,9 @@ template Instrument
 
     interface instance Lifecycle.I for Instrument where
       view = Lifecycle.View with lifecycler = issuer
-      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; clockCid; observableCids} self =
+      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; timeObservableCid; observableCids} self =
         case ruleName of
-          "Time" -> processClockUpdate settlers eventCid clockCid self this observableCids
+          "Time" -> processClockUpdate settlers eventCid timeObservableCid self this observableCids
           other -> abort $ "Unknown lifecycle rule " <> other
 
     interface instance Disclosure.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate/Instrument.daml
@@ -88,9 +88,9 @@ template Instrument
 
     interface instance Lifecycle.I for Instrument where
       view = Lifecycle.View with lifecycler = issuer
-      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; clockCid; observableCids} self =
+      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; timeObservableCid; observableCids} self =
         case ruleName of
-          "Time" -> processClockUpdate settlers eventCid clockCid self this observableCids
+          "Time" -> processClockUpdate settlers eventCid timeObservableCid self this observableCids
           other -> abort $ "Unknown lifecycle rule " <> other
 
     interface instance Disclosure.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Bond/InflationLinked/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/InflationLinked/Instrument.daml
@@ -111,9 +111,9 @@ template Instrument
 
     interface instance Lifecycle.I for Instrument where
       view = Lifecycle.View with lifecycler = issuer
-      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; clockCid; observableCids} self =
+      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; timeObservableCid; observableCids} self =
         case ruleName of
-          "Time" -> processClockUpdate settlers eventCid clockCid self this observableCids
+          "Time" -> processClockUpdate settlers eventCid timeObservableCid self this observableCids
           other -> abort $ "Unknown lifecycle rule " <> other
 
     interface instance Disclosure.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Bond/ZeroCoupon/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/ZeroCoupon/Instrument.daml
@@ -71,9 +71,9 @@ template Instrument
 
     interface instance Lifecycle.I for Instrument where
       view = Lifecycle.View with lifecycler = issuer
-      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; clockCid; observableCids} self =
+      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; timeObservableCid; observableCids} self =
         case ruleName of
-          "Time" -> processClockUpdate settlers eventCid clockCid self this observableCids
+          "Time" -> processClockUpdate settlers eventCid timeObservableCid self this observableCids
           other -> abort $ "Unknown lifecycle rule " <> other
 
     interface instance Disclosure.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Instrument.daml
@@ -11,10 +11,10 @@ import Daml.Finance.Interface.Claims.Types (C, TaggedClaim(..))
 import Daml.Finance.Interface.Claims.Util (isZero')
 import Daml.Finance.Interface.Claims.Util.Lifecycle (electionEvent, lifecycle, splitPending, timeEvent)
 import Daml.Finance.Interface.Data.NumericObservable qualified as NumericObservable (I)
+import Daml.Finance.Interface.Data.TimeObservable qualified as TimeObservable (I)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, R, View(..), createReference, disclosureUpdateReference, getKey)
 import Daml.Finance.Interface.Instrument.Generic.Election qualified as Election (ApplyElection(..), Exercisable(..), ExercisableHasImplementation, ExercisableView(..), getElectionTime)
 import Daml.Finance.Interface.Instrument.Generic.Instrument qualified as GenericInstrument (HasImplementation, I, View(..))
-import Daml.Finance.Interface.Lifecycle.Clock qualified as Clock (I)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (I)
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Evolve(..), View(..))
@@ -77,9 +77,9 @@ template Instrument
 
     interface instance Lifecycle.I for Instrument where
       view = Lifecycle.View with lifecycler = issuer
-      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; clockCid; observableCids} self =
+      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; timeObservableCid; observableCids} self =
         case ruleName of
-          "Time" -> processClockUpdate settlers eventCid clockCid self this observableCids
+          "Time" -> processClockUpdate settlers eventCid timeObservableCid self this observableCids
           other -> abort $ "Unknown lifecycle rule " <> other
 
     interface instance Disclosure.I for Instrument where
@@ -138,8 +138,8 @@ template Instrument
           pure (coerceContractId newInstrumentCid, [effectCid])
 
 -- | HIDE
--- | Rule to process a clock update event.
-processClockUpdate : Parties -> ContractId Event.I -> ContractId Clock.I -> ContractId Lifecycle.I -> Instrument -> [ContractId NumericObservable.I] -> Update (ContractId Lifecycle.I, [ContractId Effect.I])
+-- | Rule to process a time update event.
+processClockUpdate : Parties -> ContractId Event.I -> ContractId TimeObservable.I -> ContractId Lifecycle.I -> Instrument -> [ContractId NumericObservable.I] -> Update (ContractId Lifecycle.I, [ContractId Effect.I])
 processClockUpdate settlers eventCid _ self instrument observableCids = do
   v <- view <$> fetch eventCid
   claims <- Claim.getClaims $ toInterface @Claim.I instrument

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Instrument.daml
@@ -10,7 +10,7 @@ import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, View(..), getC
 import Daml.Finance.Interface.Claims.Types (C, TaggedClaim(..))
 import Daml.Finance.Interface.Claims.Util (isZero')
 import Daml.Finance.Interface.Claims.Util.Lifecycle (electionEvent, lifecycle, splitPending, timeEvent)
-import Daml.Finance.Interface.Data.Observable qualified as Observable (I)
+import Daml.Finance.Interface.Data.NumericObservable qualified as NumericObservable (I)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, R, View(..), createReference, disclosureUpdateReference, getKey)
 import Daml.Finance.Interface.Instrument.Generic.Election qualified as Election (ApplyElection(..), Exercisable(..), ExercisableHasImplementation, ExercisableView(..), getElectionTime)
 import Daml.Finance.Interface.Instrument.Generic.Instrument qualified as GenericInstrument (HasImplementation, I, View(..))
@@ -139,7 +139,7 @@ template Instrument
 
 -- | HIDE
 -- | Rule to process a clock update event.
-processClockUpdate : Parties -> ContractId Event.I -> ContractId Clock.I -> ContractId Lifecycle.I -> Instrument -> [ContractId Observable.I] -> Update (ContractId Lifecycle.I, [ContractId Effect.I])
+processClockUpdate : Parties -> ContractId Event.I -> ContractId Clock.I -> ContractId Lifecycle.I -> Instrument -> [ContractId NumericObservable.I] -> Update (ContractId Lifecycle.I, [ContractId Effect.I])
 processClockUpdate settlers eventCid _ self instrument observableCids = do
   v <- view <$> fetch eventCid
   claims <- Claim.getClaims $ toInterface @Claim.I instrument

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
@@ -15,7 +15,7 @@ import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, getAcquisition
 import Daml.Finance.Interface.Claims.Types (C, Deliverable, Observable, TaggedClaim(..))
 import Daml.Finance.Interface.Claims.Util (isZero', toTime')
 import Daml.Finance.Interface.Claims.Util.Lifecycle (lifecycle, lifecycleClaims, net, splitPending, timeEvent)
-import Daml.Finance.Interface.Data.Observable qualified as Observable (I)
+import Daml.Finance.Interface.Data.NumericObservable qualified as NumericObservable (I)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (I, createReference, getKey)
 import Daml.Finance.Interface.Lifecycle.Clock qualified as Clock (I)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (I)
@@ -232,7 +232,7 @@ mapClaimToUTCTime =
 
 -- BOND_PROCESS_CLOCK_UPDATE_INITAL_CLAIMS_BEGIN
 -- | Rule to process a clock update event.
-processClockUpdate : IsBond t => Parties -> ContractId Event.I -> ContractId Clock.I -> ContractId Lifecycle.I -> t -> [ContractId Observable.I] -> Update (ContractId Lifecycle.I, [ContractId Effect.I])
+processClockUpdate : IsBond t => Parties -> ContractId Event.I -> ContractId Clock.I -> ContractId Lifecycle.I -> t -> [ContractId NumericObservable.I] -> Update (ContractId Lifecycle.I, [ContractId Effect.I])
 processClockUpdate settlers eventCid _ self instrument observableCids = do
   v <- view <$> fetch eventCid
   let

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
@@ -16,8 +16,8 @@ import Daml.Finance.Interface.Claims.Types (C, Deliverable, Observable, TaggedCl
 import Daml.Finance.Interface.Claims.Util (isZero', toTime')
 import Daml.Finance.Interface.Claims.Util.Lifecycle (lifecycle, lifecycleClaims, net, splitPending, timeEvent)
 import Daml.Finance.Interface.Data.NumericObservable qualified as NumericObservable (I)
+import Daml.Finance.Interface.Data.TimeObservable qualified as TimeObservable (I)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (I, createReference, getKey)
-import Daml.Finance.Interface.Lifecycle.Clock qualified as Clock (I)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (I)
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I)
@@ -232,7 +232,7 @@ mapClaimToUTCTime =
 
 -- BOND_PROCESS_CLOCK_UPDATE_INITAL_CLAIMS_BEGIN
 -- | Rule to process a clock update event.
-processClockUpdate : IsBond t => Parties -> ContractId Event.I -> ContractId Clock.I -> ContractId Lifecycle.I -> t -> [ContractId NumericObservable.I] -> Update (ContractId Lifecycle.I, [ContractId Effect.I])
+processClockUpdate : IsBond t => Parties -> ContractId Event.I -> ContractId TimeObservable.I -> ContractId Lifecycle.I -> t -> [ContractId NumericObservable.I] -> Update (ContractId Lifecycle.I, [ContractId Effect.I])
 processClockUpdate settlers eventCid _ self instrument observableCids = do
   v <- view <$> fetch eventCid
   let

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Asset/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Asset/Instrument.daml
@@ -89,9 +89,9 @@ template Instrument
 
     interface instance Lifecycle.I for Instrument where
       view = Lifecycle.View with lifecycler = issuer
-      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; clockCid; observableCids} self =
+      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; timeObservableCid; observableCids} self =
         case ruleName of
-          "Time" -> processClockUpdate settlers eventCid clockCid self this observableCids
+          "Time" -> processClockUpdate settlers eventCid timeObservableCid self this observableCids
           other -> abort $ "Unknown lifecycle rule " <> other
 
     interface instance Disclosure.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault/Instrument.daml
@@ -88,9 +88,9 @@ template Instrument
 
     interface instance Lifecycle.I for Instrument where
       view = Lifecycle.View with lifecycler = issuer
-      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; clockCid; observableCids} self =
+      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; timeObservableCid; observableCids} self =
         case ruleName of
-          "Time" -> processClockUpdate settlers eventCid clockCid self this observableCids
+          "Time" -> processClockUpdate settlers eventCid timeObservableCid self this observableCids
           other -> abort $ "Unknown lifecycle rule " <> other
 
     interface instance Disclosure.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Currency/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Currency/Instrument.daml
@@ -95,9 +95,9 @@ template Instrument
 
     interface instance Lifecycle.I for Instrument where
       view = Lifecycle.View with lifecycler = issuer
-      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; clockCid; observableCids} self =
+      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; timeObservableCid; observableCids} self =
         case ruleName of
-          "Time" -> processClockUpdate settlers eventCid clockCid self this observableCids
+          "Time" -> processClockUpdate settlers eventCid timeObservableCid self this observableCids
           other -> abort $ "Unknown lifecycle rule " <> other
 
     interface instance Disclosure.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange/Instrument.daml
@@ -85,9 +85,9 @@ template Instrument
 
     interface instance Lifecycle.I for Instrument where
       view = Lifecycle.View with lifecycler = issuer
-      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; clockCid; observableCids} self =
+      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; timeObservableCid; observableCids} self =
         case ruleName of
-          "Time" -> processClockUpdate settlers eventCid clockCid self this observableCids
+          "Time" -> processClockUpdate settlers eventCid timeObservableCid self this observableCids
           other -> abort $ "Unknown lifecycle rule " <> other
 
     interface instance Disclosure.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
@@ -86,9 +86,9 @@ template Instrument
 
     interface instance Lifecycle.I for Instrument where
       view = Lifecycle.View with lifecycler = issuer
-      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; clockCid; observableCids} self =
+      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; timeObservableCid; observableCids} self =
         case ruleName of
-          "Time" -> processClockUpdate settlers eventCid clockCid self this observableCids
+          "Time" -> processClockUpdate settlers eventCid timeObservableCid self this observableCids
           other -> abort $ "Unknown lifecycle rule " <> other
 
     interface instance Disclosure.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate/Instrument.daml
@@ -87,9 +87,9 @@ template Instrument
 
     interface instance Lifecycle.I for Instrument where
       view = Lifecycle.View with lifecycler = issuer
-      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; clockCid; observableCids} self =
+      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; timeObservableCid; observableCids} self =
         case ruleName of
-          "Time" -> processClockUpdate settlers eventCid clockCid self this observableCids
+          "Time" -> processClockUpdate settlers eventCid timeObservableCid self this observableCids
           other -> abort $ "Unknown lifecycle rule " <> other
 
     interface instance Disclosure.I for Instrument where

--- a/src/main/daml/Daml/Finance/Interface/Claims/Types.daml
+++ b/src/main/daml/Daml/Finance/Interface/Claims/Types.daml
@@ -21,14 +21,14 @@ type Observable = Text
 -- | The specialized claim type
 type C = Claim Time Decimal Deliverable Observable
 
--- | A claim and a textual tag
+-- | A claim and a textual tag.
 data TaggedClaim = TaggedClaim
   with
     claim : C
     tag : Text
   deriving (Eq, Show)
 
--- | Type used to record pending payments
+-- | Type used to record pending payments.
 data Pending = Pending
   with
     t : Time

--- a/src/main/daml/Daml/Finance/Interface/Claims/Util/Lifecycle.daml
+++ b/src/main/daml/Daml/Finance/Interface/Claims/Util/Lifecycle.daml
@@ -16,7 +16,7 @@ import DA.List (head, groupOn, sort)
 import DA.Map as M (fromList, lookup)
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, getAcquisitionTime, getClaims)
 import Daml.Finance.Interface.Claims.Types (C, Observable, Pending(..), TaggedClaim(..))
-import Daml.Finance.Interface.Data.Observable qualified as Observable (I, observe)
+import Daml.Finance.Interface.Data.NumericObservable qualified as NumericObservable (I, observe)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (Q, qty)
 import Prelude hiding (exercise)
 
@@ -66,7 +66,7 @@ applyEvents observe acquisitionTime es claim =
   in foldl folder (pure (claim,[])) $ sort es
 
 -- | Lifecycle a set of claims at specified events.
-lifecycleClaims : [ContractId Observable.I]          -- ^ The set of observables.
+lifecycleClaims : [ContractId NumericObservable.I]   -- ^ The set of observables.
                -> Time                               -- ^ The input claims' acquisition time.
                -> [TaggedClaim]                      -- ^ The input claims.
                -> [Event]                            -- ^ Lifecycle events.
@@ -93,8 +93,8 @@ net pending =
     map createPendingNode groupedPending
 
 -- | Lifecycle a claim instrument at specified events.
-lifecycle : [ContractId Observable.I]          -- ^ The set of observables.
-         -> Claim.I                        -- ^ The input instrument.
+lifecycle : [ContractId NumericObservable.I]   -- ^ The set of observables.
+         -> Claim.I                            -- ^ The input instrument.
          -> [Event]                            -- ^ Lifecycle events.
          -> Update ([TaggedClaim], [Pending])  -- ^ The remaining claims and pending payments.
 lifecycle observableCids instrument events = do
@@ -106,13 +106,13 @@ lifecycle observableCids instrument events = do
 -- | HIDE
 -- Fetches all `Observable` contracts and stores them in a `Map` keyed by their `id`. It then returns a function that can be used to query them.
 -- The controller must be authorized to fetch the `Observable` contracts.
-collectObservables : [ContractId Observable.I] -> Update (Observable -> Time -> Update Decimal)
+collectObservables : [ContractId NumericObservable.I] -> Update (Observable -> Time -> Update Decimal)
 collectObservables observableCids = do
   os <- M.fromList <$> forA observableCids \cid -> do
     observation <- fetch cid
     pure (show (view observation).id, observation)
   pure \key t -> case M.lookup key os of
-    Some o -> Observable.observe o t
+    Some o -> NumericObservable.observe o t
     None -> do abort $ "Missing observable" <> show key <> " at time " <> show t
 
 -- | Map pending settlements into corresponding instrument quantities and split them into consumed and produced.

--- a/src/main/daml/Daml/Finance/Interface/Data/NumericObservable.daml
+++ b/src/main/daml/Daml/Finance/Interface/Data/NumericObservable.daml
@@ -1,13 +1,13 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Daml.Finance.Interface.Data.Observable where
+module Daml.Finance.Interface.Data.NumericObservable where
 
 import DA.Map as M (Map)
 import Daml.Finance.Interface.Types.Common (Id, Parties)
 
 -- | Type synonym for `Observable`.
-type I = Observable
+type I = NumericObservable
 
 -- | Type synonym for `View`.
 type V = View
@@ -23,8 +23,8 @@ data View = View
       -- ^ The time-dependent values.
   deriving (Eq, Show)
 
--- | An inferface to inspect some numerical values (e.g. a stock price or an interest rate) required when processing a lifecycle rule.
-interface Observable where
+-- | An interface to inspect some (time-dependent) numerical values (e.g. a stock price or an interest rate fixing) required when processing a lifecycle rule.
+interface NumericObservable where
   viewtype V
 
   observe : Time -> Update Decimal

--- a/src/main/daml/Daml/Finance/Interface/Data/NumericObservable.daml
+++ b/src/main/daml/Daml/Finance/Interface/Data/NumericObservable.daml
@@ -16,7 +16,7 @@ type V = View
 data View = View
   with
     provider : Party
-      -- ^ Party providing the observables.
+      -- ^ Party providing the observations.
     id : Id
       -- ^ Textual reference to the observable.
     observations : Map Time Decimal

--- a/src/main/daml/Daml/Finance/Interface/Data/NumericObservable.daml
+++ b/src/main/daml/Daml/Finance/Interface/Data/NumericObservable.daml
@@ -1,6 +1,7 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+-- | This module defines an interface for a `NumericObservable`, which is used to inspect time-dependent numerical values.
 module Daml.Finance.Interface.Data.NumericObservable where
 
 import DA.Map as M (Map)

--- a/src/main/daml/Daml/Finance/Interface/Data/TimeObservable.daml
+++ b/src/main/daml/Daml/Finance/Interface/Data/TimeObservable.daml
@@ -1,6 +1,7 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+-- | This module defines an interface for a `TimeObservable`, which is implemented by templates exposing time information.
 module Daml.Finance.Interface.Data.TimeObservable where
 
 import Daml.Finance.Interface.Types.Common (Id, Parties)

--- a/src/main/daml/Daml/Finance/Interface/Data/TimeObservable.daml
+++ b/src/main/daml/Daml/Finance/Interface/Data/TimeObservable.daml
@@ -1,28 +1,30 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Daml.Finance.Interface.Lifecycle.Clock where
+module Daml.Finance.Interface.Data.TimeObservable where
 
-import Daml.Finance.Interface.Types.Common (Id)
+import Daml.Finance.Interface.Types.Common (Id, Parties)
 import Daml.Finance.Interface.Types.Date.Classes (HasUTCTimeConversion(..))
 
--- | Type synonym for `Clock`.
-type I = Clock
+-- | Type synonym for `TimeObservable`.
+type I = TimeObservable
 
 -- | Type synonym for `View`.
 type V = View
 
--- | View for `Clock`.
+-- | View for `TimeObservable`.
 data View = View
   with
+    providers : Parties
+      -- ^ Parties providing the observation.
     id : Id
-      -- ^ The clock's identifier.
-    clockTime : Time
-      -- ^ The clock's time expressed in UTC time.
+      -- ^ Textual reference to the observable.
+    time : Time
+      -- ^ The observed UTC time.
   deriving (Eq, Show)
 
--- | A clock is a subdivision of the Time continuum into a countable set. For each element of this set, we can calculate the corresponding UTC time.
-interface Clock where
+-- | An interface to inspect a time value.
+interface TimeObservable where
   viewtype V
 
   nonconsuming choice GetView : View
@@ -34,13 +36,13 @@ interface Clock where
     do
       pure $ view this
 
--- | Type constraint for requiring interface implementations for `Clock`.
+-- | Type constraint for requiring interface implementations for `TimeObservable`.
 type Implementation t = HasToInterface t I
 class (Implementation t) => HasImplementation t
 instance HasImplementation I
 
-instance HasUTCTimeConversion Clock where
-  toUTCTime c = (view c).clockTime
+instance HasUTCTimeConversion TimeObservable where
+  toUTCTime c = (view c).time
 
-instance Ord Clock where
+instance Ord TimeObservable where
   x <= y = toUTCTime x <= toUTCTime y

--- a/src/main/daml/Daml/Finance/Interface/Holding/Transferable.daml
+++ b/src/main/daml/Daml/Finance/Interface/Holding/Transferable.daml
@@ -45,7 +45,7 @@ interface Transferable where
       pure $ view this
 
   nonconsuming choice Transfer : ContractId Transferable
-    -- ^ Transfer a contract to a new owner
+    -- ^ Transfer a contract to a new owner.
     with
       actors : Parties
         -- ^ Parties authorizing the transfer.

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Generic/Election.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Generic/Election.daml
@@ -4,7 +4,7 @@
 module Daml.Finance.Interface.Instrument.Generic.Election where
 
 import Daml.Finance.Interface.Claims.Types (C)
-import Daml.Finance.Interface.Data.Observable qualified as Observable (I)
+import Daml.Finance.Interface.Data.NumericObservable qualified as NumericObservable (I)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (K, exerciseInterfaceByKey)
 import Daml.Finance.Interface.Lifecycle.Clock qualified as Clock (I)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (I)
@@ -67,7 +67,7 @@ interface Election where
     with
       clockCid : ContractId Clock.I
         -- ^ current time.
-      observableCids : [ContractId Observable.I]
+      observableCids : [ContractId NumericObservable.I]
         -- ^ set of observables
       settlers : Parties
         -- ^ parties responsible for settling effects
@@ -125,7 +125,7 @@ interface Exercisable where
         -- ^ Current time. This is also an observable, but not a strictly 'Decimal' one.
       electionCid : ContractId Election
         -- ^ The election.
-      observableCids : [ContractId Observable.I]
+      observableCids : [ContractId NumericObservable.I]
         -- ^ Set of observables.
       settlers : Parties
         -- ^ The party settling the transaction.

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Generic/Election.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Generic/Election.daml
@@ -6,7 +6,7 @@ module Daml.Finance.Interface.Instrument.Generic.Election where
 import Daml.Finance.Interface.Claims.Types (C)
 import Daml.Finance.Interface.Data.NumericObservable qualified as NumericObservable (I)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (K, exerciseInterfaceByKey)
-import Daml.Finance.Interface.Lifecycle.Clock qualified as Clock (I)
+import Daml.Finance.Interface.Data.TimeObservable qualified as TimeObservable (I)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (I)
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I, Implementation, getEventTime)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Implementation)
@@ -65,7 +65,7 @@ interface Election where
     -- ^ applies the election to the instrument, returning the new instrument as well
     -- as the corresponding effects. The election is archived as part of this choice.
     with
-      clockCid : ContractId Clock.I
+      clockCid : ContractId TimeObservable.I
         -- ^ current time.
       observableCids : [ContractId NumericObservable.I]
         -- ^ set of observables
@@ -121,7 +121,7 @@ interface Exercisable where
   nonconsuming choice ApplyElection : (ContractId Lifecycle.I, [ContractId Effect.I])
     -- ^ Applies an election to the instrument.
     with
-      clockCid : ContractId Clock.I
+      clockCid : ContractId TimeObservable.I
         -- ^ Current time. This is also an observable, but not a strictly 'Decimal' one.
       electionCid : ContractId Election
         -- ^ The election.

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Rule/Lifecycle.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Rule/Lifecycle.daml
@@ -3,7 +3,7 @@
 
 module Daml.Finance.Interface.Lifecycle.Rule.Lifecycle where
 
-import Daml.Finance.Interface.Data.Observable (Observable)
+import Daml.Finance.Interface.Data.NumericObservable (NumericObservable)
 import Daml.Finance.Interface.Lifecycle.Clock qualified as Clock (I)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (I)
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I)
@@ -49,7 +49,7 @@ interface Lifecycle where
         -- ^ The event.
       clockCid : ContractId Clock.I
         -- ^ Current time. This is also an observable, but not a strictly 'Decimal' one.
-      observableCids : [ContractId Observable]
+      observableCids : [ContractId NumericObservable]
         -- ^ Set of numerical time-dependent observables.
     controller (view this).lifecycler
     do

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Rule/Lifecycle.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Rule/Lifecycle.daml
@@ -3,8 +3,8 @@
 
 module Daml.Finance.Interface.Lifecycle.Rule.Lifecycle where
 
-import Daml.Finance.Interface.Data.NumericObservable (NumericObservable)
-import Daml.Finance.Interface.Lifecycle.Clock qualified as Clock (I)
+import Daml.Finance.Interface.Data.NumericObservable qualified as NumericObservable (I)
+import Daml.Finance.Interface.Data.TimeObservable qualified as TimeObservable (I)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (I)
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I)
 import Daml.Finance.Interface.Types.Common (Parties)
@@ -47,9 +47,9 @@ interface Lifecycle where
         -- ^ The party settling the effects.
       eventCid : ContractId Event.I
         -- ^ The event.
-      clockCid : ContractId Clock.I
-        -- ^ Current time. This is also an observable, but not a strictly 'Decimal' one.
-      observableCids : [ContractId NumericObservable]
+      timeObservableCid : ContractId TimeObservable.I
+        -- ^ Current time.
+      observableCids : [ContractId NumericObservable.I]
         -- ^ Set of numerical time-dependent observables.
     controller (view this).lifecycler
     do

--- a/src/main/daml/Daml/Finance/Lifecycle/Rule/Distribution.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Rule/Distribution.daml
@@ -4,7 +4,7 @@
 module Daml.Finance.Lifecycle.Rule.Distribution where
 
 import DA.Date (toDateUTC)
-import Daml.Finance.Interface.Lifecycle.Clock qualified as Clock (GetView(..))
+import Daml.Finance.Interface.Data.TimeObservable qualified as TimeObservable (GetView(..))
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (HasImplementation, I, Evolve(..), View(..))
 import Daml.Finance.Interface.Types.Common (Parties)
 import Daml.Finance.Lifecycle.Effect (Effect(..))
@@ -30,9 +30,9 @@ template Rule
 
     interface instance Lifecycle.I for Rule where
       view = Lifecycle.View with lifecycler
-      evolve Lifecycle.Evolve{settlers; eventCid; clockCid} self = do
+      evolve Lifecycle.Evolve{settlers; eventCid; timeObservableCid} self = do
         distribution <- fetch $ fromInterfaceContractId @Distribution.Event eventCid
-        clockTime <- toDateUTC . (.clockTime) <$> exercise clockCid Clock.GetView with viewer = lifecycler
+        clockTime <- toDateUTC . (.time) <$> exercise timeObservableCid TimeObservable.GetView with viewer = lifecycler
         if clockTime >= distribution.effectiveDate
         then do
           effectCid <- toInterfaceContractId <$> create Effect

--- a/src/main/daml/Daml/Finance/Lifecycle/Rule/Replacement.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Rule/Replacement.daml
@@ -4,7 +4,7 @@
 module Daml.Finance.Lifecycle.Rule.Replacement where
 
 import DA.Date (toDateUTC)
-import Daml.Finance.Interface.Lifecycle.Clock qualified as Clock (GetView(..))
+import Daml.Finance.Interface.Data.TimeObservable qualified as TimeObservable (GetView(..))
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (HasImplementation, Evolve(..), I, View(..))
 import Daml.Finance.Interface.Types.Common (Parties)
 import Daml.Finance.Lifecycle.Effect (Effect(..))
@@ -30,9 +30,9 @@ template Rule
 
     interface instance Lifecycle.I for Rule where
       view = Lifecycle.View with lifecycler
-      evolve Lifecycle.Evolve{settlers; eventCid; clockCid} self = do
+      evolve Lifecycle.Evolve{settlers; eventCid; timeObservableCid} self = do
         replacement <- fetch $ fromInterfaceContractId @Replacement.Event eventCid
-        clockTime <- toDateUTC . (.clockTime) <$> exercise clockCid Clock.GetView with viewer = lifecycler
+        clockTime <- toDateUTC . (.time) <$> exercise timeObservableCid TimeObservable.GetView with viewer = lifecycler
         if clockTime >= replacement.effectiveDate
         then do
           effectCid <- toInterfaceContractId <$> create Effect

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
@@ -110,7 +110,7 @@ lifecycleInstrument readAs today instrument settlers issuer observableCids = do
   -- LIFECYCLE_BOND_BEGIN
   -- Try to lifecycle instrument
   (lifecycleCid, effectCids) <- Instrument.submitExerciseInterfaceByKeyCmd @Lifecycle.I [issuer] readAs instrument
-    Lifecycle.Evolve with settlers; eventCid = clockEventCid; observableCids; ruleName = "Time"; clockCid
+    Lifecycle.Evolve with settlers; eventCid = clockEventCid; observableCids; ruleName = "Time"; timeObservableCid = clockCid
   -- LIFECYCLE_BOND_END
 
   pure (lifecycleCid, effectCids)

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
@@ -12,7 +12,7 @@ import Daml.Finance.Instrument.Bond.FloatingRate.Instrument qualified as Floatin
 import Daml.Finance.Instrument.Bond.InflationLinked.Instrument qualified as InflationLinked (Instrument(..))
 import Daml.Finance.Instrument.Bond.ZeroCoupon.Instrument qualified as ZeroCoupon (Instrument(..))
 import Daml.Finance.Interface.Claims.Types (Deliverable)
-import Daml.Finance.Interface.Data.Observable qualified as Observable (I)
+import Daml.Finance.Interface.Data.NumericObservable qualified as NumericObservable (I)
 import Daml.Finance.Interface.Holding.Base qualified as Base (I)
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (GetView(..), K, I, Q, toKey)
@@ -100,7 +100,7 @@ originateInflationLinkedBond depository issuer label description observers lastE
   createReference cid depository issuer observers
 
 -- | Lifecycle the instrument as of this date. This is a general function that can be used for both bonds and swaps.
-lifecycleInstrument : [Party] -> Date -> Instrument.K -> Parties -> Party -> [ContractId Observable.I] -> Script (ContractId Lifecycle.I, [ContractId Effect.I])
+lifecycleInstrument : [Party] -> Date -> Instrument.K -> Parties -> Party -> [ContractId NumericObservable.I] -> Script (ContractId Lifecycle.I, [ContractId Effect.I])
 lifecycleInstrument readAs today instrument settlers issuer observableCids = do
   -- CREATE_CLOCK_FOR_BOND_LIFECYCLING_BEGIN
   -- create clock and clock update event
@@ -116,13 +116,13 @@ lifecycleInstrument readAs today instrument settlers issuer observableCids = do
   pure (lifecycleCid, effectCids)
 
 -- | Verify a that there are no lifecycle effects of the instrument on this date. This is a general function that can be used for both bonds and swaps.
-verifyNoLifecycleEffects : [Party] -> Date -> Instrument.K -> Parties -> Party -> [ContractId Observable.I] -> Script ()
+verifyNoLifecycleEffects : [Party] -> Date -> Instrument.K -> Parties -> Party -> [ContractId NumericObservable.I] -> Script ()
 verifyNoLifecycleEffects readAs today instrument settlers issuer observableCids = do
   (bondLifecycleCid2, effectCids) <- lifecycleInstrument readAs today instrument settlers issuer observableCids
   assertMsg ("There should be no lifecycle effects on " <> show today) (null effectCids)
 
 -- | Verify the payments from a payment date of a bond (excluding settlement)
-lifecycleAndVerifyBondPaymentEffects : [Party] -> Date -> Instrument.K -> Parties -> Party -> Party -> [(Text, Parties)] -> Party -> [ContractId Observable.I] -> [Instrument.Q] -> [Instrument.Q] -> Script Instrument.K
+lifecycleAndVerifyBondPaymentEffects : [Party] -> Date -> Instrument.K -> Parties -> Party -> Party -> [(Text, Parties)] -> Party -> [ContractId NumericObservable.I] -> [Instrument.Q] -> [Instrument.Q] -> Script Instrument.K
 lifecycleAndVerifyBondPaymentEffects readAs today instrument settlers issuer investor obs custodian observableCids expectedConsumedQuantities expectedProducedQuantities = do
   (bondLifecycleCid, [effectCid]) <- lifecycleInstrument readAs today instrument settlers issuer observableCids
 
@@ -142,7 +142,7 @@ lifecycleAndVerifyBondPaymentEffects readAs today instrument settlers issuer inv
 -- | Verify a coupon payment of a bond (excluding the last date, which also includes a redemption amount).
 -- Since we have moved to unit tests, this function is mainly kept for the docs.
 -- It contains the code snippets needed for the bond lifecycling tutorial.
-lifecycleAndVerifyCouponEffectsAndSettlement : [Party] -> Date -> Instrument.K -> Parties -> Party -> Party -> ContractId Transferable.I -> ContractId Transferable.I -> AccountKey -> AccountKey -> [(Text, Parties)] -> Party -> [ContractId Observable.I] -> Script (Instrument.K, ContractId Transferable.I)
+lifecycleAndVerifyCouponEffectsAndSettlement : [Party] -> Date -> Instrument.K -> Parties -> Party -> Party -> ContractId Transferable.I -> ContractId Transferable.I -> AccountKey -> AccountKey -> [(Text, Parties)] -> Party -> [ContractId NumericObservable.I] -> Script (Instrument.K, ContractId Transferable.I)
 lifecycleAndVerifyCouponEffectsAndSettlement readAs today instrument settlers issuer investor investorBondTransferableCid custodianCashTransferableCid custodianAccount investorAccount obs custodian observableCids = do
   (lifecycleCid, [effectCid]) <- lifecycleInstrument readAs today instrument settlers issuer observableCids
 

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
@@ -77,7 +77,7 @@ run = script do
       perUnitDistribution = [Instrument.qty 2.0 cashInstrument]
 
   -- Lifecycle cash dividend
-  (_, [effectCid]) <- submit issuer do exerciseCmd distributionRuleCid Lifecycle.Evolve with ruleName = "Dividend"; settlers = singleton investor; observableCids = []; eventCid = distributionEventCid; clockCid
+  (_, [effectCid]) <- submit issuer do exerciseCmd distributionRuleCid Lifecycle.Evolve with ruleName = "Dividend"; settlers = singleton investor; observableCids = []; eventCid = distributionEventCid; timeObservableCid = clockCid
 
   -- Claim effect
   result <- submitMulti [investor] [public] do

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Merger.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Merger.daml
@@ -74,7 +74,7 @@ run = script do
       perUnitReplacement = [Instrument.qty 0.5 mergedInstrument]
 
   -- Lifecycle replacement event
-  (_, [effectCid]) <- submitMulti [merging] [public] do exerciseCmd replacementRuleCid Lifecycle.Evolve with ruleName = "Merger"; settlers = singleton investor; eventCid = replacementEventCid; observableCids = []; clockCid
+  (_, [effectCid]) <- submitMulti [merging] [public] do exerciseCmd replacementRuleCid Lifecycle.Evolve with ruleName = "Merger"; settlers = singleton investor; eventCid = replacementEventCid; observableCids = []; timeObservableCid = clockCid
 
   -- Claim effect
   result <- submitMulti [investor] [public] do

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/StockSplit.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/StockSplit.daml
@@ -72,7 +72,7 @@ run = script do
       adjustmentFactor = 0.5
 
   -- Lifecycle stock split
-  (_, [effectCid]) <- submit issuer do exerciseCmd replacementRuleCid Lifecycle.Evolve with ruleName = "Dividend"; settlers = singleton investor; observableCids = []; eventCid = replacementEventCid; clockCid
+  (_, [effectCid]) <- submit issuer do exerciseCmd replacementRuleCid Lifecycle.Evolve with ruleName = "Dividend"; settlers = singleton investor; observableCids = []; eventCid = replacementEventCid; timeObservableCid = clockCid
 
   -- Claim effect
   result <- submitMulti [investor] [public] do

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardCash.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardCash.daml
@@ -79,7 +79,7 @@ run = script do
   (clockCid, clockEventCid) <- createClockAndEvent (singleton broker) maturity empty
 
   -- Lifecycle derivative
-  (_, [effectCid]) <- Instrument.submitExerciseInterfaceByKeyCmd @Lifecycle.I [broker] [] genericInstrument Lifecycle.Evolve with settlers; eventCid = clockEventCid; observableCids = [observableCid]; ruleName = "Time"; clockCid
+  (_, [effectCid]) <- Instrument.submitExerciseInterfaceByKeyCmd @Lifecycle.I [broker] [] genericInstrument Lifecycle.Evolve with settlers; eventCid = clockEventCid; observableCids = [observableCid]; ruleName = "Time"; timeObservableCid = clockCid
 
   -- Create settlement factory
   settlementFactoryCid <- toInterfaceContractId <$> submit investor do createCmd Factory with provider = investor; observers = empty

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardPhysical.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardPhysical.daml
@@ -79,7 +79,7 @@ run = script do
   (clockCid, clockEventCid) <- createClockAndEvent (singleton broker) maturity empty
 
   -- Lifecycle a generic derivative
-  (_, [effectCid]) <- Instrument.submitExerciseInterfaceByKeyCmd @Lifecycle.I [broker] [] genericInstrument Lifecycle.Evolve with settlers; eventCid = clockEventCid; observableCids = []; ruleName = "Time"; clockCid
+  (_, [effectCid]) <- Instrument.submitExerciseInterfaceByKeyCmd @Lifecycle.I [broker] [] genericInstrument Lifecycle.Evolve with settlers; eventCid = clockEventCid; observableCids = []; ruleName = "Time"; timeObservableCid = clockCid
 
   -- Create settlement factory
   settlementFactoryCid <- toInterfaceContractId <$> submitMulti [investor] [] do createCmd Factory with provider = investor; observers = empty

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
@@ -134,7 +134,7 @@ run = script do
   (clockCid, clockEventCid) <- createClockAndEvent (singleton issuer) today empty
 
   -- Lifecycle bond
-  (genericLifecycleCid2, [effectCid]) <- BaseInstrument.submitExerciseInterfaceByKeyCmd @Lifecycle.I [issuer] [] genericInstrument Lifecycle.Evolve with settlers; eventCid = clockEventCid; observableCids = []; ruleName = "Time"; clockCid
+  (genericLifecycleCid2, [effectCid]) <- BaseInstrument.submitExerciseInterfaceByKeyCmd @Lifecycle.I [issuer] [] genericInstrument Lifecycle.Evolve with settlers; eventCid = clockEventCid; observableCids = []; ruleName = "Time"; timeObservableCid = clockCid
 
   -- Setup settlement contract between issuer and CSD
   -- In order for the workflow to be successful, we need to disclose the CSD's cash account to the Issuer.

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -13,7 +13,7 @@ import Daml.Finance.Instrument.Swap.Currency.Instrument qualified as CurrencySwa
 import Daml.Finance.Instrument.Swap.ForeignExchange.Instrument qualified as ForeignExchange (Instrument(..))
 import Daml.Finance.Instrument.Swap.Fpml.Instrument qualified as FpmlSwap (Instrument(..))
 import Daml.Finance.Instrument.Swap.InterestRate.Instrument qualified as InterestRateSwap (Instrument(..))
-import Daml.Finance.Interface.Data.Observable qualified as Observable (I)
+import Daml.Finance.Interface.Data.NumericObservable qualified as NumericObservable (I)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (GetView(..), K, I, Q, toKey)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (I, GetView(..))
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Evolve(..))
@@ -119,7 +119,7 @@ originateForeignExchangeSwap depository issuer label description observers lastE
   createReference cid depository issuer observers
 
 -- | Lifecycle the instrument as of this date. This is a general function that can be used for both bonds and swaps.
-lifecycleInstrument : [Party] -> Date -> Instrument.K -> Parties -> Party -> [ContractId Observable.I] -> Script (ContractId Lifecycle.I, [ContractId Effect.I])
+lifecycleInstrument : [Party] -> Date -> Instrument.K -> Parties -> Party -> [ContractId NumericObservable.I] -> Script (ContractId Lifecycle.I, [ContractId Effect.I])
 lifecycleInstrument readAs today instrument settlers issuer observableCids = do
   -- CREATE_CLOCK_FOR_BOND_LIFECYCLING_BEGIN
   -- create clock and clock update event
@@ -135,13 +135,13 @@ lifecycleInstrument readAs today instrument settlers issuer observableCids = do
   pure (lifecycleCid, effectCids)
 
 -- | Verify a that there are no lifecycle effects of the instrument on this date. This is a general function that can be used for both bonds and swaps.
-verifyNoLifecycleEffects : [Party] -> Date -> Instrument.K -> Parties -> Party -> [ContractId Observable.I] -> Script ()
+verifyNoLifecycleEffects : [Party] -> Date -> Instrument.K -> Parties -> Party -> [ContractId NumericObservable.I] -> Script ()
 verifyNoLifecycleEffects readAs today instrument settlers issuer observableCids = do
   (bondLifecycleCid2, effectCids) <- lifecycleInstrument readAs today instrument settlers issuer observableCids
   assertMsg ("There should be no lifecycle effects on " <> show today) (null effectCids)
 
 -- | Verify the payments from a payment date of a swap (excluding settlement)
-lifecycleAndVerifySwapPaymentEffects : [Party] -> Date -> Instrument.K -> Parties -> Party -> Party -> [(Text, Parties)] -> Party -> [ContractId Observable.I] -> [Instrument.Q] -> [Instrument.Q] -> Script Instrument.K
+lifecycleAndVerifySwapPaymentEffects : [Party] -> Date -> Instrument.K -> Parties -> Party -> Party -> [(Text, Parties)] -> Party -> [ContractId NumericObservable.I] -> [Instrument.Q] -> [Instrument.Q] -> Script Instrument.K
 lifecycleAndVerifySwapPaymentEffects readAs today swapInstrument settlers issuer investor obs custodian observableCids expectedConsumedQuantities expectedProducedQuantities = do
   (swapLifecycleCid, [effectCid]) <- lifecycleInstrument readAs today swapInstrument settlers issuer observableCids
 

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -129,7 +129,7 @@ lifecycleInstrument readAs today instrument settlers issuer observableCids = do
   -- LIFECYCLE_BOND_BEGIN
   -- Try to lifecycle instrument
   (lifecycleCid, effectCids) <- Instrument.submitExerciseInterfaceByKeyCmd @Lifecycle.I [issuer] readAs instrument
-    Lifecycle.Evolve with settlers; eventCid = clockEventCid; observableCids; ruleName = "Time"; clockCid
+    Lifecycle.Evolve with settlers; eventCid = clockEventCid; observableCids; ruleName = "Time"; timeObservableCid = clockCid
   -- LIFECYCLE_BOND_END
 
   pure (lifecycleCid, effectCids)

--- a/src/test/daml/Daml/Finance/Test/Util/Lifecycle.daml
+++ b/src/test/daml/Daml/Finance/Test/Util/Lifecycle.daml
@@ -4,15 +4,15 @@
 module Daml.Finance.Test.Util.Lifecycle where
 
 import DA.Set (toList)
+import Daml.Finance.Data.Time.DateClock (DateClock(..))
 import Daml.Finance.Interface.Types.Common (Id(..), Parties)
-import Daml.Finance.Interface.Lifecycle.Clock qualified as Clock (I)
+import Daml.Finance.Interface.Data.TimeObservable qualified as TimeObservable (I)
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I)
-import Daml.Finance.Lifecycle.DateClock (DateClock(..))
 import Daml.Finance.Lifecycle.Event.DateClock qualified as DateClock (Event(..))
 import Daml.Finance.Lifecycle.Types (Unit(..))
 import Daml.Script
 
-createClockAndEvent : Parties -> Date -> Parties -> Script (ContractId Clock.I, ContractId Event.I)
+createClockAndEvent : Parties -> Date -> Parties -> Script (ContractId TimeObservable.I, ContractId Event.I)
 createClockAndEvent providers today observers = do
   let
     description = show today


### PR DESCRIPTION
Move `TimeObservable` to `D.F.Interface.Data`.

This re-addresses #100.

Green light 🟢 from @georg-da in https://github.com/digital-asset/daml-finance/pull/218#discussion_r986128932 regarding the move.

Proposal for subsequent changes:
- rename the `DateClock` event to `DateClockUpdate`. Move it to `Data` as well

I think we should revisit the modules in the `Data` package, as we currently have
- Observable.Observation
- Time.DateClock
- Reference.HolidayCalendar

To be in line with our interfaces, I would suggest using
- NumericObservable.Observation
- TimeObservable.DateClock
- HolidayCalendar

or, alternatively
- Numeric.Observation
- Time.DateClock
- HolidayCalendar

Happy to hear what you think about this proposal. I will implement any agreed solution in a subsequent PR