### PR TITLE
Add support for FpML swapStream notional

### DIFF
--- a/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate/Instrument.daml
@@ -68,10 +68,11 @@ template Instrument
         schedule <- rollPaymentSchedule periodicSchedule holidayCalendarIds issuer calendarDataProvider
         let
           useAdjustedDatesForDcf = True
+          notional = 1.0
           issuerPays = True
           fxAdjustment = 1.0
-          couponClaims = createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf couponRate issuerPays dayCountConvention currency
-          redemptionClaim = createFxAdjustedPrincipalClaim issuerPays fxAdjustment currency periodicSchedule.terminationDate
+          couponClaims = createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf couponRate issuerPays dayCountConvention notional currency
+          redemptionClaim = createFxAdjustedPrincipalClaim issuerPays fxAdjustment notional currency periodicSchedule.terminationDate
         pure $ [couponClaims, redemptionClaim]
     -- FIXED_RATE_BOND_CLAIMS_END
 

--- a/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate/Instrument.daml
@@ -71,10 +71,11 @@ template Instrument
         schedule <- rollPaymentSchedule periodicSchedule holidayCalendarIds issuer calendarDataProvider
         let
           useAdjustedDatesForDcf = True
+          notional = 1.0
           issuerPays = True
           fxAdjustment = 1.0
-          couponClaims = createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf couponSpread issuerPays dayCountConvention currency referenceRateId
-          redemptionClaim = createFxAdjustedPrincipalClaim issuerPays fxAdjustment currency periodicSchedule.terminationDate
+          couponClaims = createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf couponSpread issuerPays dayCountConvention notional currency referenceRateId
+          redemptionClaim = createFxAdjustedPrincipalClaim issuerPays fxAdjustment notional currency periodicSchedule.terminationDate
         pure $ [couponClaims, redemptionClaim]
 
     interface instance BaseInstrument.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Bond/ZeroCoupon/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/ZeroCoupon/Instrument.daml
@@ -55,9 +55,10 @@ template Instrument
       getClaims = do
         -- get the initial claims tree (as of the bond's acquisition time)
         let
+          notional = 1.0
           issuerPays = True
           fxAdjustment = 1.0
-          redemptionClaim = createFxAdjustedPrincipalClaim issuerPays fxAdjustment currency maturityDate
+          redemptionClaim = createFxAdjustedPrincipalClaim issuerPays fxAdjustment notional currency maturityDate
         pure $ [redemptionClaim]
 
     interface instance BaseInstrument.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
@@ -59,37 +59,37 @@ prepareAndTagClaims cs tag = do
   TaggedClaim with tag; claim
 
 -- FIXED_RATE_BOND_COUPON_CLAIMS_BEGIN
-createFixRatePaymentClaimsList : [SchedulePeriod] -> PeriodicSchedule -> Bool -> Decimal -> Bool -> DayCountConventionEnum -> Deliverable -> [Claim Date Decimal Deliverable Observable]
-createFixRatePaymentClaimsList schedule periodicSchedule useAdjustedDatesForDcf couponRate issuerPays dayCountConvention cashInstrumentCid = do
+createFixRatePaymentClaimsList : [SchedulePeriod] -> PeriodicSchedule -> Bool -> Decimal -> Bool -> DayCountConventionEnum -> Decimal -> Deliverable -> [Claim Date Decimal Deliverable Observable]
+createFixRatePaymentClaimsList schedule periodicSchedule useAdjustedDatesForDcf couponRate issuerPays dayCountConvention notional cashInstrumentCid = do
   let
     couponDatesAdjusted = map (.adjustedEndDate) schedule
     couponAmounts = map (\p -> couponRate * (calcPeriodDcf dayCountConvention p useAdjustedDatesForDcf periodicSchedule.terminationDate periodicSchedule.frequency)) schedule
-    couponClaimAmounts = mconcat $ zipWith (\d a -> when (TimeGte d) $ scale (Const a) $ one cashInstrumentCid) couponDatesAdjusted couponAmounts
+    couponClaimAmounts = mconcat $ zipWith (\d a -> when (TimeGte d) $ scale (Const a) $ scale (Const notional) $ one cashInstrumentCid) couponDatesAdjusted couponAmounts
     couponClaims = if issuerPays then couponClaimAmounts else give couponClaimAmounts
   pure couponClaims
 -- FIXED_RATE_BOND_COUPON_CLAIMS_END
 
 -- | Calculate a fix rate amount for each payment date and create claims.
-createFixRatePaymentClaims : [SchedulePeriod] -> PeriodicSchedule -> Bool -> Decimal -> Bool -> DayCountConventionEnum -> Deliverable -> TaggedClaim
-createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf couponRate issuerPays dayCountConvention cashInstrumentCid = do
-  let couponClaims = createFixRatePaymentClaimsList schedule periodicSchedule useAdjustedDatesForDcf couponRate issuerPays dayCountConvention cashInstrumentCid
+createFixRatePaymentClaims : [SchedulePeriod] -> PeriodicSchedule -> Bool -> Decimal -> Bool -> DayCountConventionEnum -> Decimal -> Deliverable -> TaggedClaim
+createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf couponRate issuerPays dayCountConvention notional cashInstrumentCid = do
+  let couponClaims = createFixRatePaymentClaimsList schedule periodicSchedule useAdjustedDatesForDcf couponRate issuerPays dayCountConvention notional cashInstrumentCid
   prepareAndTagClaims couponClaims "Fix rate payment"
 
 -- | Calculate a fix rate amount (if a credit event has not yet happened) for each payment date and create claims.
-createConditionalCreditFixRatePaymentClaims : [SchedulePeriod] -> PeriodicSchedule -> Bool -> Decimal -> Bool -> DayCountConventionEnum -> Deliverable -> Observable -> TaggedClaim
-createConditionalCreditFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf couponRate issuerPays dayCountConvention cashInstrumentCid defaultProbabilityReferenceId = do
+createConditionalCreditFixRatePaymentClaims : [SchedulePeriod] -> PeriodicSchedule -> Bool -> Decimal -> Bool -> DayCountConventionEnum -> Decimal -> Deliverable -> Observable -> TaggedClaim
+createConditionalCreditFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf couponRate issuerPays dayCountConvention notional cashInstrumentCid defaultProbabilityReferenceId = do
   let
-    couponClaims = createFixRatePaymentClaimsList schedule periodicSchedule useAdjustedDatesForDcf couponRate issuerPays dayCountConvention cashInstrumentCid
+    couponClaims = createFixRatePaymentClaimsList schedule periodicSchedule useAdjustedDatesForDcf couponRate issuerPays dayCountConvention notional cashInstrumentCid
     creditEvent = Lte (Const 1.0, Observe defaultProbabilityReferenceId)
     couponClaimUntilCreditEvent = until creditEvent $ mconcat couponClaims
   prepareAndTagClaims [couponClaimUntilCreditEvent] "Fix rate payment (unless credit event has occurred)"
 
 -- | Calculate a (1-recoveryRate) payment if a credit event just happened and create claims.
-createCreditEventPaymentClaims : Bool -> Deliverable -> Observable -> Observable -> PeriodicSchedule -> TaggedClaim
-createCreditEventPaymentClaims issuerPays cashInstrumentCid defaultProbabilityReferenceId recoveryRateReferenceId periodicSchedule = do
+createCreditEventPaymentClaims : Bool -> Decimal -> Deliverable -> Observable -> Observable -> PeriodicSchedule -> TaggedClaim
+createCreditEventPaymentClaims issuerPays notional cashInstrumentCid defaultProbabilityReferenceId recoveryRateReferenceId periodicSchedule = do
   let
     creditEvent = Lte (Const 1.0, Observe defaultProbabilityReferenceId)
-    payoffAmount = scale (Const 1.0 - Observe recoveryRateReferenceId) $ one cashInstrumentCid
+    payoffAmount = scale (Const 1.0 - Observe recoveryRateReferenceId) $ scale (Const notional) $ one cashInstrumentCid
     payoff = if issuerPays then payoffAmount else give payoffAmount
     creditEventClaim =
       when (TimeGte periodicSchedule.effectiveDate)
@@ -103,12 +103,12 @@ createCreditEventPaymentClaims issuerPays cashInstrumentCid defaultProbabilityRe
 -- The floating rate is always observed on the first day of each payment period and used for the corresponding payment on the last day of that payment period.
 -- This means that the calculation agent needs to provide such an Observable, irrespective of
 -- the kind of reference rate used (e.g. a forward looking LIBOR or a backward looking SOFR-COMPOUND).
-createFloatingRatePaymentClaims : [SchedulePeriod] -> PeriodicSchedule -> Bool -> Decimal -> Bool -> DayCountConventionEnum -> Deliverable -> Observable -> TaggedClaim
-createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf floatingRateSpread issuerPays dayCountConvention cashInstrumentCid referenceRateId = do
+createFloatingRatePaymentClaims : [SchedulePeriod] -> PeriodicSchedule -> Bool -> Decimal -> Bool -> DayCountConventionEnum -> Decimal -> Deliverable -> Observable -> TaggedClaim
+createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf floatingRateSpread issuerPays dayCountConvention notional cashInstrumentCid referenceRateId = do
   let
     couponClaimAmounts = mconcat $ map (\p ->
       when (TimeGte p.adjustedStartDate) $ scale ((Observe referenceRateId + Const floatingRateSpread) * (Const (calcPeriodDcf dayCountConvention p useAdjustedDatesForDcf periodicSchedule.terminationDate periodicSchedule.frequency))) $
-      when (TimeGte p.adjustedEndDate) $ one cashInstrumentCid) schedule
+      when (TimeGte p.adjustedEndDate) $ scale (Const notional) $ one cashInstrumentCid) schedule
     couponClaims = if issuerPays then couponClaimAmounts else give couponClaimAmounts
   prepareAndTagClaims [couponClaims] "Floating rate payment"
 -- FLOATING_RATE_BOND_COUPON_CLAIMS_END
@@ -119,14 +119,14 @@ createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf
 -- The reference asset Observable needs to contain the appropriate type of fixings:
 --   unadjusted fixings in case of a price return asset swap
 --   adjusted fixings in case of a total return asset swap
-createAssetPerformancePaymentClaims : [SchedulePeriod] -> PeriodicSchedule -> Bool -> Bool -> DayCountConventionEnum -> Deliverable -> Observable -> TaggedClaim
-createAssetPerformancePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf issuerPays dayCountConvention cashInstrumentCid referenceAssetId = do
+createAssetPerformancePaymentClaims : [SchedulePeriod] -> PeriodicSchedule -> Bool -> Bool -> DayCountConventionEnum -> Decimal -> Deliverable -> Observable -> TaggedClaim
+createAssetPerformancePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf issuerPays dayCountConvention notional cashInstrumentCid referenceAssetId = do
   let
     assetClaimAmounts = mconcat $ map (\p ->
       when (TimeGte p.adjustedStartDate) $ scale (Const 1.0 / Observe referenceAssetId) $
-      when (TimeGte p.adjustedEndDate) $ scale (Observe referenceAssetId) $ one cashInstrumentCid) schedule
+      when (TimeGte p.adjustedEndDate) $ scale (Observe referenceAssetId) $ scale (Const notional) $ one cashInstrumentCid) schedule
     correctionClaimAmounts = mconcat $ map (\p ->
-      when (TimeGte p.adjustedEndDate) $ one cashInstrumentCid) schedule
+      when (TimeGte p.adjustedEndDate) $ scale (Const notional) $ one cashInstrumentCid) schedule
     assetClaims = if issuerPays then assetClaimAmounts else give assetClaimAmounts
     correctionAssetClaims = if issuerPays then give correctionClaimAmounts else correctionClaimAmounts
   prepareAndTagClaims [assetClaims, correctionAssetClaims] "Asset performance payment"
@@ -135,10 +135,10 @@ createAssetPerformancePaymentClaims schedule periodicSchedule useAdjustedDatesFo
 -- FIXED_RATE_BOND_REDEMPTION_CLAIM_BEGIN
 -- | Create an FX adjusted principal claim.
 -- This can be used for both FX swaps (using the appropriate FX rate) and single currency bonds (setting the FX rate to 1.0).
-createFxAdjustedPrincipalClaim : Bool -> Decimal -> Deliverable -> Date -> TaggedClaim
-createFxAdjustedPrincipalClaim issuerPays fxRateMultiplier cashInstrumentCid valueDate = do
+createFxAdjustedPrincipalClaim : Bool -> Decimal -> Decimal -> Deliverable -> Date -> TaggedClaim
+createFxAdjustedPrincipalClaim issuerPays fxRateMultiplier notional cashInstrumentCid valueDate = do
   let
-    fxLegClaimAmount = when (TimeGte valueDate) $ scale (Const fxRateMultiplier) $ one cashInstrumentCid
+    fxLegClaimAmount = when (TimeGte valueDate) $ scale (Const fxRateMultiplier) $ scale (Const notional) $ one cashInstrumentCid
     fxLegClaim = if issuerPays then fxLegClaimAmount else give fxLegClaimAmount
   prepareAndTagClaims [fxLegClaim] "Principal payment"
 -- FIXED_RATE_BOND_REDEMPTION_CLAIM_END

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Asset/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Asset/Instrument.daml
@@ -73,9 +73,10 @@ template Instrument
         schedule <- rollPaymentSchedule periodicSchedule holidayCalendarIds issuer calendarDataProvider
         let
           useAdjustedDatesForDcf = True
+          notional = 1.0
           issuerPaysAssetLeg = not issuerPaysFix
-          fixClaims = createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf fixRate issuerPaysFix dayCountConvention currency
-          assetClaims = createAssetPerformancePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf issuerPaysAssetLeg dayCountConvention currency referenceAssetId
+          fixClaims = createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf fixRate issuerPaysFix dayCountConvention notional currency
+          assetClaims = createAssetPerformancePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf issuerPaysAssetLeg dayCountConvention notional currency referenceAssetId
         pure $ [fixClaims, assetClaims]
 
     interface instance BaseInstrument.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault/Instrument.daml
@@ -72,9 +72,10 @@ template Instrument
         schedule <- rollPaymentSchedule periodicSchedule holidayCalendarIds issuer calendarDataProvider
         let
           useAdjustedDatesForDcf = True
+          notional = 1.0
           issuerPaysCreditLeg = not issuerPaysFix
-          fixClaims = createConditionalCreditFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf fixRate issuerPaysFix dayCountConvention currency defaultProbabilityReferenceId
-          creditDefaultClaims = createCreditEventPaymentClaims issuerPaysCreditLeg currency defaultProbabilityReferenceId recoveryRateReferenceId periodicSchedule
+          fixClaims = createConditionalCreditFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf fixRate issuerPaysFix dayCountConvention notional currency defaultProbabilityReferenceId
+          creditDefaultClaims = createCreditEventPaymentClaims issuerPaysCreditLeg notional currency defaultProbabilityReferenceId recoveryRateReferenceId periodicSchedule
         pure $ [fixClaims, creditDefaultClaims]
 
     interface instance BaseInstrument.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Currency/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Currency/Instrument.daml
@@ -78,10 +78,11 @@ template Instrument
         schedule <- rollPaymentSchedule periodicSchedule holidayCalendarIds issuer calendarDataProvider
         let
           useAdjustedDatesForDcf = True
+          notional = 1.0
           issuerPaysForeignLeg = not issuerPaysBase
           foreignRateInclFxPrincipalAdjustmentFactor = foreignRate * fxRate
-          baseLegClaims = createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf baseRate issuerPaysBase dayCountConvention baseCurrency
-          foreignLegClaims = createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf foreignRateInclFxPrincipalAdjustmentFactor issuerPaysForeignLeg dayCountConvention foreignCurrency
+          baseLegClaims = createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf baseRate issuerPaysBase dayCountConvention notional baseCurrency
+          foreignLegClaims = createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf foreignRateInclFxPrincipalAdjustmentFactor issuerPaysForeignLeg dayCountConvention notional foreignCurrency
         pure $ [baseLegClaims, foreignLegClaims]
 
     interface instance BaseInstrument.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange/Instrument.daml
@@ -68,10 +68,11 @@ template Instrument
       getClaims = do
         -- get the initial claims tree (as of the swap's acquisition time)
         let
-          baseCurrencyFirstPayment = createFxAdjustedPrincipalClaim False 1.0 baseCurrency firstPaymentDate
-          foreignCurrencyFirstPayment = createFxAdjustedPrincipalClaim True firstFxRate foreignCurrency firstPaymentDate
-          baseCurrencyFinalPayment = createFxAdjustedPrincipalClaim True 1.0 baseCurrency maturityDate
-          foreignCurrencyFinalPayment = createFxAdjustedPrincipalClaim False finalFxRate foreignCurrency maturityDate
+          notional = 1.0
+          baseCurrencyFirstPayment = createFxAdjustedPrincipalClaim False 1.0 notional baseCurrency firstPaymentDate
+          foreignCurrencyFirstPayment = createFxAdjustedPrincipalClaim True firstFxRate notional foreignCurrency firstPaymentDate
+          baseCurrencyFinalPayment = createFxAdjustedPrincipalClaim True 1.0 notional baseCurrency maturityDate
+          foreignCurrencyFinalPayment = createFxAdjustedPrincipalClaim False finalFxRate notional foreignCurrency maturityDate
         pure $ [baseCurrencyFirstPayment, foreignCurrencyFirstPayment, baseCurrencyFinalPayment, foreignCurrencyFinalPayment]
 
     interface instance BaseInstrument.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
@@ -68,9 +68,10 @@ template Instrument
               periodicSchedule = createPaymentPeriodicSchedule s
               useAdjustedDatesForDcf = True
               issuerPaysLeg = (s.payerPartyReference == issuerPartyRef)
+              n = s.calculationPeriodAmount.calculation.notionalSchedule.notionalStepSchedule
             streamSchedule <- rollPaymentSchedule periodicSchedule s.calculationPeriodDates.calculationPeriodDatesAdjustments.businessCenters issuer calendarDataProvider
-            if isSome c.fixedRateSchedule && isNone c.floatingRateCalculation then calculateClaimsFromFixSwapStream s periodicSchedule streamSchedule useAdjustedDatesForDcf issuerPaysLeg currency
-            else if isNone c.fixedRateSchedule && isSome c.floatingRateCalculation then calculateClaimsFromFloatingSwapStream s periodicSchedule streamSchedule useAdjustedDatesForDcf issuerPaysLeg currency issuer calendarDataProvider
+            if isSome c.fixedRateSchedule && isNone c.floatingRateCalculation then calculateClaimsFromFixSwapStream s periodicSchedule streamSchedule useAdjustedDatesForDcf issuerPaysLeg n.initialValue currency
+            else if isNone c.fixedRateSchedule && isSome c.floatingRateCalculation then calculateClaimsFromFloatingSwapStream s periodicSchedule streamSchedule useAdjustedDatesForDcf issuerPaysLeg n.initialValue currency issuer calendarDataProvider
             else error "leg type not supported"
         mapA calculateClaimsFromSwapStream swapStreams
 

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
@@ -69,9 +69,10 @@ template Instrument
               useAdjustedDatesForDcf = True
               issuerPaysLeg = (s.payerPartyReference == issuerPartyRef)
               n = s.calculationPeriodAmount.calculation.notionalSchedule.notionalStepSchedule
+              notional = if Id n.currency == currency.id then n.initialValue else error "swapStream currency does not match swap currency"
             streamSchedule <- rollPaymentSchedule periodicSchedule s.calculationPeriodDates.calculationPeriodDatesAdjustments.businessCenters issuer calendarDataProvider
-            if isSome c.fixedRateSchedule && isNone c.floatingRateCalculation then calculateClaimsFromFixSwapStream s periodicSchedule streamSchedule useAdjustedDatesForDcf issuerPaysLeg n.initialValue currency
-            else if isNone c.fixedRateSchedule && isSome c.floatingRateCalculation then calculateClaimsFromFloatingSwapStream s periodicSchedule streamSchedule useAdjustedDatesForDcf issuerPaysLeg n.initialValue currency issuer calendarDataProvider
+            if isSome c.fixedRateSchedule && isNone c.floatingRateCalculation then calculateClaimsFromFixSwapStream s periodicSchedule streamSchedule useAdjustedDatesForDcf issuerPaysLeg notional currency
+            else if isNone c.fixedRateSchedule && isSome c.floatingRateCalculation then calculateClaimsFromFloatingSwapStream s periodicSchedule streamSchedule useAdjustedDatesForDcf issuerPaysLeg notional currency issuer calendarDataProvider
             else error "leg type not supported"
         mapA calculateClaimsFromSwapStream swapStreams
 

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -22,10 +22,10 @@ import Prelude hiding (key)
 type O = Observation Date Decimal Observable
 
 -- | Create claims from swapStream that describes a fix coupon stream.
-calculateClaimsFromFixSwapStream : SwapStream -> PeriodicSchedule -> [SchedulePeriod] -> Bool -> Bool -> Deliverable -> Update TaggedClaim
-calculateClaimsFromFixSwapStream s periodicSchedule streamSchedule useAdjustedDatesForDcf issuerPaysLeg currency = do
+calculateClaimsFromFixSwapStream : SwapStream -> PeriodicSchedule -> [SchedulePeriod] -> Bool -> Bool -> Decimal -> Deliverable -> Update TaggedClaim
+calculateClaimsFromFixSwapStream s periodicSchedule streamSchedule useAdjustedDatesForDcf issuerPaysLeg notional currency = do
   let f = fromSome s.calculationPeriodAmount.calculation.fixedRateSchedule
-  pure $ createFixRatePaymentClaims streamSchedule periodicSchedule useAdjustedDatesForDcf f.initialValue issuerPaysLeg s.calculationPeriodAmount.calculation.dayCountFraction currency
+  pure $ createFixRatePaymentClaims streamSchedule periodicSchedule useAdjustedDatesForDcf f.initialValue issuerPaysLeg s.calculationPeriodAmount.calculation.dayCountFraction notional currency
 
 -- | Define observable part of claim when one specific floating rate is provided for a stub period.
 getSingleStubRate : StubFloatingRate -> Optional O
@@ -78,8 +78,8 @@ getStubRate sc initialStub p cal convention = do
 
 -- | Calculate a floating rate amount for each payment date and create claims.
 -- The floating rate is observed according to the FpML ResetDates component and used for the corresponding payment on the last day of that payment period.
-createFloatingRatePaymentClaims : [SchedulePeriod] -> PeriodicSchedule -> Bool -> Decimal -> Bool -> DayCountConventionEnum -> Deliverable -> Observable -> HolidayCalendarData -> SwapStream -> Update TaggedClaim
-createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf floatingRateSpread issuerPays dayCountConvention cashInstrumentCid referenceRateId fixingCalendars s = do
+createFloatingRatePaymentClaims : [SchedulePeriod] -> PeriodicSchedule -> Bool -> Decimal -> Bool -> DayCountConventionEnum -> Decimal -> Deliverable -> Observable -> HolidayCalendarData -> SwapStream -> Update TaggedClaim
+createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf floatingRateSpread issuerPays dayCountConvention notional cashInstrumentCid referenceRateId fixingCalendars s = do
   let
     resetDates = fromSome s.resetDates
     bdc = s.calculationPeriodDates.calculationPeriodDatesAdjustments.businessDayConvention
@@ -90,7 +90,7 @@ createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf
     fixingDates = map (\p -> addBusinessDays fixingCalendars resetDates.fixingDates.periodMultiplier p.adjustedStartDate) schedule
     createClaim p f =
       when (TimeGte f) $ scale (rate * (Const (calcPeriodDcf dayCountConvention p useAdjustedDatesForDcf periodicSchedule.terminationDate periodicSchedule.frequency))) $
-      when (TimeGte p.adjustedEndDate) $ one cashInstrumentCid
+      when (TimeGte p.adjustedEndDate) $ scale (Const notional) $ one cashInstrumentCid
         where
           regularRate = Observe referenceRateId + Const floatingRateSpread
           stubType = p.stubType
@@ -102,10 +102,10 @@ createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf
   pure $ prepareAndTagClaims [floatingClaims] "Floating rate payment"
 
 -- | Create claims from swapStream that describes a floating coupon stream.
-calculateClaimsFromFloatingSwapStream : SwapStream -> PeriodicSchedule -> [SchedulePeriod] -> Bool -> Bool -> Deliverable -> Party -> Party -> Update TaggedClaim
-calculateClaimsFromFloatingSwapStream s periodicSchedule streamSchedule useAdjustedDatesForDcf issuerPaysLeg currency issuer calendarDataAgency = do
+calculateClaimsFromFloatingSwapStream : SwapStream -> PeriodicSchedule -> [SchedulePeriod] -> Bool -> Bool -> Decimal -> Deliverable -> Party -> Party -> Update TaggedClaim
+calculateClaimsFromFloatingSwapStream s periodicSchedule streamSchedule useAdjustedDatesForDcf issuerPaysLeg notional currency issuer calendarDataAgency= do
   let
     f = fromSome s.calculationPeriodAmount.calculation.floatingRateCalculation
     resetDates = fromSome s.resetDates
   fixingCalendars <- getHolidayCalendars resetDates.fixingDates.businessCenters issuer calendarDataAgency
-  createFloatingRatePaymentClaims streamSchedule periodicSchedule useAdjustedDatesForDcf f.spreadSchedule.initialValue issuerPaysLeg s.calculationPeriodAmount.calculation.dayCountFraction currency f.floatingRateIndex (merge fixingCalendars) s
+  createFloatingRatePaymentClaims streamSchedule periodicSchedule useAdjustedDatesForDcf f.spreadSchedule.initialValue issuerPaysLeg s.calculationPeriodAmount.calculation.dayCountFraction notional currency f.floatingRateIndex (merge fixingCalendars) s

--- a/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate/Instrument.daml
@@ -71,9 +71,10 @@ template Instrument
         schedule <- rollPaymentSchedule periodicSchedule holidayCalendarIds issuer calendarDataProvider
         let
           useAdjustedDatesForDcf = True
+          notional = 1.0
           issuerPaysFloatingLeg = not issuerPaysFix
-          fixClaims = createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf fixRate issuerPaysFix dayCountConvention currency
-          floatingClaims = createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf 0.0 issuerPaysFloatingLeg dayCountConvention currency referenceRateId
+          fixClaims = createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf fixRate issuerPaysFix dayCountConvention notional currency
+          floatingClaims = createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf 0.0 issuerPaysFloatingLeg dayCountConvention notional currency referenceRateId
         pure $ [fixClaims, floatingClaims]
 
     interface instance BaseInstrument.I for Instrument where

--- a/src/main/daml/Daml/Finance/Interface/Types/Fpml.daml
+++ b/src/main/daml/Daml/Finance/Interface/Types/Fpml.daml
@@ -7,6 +7,7 @@ import Daml.Finance.Interface.Types.Date.Calendar (BusinessDayConventionEnum)
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
 import Daml.Finance.Interface.Types.Date.RollConvention
 
+-- | The swap streams, describing each leg of the swap.
 data SwapStream = SwapStream
   with
     payerPartyReference : Text
@@ -16,6 +17,7 @@ data SwapStream = SwapStream
     stubCalculationPeriodAmount : Optional StubCalculationPeriodAmount
   deriving (Eq, Show)
 
+-- | The calculation periods dates schedule.
 data CalculationPeriodDates = CalculationPeriodDates
   with
     -- id : Text
@@ -27,6 +29,7 @@ data CalculationPeriodDates = CalculationPeriodDates
     calculationPeriodFrequency : CalculationPeriodFrequency
   deriving (Eq, Show)
 
+-- | The reset dates schedule. The reset dates schedule only applies for a floating rate stream.
 data ResetDates = ResetDates
   with
     resetRelativeTo : ResetRelativeToEnum
@@ -45,6 +48,7 @@ data ResetRelativeToEnum
     --   calculation period.
   deriving (Eq, Show)
 
+-- | Specifies the fixing date relative to the reset date in terms of a business days offset and an associated set of financial business centers.
 data FixingDates = FixingDates
   with
     periodMultiplier : Int
@@ -77,12 +81,14 @@ data DayTypeEnum
     --   the count includes only scheduled trading days.
   deriving (Eq, Show)
 
+-- | The frequency at which reset dates occur.
 data ResetFrequency = ResetFrequency
   with
     periodMultiplier : Int
     period : PeriodEnum
   deriving (Eq, Show)
 
+-- | The business day convention to apply to each calculation period end date if it would otherwise fall on a day that is not a business day in the specified financial business centers.
 data CalculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments
   with
     businessDayConvention : BusinessDayConventionEnum
@@ -113,11 +119,13 @@ data CalculationPeriodFrequency = CalculationPeriodFrequency with
     --   part of a calculation period schedule.
     deriving (Eq, Show)
 
+-- | The calculation period amount parameters.
 data CalculationPeriodAmount = CalculationPeriodAmount
   with
     calculation : Calculation
   deriving (Eq, Show)
 
+-- | The parameters used in the calculation of fixed or floating rate calculation period amounts.
 data Calculation = Calculation
   with
     notionalSchedule : NotionalSchedule
@@ -126,11 +134,14 @@ data Calculation = Calculation
     dayCountFraction : DayCountConventionEnum
   deriving (Eq, Show)
 
+-- | The notional amount or notional amount schedule.
 data NotionalSchedule = NotionalSchedule
   with
     notionalStepSchedule : NotionalStepSchedule
   deriving (Eq, Show)
 
+-- | The notional amount or notional amount schedule expressed as explicit outstanding notional amounts and dates.
+-- Currently, only an initial value is supported, which corresponds to a fix notional (of each leg).
 data NotionalStepSchedule = NotionalStepSchedule
   with
     initialValue : Decimal
@@ -262,18 +273,21 @@ data FixedRateSchedule = FixedRateSchedule with
   -- type_ : Optional SpreadScheduleType
     deriving (Eq, Show)
 
+-- | The stub calculation period amount parameters. This element must only be included if there is an initial or final stub calculation period. Even then, it must only be included if either the stub references a different floating rate tenor to the regular calculation periods, or if the stub is calculated as a linear interpolation of two different floating rate tenors, or if a specific stub rate or stub amount has been negotiated.
 data StubCalculationPeriodAmount = StubCalculationPeriodAmount
   with
     initialStub : Optional StubValue
     finalStub : Optional StubValue
   deriving (Eq, Show)
 
+-- | Specifies how the stub amount is calculated. A single floating rate tenor different to that used for the regular part of the calculation periods schedule may be specified, or two floating tenors may be specified. If two floating rate tenors are specified then Linear Interpolation (in accordance with the 2000 ISDA Definitions, Section 8.3. Interpolation) is assumed to apply. Alternatively, an actual known stub rate or stub amount may be specified.
 data StubValue = StubValue
   with
     stubRate : Optional Decimal
     floatingRate : Optional [StubFloatingRate]
   deriving (Eq, Show)
 
+-- | The rates to be applied to the initial or final stub may be the linear interpolation of two different rates.
 data StubFloatingRate = StubFloatingRate
   with
     floatingRateIndex : Text

--- a/src/main/daml/Daml/Finance/Interface/Types/Fpml.daml
+++ b/src/main/daml/Daml/Finance/Interface/Types/Fpml.daml
@@ -29,7 +29,7 @@ data CalculationPeriodDates = CalculationPeriodDates
     calculationPeriodFrequency : CalculationPeriodFrequency
   deriving (Eq, Show)
 
--- | The reset dates schedule. The reset dates schedule only applies for a floating rate stream.
+-- | The reset dates schedule. This only applies for a floating rate stream.
 data ResetDates = ResetDates
   with
     resetRelativeTo : ResetRelativeToEnum
@@ -125,7 +125,7 @@ data CalculationPeriodAmount = CalculationPeriodAmount
     calculation : Calculation
   deriving (Eq, Show)
 
--- | The parameters used in the calculation of fixed or floating rate calculation period amounts.
+-- | The parameters used in the calculation of fixed or floating rate period amounts.
 data Calculation = Calculation
   with
     notionalSchedule : NotionalSchedule
@@ -141,7 +141,7 @@ data NotionalSchedule = NotionalSchedule
   deriving (Eq, Show)
 
 -- | The notional amount or notional amount schedule expressed as explicit outstanding notional amounts and dates.
--- Currently, only an initial value is supported, which corresponds to a fix notional (of each leg).
+-- Currently, only an initial value is supported, which corresponds to a fix notional (of each leg, individually).
 data NotionalStepSchedule = NotionalStepSchedule
   with
     initialValue : Decimal

--- a/src/main/daml/Daml/Finance/Interface/Types/Fpml.daml
+++ b/src/main/daml/Daml/Finance/Interface/Types/Fpml.daml
@@ -120,9 +120,21 @@ data CalculationPeriodAmount = CalculationPeriodAmount
 
 data Calculation = Calculation
   with
+    notionalSchedule : NotionalSchedule
     floatingRateCalculation : Optional FloatingRateCalculation
     fixedRateSchedule : Optional FixedRateSchedule
     dayCountFraction : DayCountConventionEnum
+  deriving (Eq, Show)
+
+data NotionalSchedule = NotionalSchedule
+  with
+    notionalStepSchedule : NotionalStepSchedule
+  deriving (Eq, Show)
+
+data NotionalStepSchedule = NotionalStepSchedule
+  with
+    initialValue : Decimal
+    currency : Text
   deriving (Eq, Show)
 
 -- | A type defining the floating rate and definitions

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -88,6 +88,10 @@ run = script do
           businessCenters = fixingHolidayCalendarId
       calculationPeriodAmount = CalculationPeriodAmount with
         calculation = Calculation with
+          notionalSchedule = NotionalSchedule with
+            notionalStepSchedule = NotionalStepSchedule with
+              initialValue = 1.0
+              currency = "USD"
           floatingRateCalculation = Some FloatingRateCalculation with
             floatingRateIndex = referenceRateId
             indexTenor = Some Period with
@@ -117,6 +121,10 @@ run = script do
       resetDates = None
       calculationPeriodAmount = CalculationPeriodAmount with
         calculation = Calculation with
+          notionalSchedule = NotionalSchedule with
+            notionalStepSchedule = NotionalStepSchedule with
+              initialValue = 1.0
+              currency = "USD"
           floatingRateCalculation = None
           fixedRateSchedule = Some FixedRateSchedule with
             initialValue = fixRate
@@ -228,6 +236,10 @@ runDualStub = script do
           businessCenters = fixingHolidayCalendarId
       calculationPeriodAmount = CalculationPeriodAmount with
         calculation = Calculation with
+          notionalSchedule = NotionalSchedule with
+            notionalStepSchedule = NotionalStepSchedule with
+              initialValue = 1000000.0
+              currency = "USD"
           floatingRateCalculation = Some FloatingRateCalculation with
             floatingRateIndex = referenceRateId
             indexTenor = Some Period with
@@ -262,6 +274,10 @@ runDualStub = script do
       resetDates = None
       calculationPeriodAmount = CalculationPeriodAmount with
         calculation = Calculation with
+          notionalSchedule = NotionalSchedule with
+            notionalStepSchedule = NotionalStepSchedule with
+              initialValue = 1000000.0
+              currency = "USD"
           floatingRateCalculation = None
           fixedRateSchedule = Some FixedRateSchedule with
             initialValue = fixRate
@@ -288,7 +304,7 @@ runDualStub = script do
 
   -- First payment date: Lifecycle and verify the lifecycle effects for fix and floating payments.
   let
-    expectedConsumedQuantities = [Instrument.qty 0.0014466167 cashInstrumentCid]
+    expectedConsumedQuantities = [Instrument.qty 1446.6167 cashInstrumentCid]
     expectedProducedQuantities = []
   swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstRegularPeriodDate swapInstrument settlers issuer investor observers custodian [observableCid] expectedConsumedQuantities expectedProducedQuantities
 
@@ -300,7 +316,7 @@ runDualStub = script do
 
   -- Second payment date: Lifecycle and verify the lifecycle effects for fix and floating payments.
   let
-    expectedConsumedQuantities = [Instrument.qty 0.0044660695 cashInstrumentCid]
+    expectedConsumedQuantities = [Instrument.qty 4466.0695 cashInstrumentCid]
     expectedProducedQuantities = []
   swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] lastRegularPeriodDate swapInstrumentAfterFirstPayment settlers issuer investor observers custodian [observableCid] expectedConsumedQuantities expectedProducedQuantities
 
@@ -312,7 +328,7 @@ runDualStub = script do
 
   -- Lifecycle on the second payment date, which is also the expiry date. Verify the lifecycle effects for fix and floating payments.
   let
-    expectedConsumedQuantities = [Instrument.qty 0.0029414539 cashInstrumentCid]
+    expectedConsumedQuantities = [Instrument.qty 2941.4539 cashInstrumentCid]
     expectedProducedQuantities = []
   lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterSecondPayment settlers issuer investor observers custodian [observableCid] expectedConsumedQuantities expectedProducedQuantities
 
@@ -388,6 +404,10 @@ runStubRateInterpolation = script do
           businessCenters = fixingHolidayCalendarId
       calculationPeriodAmount = CalculationPeriodAmount with
         calculation = Calculation with
+          notionalSchedule = NotionalSchedule with
+            notionalStepSchedule = NotionalStepSchedule with
+              initialValue = 1.0
+              currency = "USD"
           floatingRateCalculation = Some FloatingRateCalculation with
             floatingRateIndex = referenceRateId
             indexTenor = Some Period with

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -151,6 +151,8 @@ lifecycleAndVerifySwapPaymentEffects readAs today swapInstrument settlers issuer
   effectView <- submitMulti [investor] readAs do
     exerciseCmd effectCid Effect.GetView with viewer = investor
 
+  debug expectedConsumedQuantities
+  debug effectView.consumed
   -- Verify that the consumed/produced quantities match the expected ones
   assertMsg "The consumed quantities do not match the expected ones" (sort expectedConsumedQuantities == sort effectView.consumed)
   assertMsg "The produced quantities do not match the expected ones" (sort expectedProducedQuantities == sort effectView.produced)

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -151,8 +151,6 @@ lifecycleAndVerifySwapPaymentEffects readAs today swapInstrument settlers issuer
   effectView <- submitMulti [investor] readAs do
     exerciseCmd effectCid Effect.GetView with viewer = investor
 
-  debug expectedConsumedQuantities
-  debug effectView.consumed
   -- Verify that the consumed/produced quantities match the expected ones
   assertMsg "The consumed quantities do not match the expected ones" (sort expectedConsumedQuantities == sort effectView.consumed)
   assertMsg "The produced quantities do not match the expected ones" (sort expectedProducedQuantities == sort effectView.produced)


### PR DESCRIPTION
I have added support for specifying notional in each swapStream, which is required for the sample trade as specified in the **notional / holding**  section here: https://github.com/digital-asset/daml-finance/issues/226 

For consistency, I implemented support for notional in all CC utility functions, even though it is not currently used in the other Swap/Bond templates (could potentially change in the future).