### PR TITLE
Cleanup bond and swap tests

### DIFF
--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/FixedRate.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/FixedRate.daml
@@ -92,7 +92,7 @@ run = script do
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 0.0035863014 cashInstrumentCid]
-  bondInstrumentAfterFirstCoupon <- lifecycleAndVerifyBondPaymentEffects [publicParty] firstCouponDate bondInstrument settlers issuer investor pp custodian [] expectedConsumedQuantities expectedProducedQuantities
+  bondInstrumentAfterFirstCoupon <- lifecycleAndVerifyBondPaymentEffects [publicParty] firstCouponDate bondInstrument settlers issuer [] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the first coupon date: try to lifecycle and verify that there are no lifecycle effects.
   verifyNoLifecycleEffects [publicParty] (addDays firstCouponDate 1) bondInstrumentAfterFirstCoupon settlers issuer []
@@ -104,7 +104,7 @@ run = script do
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 1.011030137 cashInstrumentCid]
-  bondInstrumentAfterRedemption <- lifecycleAndVerifyBondPaymentEffects [publicParty] maturityDate bondInstrumentAfterFirstCoupon settlers issuer investor pp custodian [] expectedConsumedQuantities expectedProducedQuantities
+  bondInstrumentAfterRedemption <- lifecycleAndVerifyBondPaymentEffects [publicParty] maturityDate bondInstrumentAfterFirstCoupon settlers issuer [] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after expiry: try to lifecycle and verify that there are no lifecycle effects.
   verifyNoLifecycleEffects [publicParty] (addDays maturityDate 1) bondInstrumentAfterRedemption settlers issuer []

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/FloatingRate.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/FloatingRate.daml
@@ -22,8 +22,8 @@ import Daml.Script
 -- Penultimate coupon payment on a bond showing creation of new instrument version
 run : Script ()
 run = script do
-  [depository, custodian, issuer, investor, calendarDataProvider, settler, publicParty] <-
-    createParties ["CSD", "Custodian", "Issuer", "Investor", "Calendar Data Provider", "Settler", "PublicParty"]
+  [depository, custodian, issuer, calendarDataProvider, settler, publicParty] <-
+    createParties ["CSD", "Custodian", "Issuer", "Calendar Data Provider", "Settler", "PublicParty"]
   let settlers = singleton settler
 
   -- Distribute commercial-bank cash
@@ -72,7 +72,7 @@ run = script do
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 0.0006484932 cashInstrumentCid]
-  bondInstrumentAfterFirstCoupon <- lifecycleAndVerifyBondPaymentEffects [publicParty] firstCouponDate bondInstrument settlers issuer investor pp custodian [observableCid] expectedConsumedQuantities expectedProducedQuantities
+  bondInstrumentAfterFirstCoupon <- lifecycleAndVerifyBondPaymentEffects [publicParty] firstCouponDate bondInstrument settlers issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the first coupon date: try to lifecycle and verify that there are no lifecycle effects.
   verifyNoLifecycleEffects [publicParty] (addDays firstCouponDate 1) bondInstrumentAfterFirstCoupon settlers issuer [observableCid]
@@ -84,7 +84,7 @@ run = script do
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 1.002033589 cashInstrumentCid]
-  bondInstrumentAfterRedemption <- lifecycleAndVerifyBondPaymentEffects [publicParty] maturityDate bondInstrumentAfterFirstCoupon settlers issuer investor pp custodian [observableCid] expectedConsumedQuantities expectedProducedQuantities
+  bondInstrumentAfterRedemption <- lifecycleAndVerifyBondPaymentEffects [publicParty] maturityDate bondInstrumentAfterFirstCoupon settlers issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after expiry: try to lifecycle and verify that there are no lifecycle effects.
   verifyNoLifecycleEffects [publicParty] (addDays maturityDate 1) bondInstrumentAfterRedemption settlers issuer [observableCid]

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/InflationLinked.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/InflationLinked.daml
@@ -22,8 +22,8 @@ import Daml.Script
 -- Penultimate coupon payment on a bond showing creation of new instrument version
 run : Script ()
 run = script do
-  [depository, custodian, issuer, investor, calendarDataProvider, settler, publicParty] <-
-    createParties ["CSD", "Custodian", "Issuer", "Investor", "Calendar Data Provider", "Settler", "PublicParty"]
+  [depository, custodian, issuer, calendarDataProvider, settler, publicParty] <-
+    createParties ["CSD", "Custodian", "Issuer", "Calendar Data Provider", "Settler", "PublicParty"]
   let settlers = singleton settler
 
   -- Distribute commercial-bank cash
@@ -74,7 +74,7 @@ run = script do
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 0.0009493151 cashInstrumentCid]
-  bondInstrumentAfterFirstCoupon <- lifecycleAndVerifyBondPaymentEffects [publicParty] firstCouponDate bondInstrument settlers issuer investor pp custodian [observableCid] expectedConsumedQuantities expectedProducedQuantities
+  bondInstrumentAfterFirstCoupon <- lifecycleAndVerifyBondPaymentEffects [publicParty] firstCouponDate bondInstrument settlers issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the first coupon date: try to lifecycle and verify that there are no lifecycle effects.
   verifyNoLifecycleEffects [publicParty] (addDays firstCouponDate 1) bondInstrumentAfterFirstCoupon settlers issuer [observableCid]
@@ -86,7 +86,7 @@ run = script do
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 1.102950411 cashInstrumentCid]
-  bondInstrumentAfterRedemption <- lifecycleAndVerifyBondPaymentEffects [publicParty] maturityDate bondInstrumentAfterFirstCoupon settlers issuer investor pp custodian [observableCid] expectedConsumedQuantities expectedProducedQuantities
+  bondInstrumentAfterRedemption <- lifecycleAndVerifyBondPaymentEffects [publicParty] maturityDate bondInstrumentAfterFirstCoupon settlers issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after expiry: try to lifecycle and verify that there are no lifecycle effects.
   verifyNoLifecycleEffects [publicParty] (addDays maturityDate 1) bondInstrumentAfterRedemption settlers issuer [observableCid]

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
@@ -113,16 +113,16 @@ verifyNoLifecycleEffects readAs today instrument settlers issuer observableCids 
   assertMsg ("There should be no lifecycle effects on " <> show today) (null effectCids)
 
 -- | Verify the payments from a payment date of a bond (excluding settlement)
-lifecycleAndVerifyBondPaymentEffects : [Party] -> Date -> Instrument.K -> Parties -> Party -> Party -> [(Text, Parties)] -> Party -> [ContractId NumericObservable.I] -> [Instrument.Q] -> [Instrument.Q] -> Script Instrument.K
-lifecycleAndVerifyBondPaymentEffects readAs today instrument settlers issuer investor obs custodian observableCids expectedConsumedQuantities expectedProducedQuantities = do
+lifecycleAndVerifyBondPaymentEffects : [Party] -> Date -> Instrument.K -> Parties -> Party -> [ContractId NumericObservable.I] -> [Instrument.Q] -> [Instrument.Q] -> Script Instrument.K
+lifecycleAndVerifyBondPaymentEffects readAs today instrument settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities = do
   (bondLifecycleCid, [effectCid]) <- lifecycleInstrument readAs today instrument settlers issuer observableCids
 
   newBondInstrumentKey <- submit issuer do
     Instrument.toKey <$> exerciseCmd @Instrument.I (coerceContractId bondLifecycleCid) Instrument.GetView with viewer = issuer
 
   -- Get the effect
-  effectView <- submitMulti [investor] readAs do
-    exerciseCmd effectCid Effect.GetView with viewer = investor
+  effectView <- submit issuer do
+    exerciseCmd effectCid Effect.GetView with viewer = issuer
 
   -- Verify that the consumed/produced quantities match the expected ones
   assertMsg "The consumed quantities do not match the expected ones" (sort expectedConsumedQuantities == sort effectView.consumed)

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/ZeroCoupon.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/ZeroCoupon.daml
@@ -14,8 +14,8 @@ import Daml.Script
 -- Test creation and lifecycling of a zero coupon bond
 run : Script ()
 run = script do
-  [depository, custodian, issuer, investor, settler, publicParty] <-
-    createParties ["CSD", "Custodian", "Issuer", "Investor", "Settler", "PublicParty"]
+  [depository, custodian, issuer, settler, publicParty] <-
+    createParties ["CSD", "Custodian", "Issuer", "Settler", "PublicParty"]
   let settlers = singleton settler
 
   -- Distribute commercial-bank cash
@@ -40,7 +40,7 @@ run = script do
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 1.0 cashInstrumentCid]
-  bondInstrumentAfterRedemption <- lifecycleAndVerifyBondPaymentEffects [publicParty] maturityDate bondInstrument settlers issuer investor pp custodian [] expectedConsumedQuantities expectedProducedQuantities
+  bondInstrumentAfterRedemption <- lifecycleAndVerifyBondPaymentEffects [publicParty] maturityDate bondInstrument settlers issuer [] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after expiry: try to lifecycle and verify that there are no lifecycle effects.
   verifyNoLifecycleEffects [publicParty] (addDays maturityDate 1) bondInstrumentAfterRedemption settlers issuer []

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Asset.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Asset.daml
@@ -22,8 +22,8 @@ import Daml.Script
 -- Calculate payments on an asset swap, including lifecycling and creation of new instrument version.
 run : Script ()
 run = script do
-  [custodian, issuer, investor, calendarDataProvider, publicParty] <-
-    createParties ["Custodian", "Issuer", "Investor", "Calendar Data Provider", "PublicParty"]
+  [custodian, issuer, calendarDataProvider, publicParty] <-
+    createParties ["Custodian", "Issuer", "Calendar Data Provider", "PublicParty"]
 
   -- Distribute commercial-bank cash
   now <- getTime
@@ -73,7 +73,7 @@ run = script do
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 0.0784811777 cashInstrumentCid]
-  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer investor observers custodian [observableCid] expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the first payment date: try to lifecycle and verify that there are no lifecycle effects.
   verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment settlers issuer [observableCid]
@@ -85,6 +85,6 @@ run = script do
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 0.0322411245 cashInstrumentCid]
-  lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment settlers issuer investor observers custodian [observableCid] expectedConsumedQuantities expectedProducedQuantities
+  lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment settlers issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
 
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/CreditDefault.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/CreditDefault.daml
@@ -28,8 +28,6 @@ data TestParties = TestParties
       -- ^ Acts as custodian in the respective holdings (both cash holdings and instrument holdings). It also acts as depository in the option instrument.
     issuer : Party
       -- ^ Acts as issuer of the instrument. It is also the party tasked with lifecycling the contract.
-    investor : Party
-      -- ^ Owner of the holding on the instrument.
     publicParty : Party
       -- ^ The public party. Every party can readAs the public party.
 
@@ -88,7 +86,7 @@ runCreditEvent = script do
   let
     expectedConsumedQuantities = [Instrument.qty 0.001675 cashInstrument]
     expectedProducedQuantities = []
-  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer investor pp custodian observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the first payment date: try to lifecycle and verify that there are no lifecycle effects.
   verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment settlers issuer observableCids
@@ -97,7 +95,7 @@ runCreditEvent = script do
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 0.4 cashInstrument]
-  swapInstrumentAfterCreditEvent <- lifecycleAndVerifySwapPaymentEffects [publicParty] creditEventDate swapInstrumentAfterFirstPayment settlers issuer investor pp custodian observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterCreditEvent <- lifecycleAndVerifySwapPaymentEffects [publicParty] creditEventDate swapInstrumentAfterFirstPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after credit event date: try to lifecycle and verify that the instrument has automatically expired.
   -- TODO: implement this after having included expire logic (of Until nodes) somewhere in the lifecycle process.
@@ -144,7 +142,7 @@ runCreditEventOnPaymentDate = script do
     settlers = singleton custodian
     expectedConsumedQuantities = [Instrument.qty 0.001675 cashInstrument]
     expectedProducedQuantities = []
-  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer investor pp custodian observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the first payment date: try to lifecycle and verify that there are no lifecycle effects.
   verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment settlers issuer observableCids
@@ -153,7 +151,7 @@ runCreditEventOnPaymentDate = script do
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 0.4 cashInstrument]
-  swapInstrumentAfterCreditEvent <- lifecycleAndVerifySwapPaymentEffects [publicParty] creditEventDate swapInstrumentAfterFirstPayment settlers issuer investor pp custodian observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterCreditEvent <- lifecycleAndVerifySwapPaymentEffects [publicParty] creditEventDate swapInstrumentAfterFirstPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after credit event date: try to lifecycle and verify that the instrument has automatically expired.
   -- TODO: implement this after having included expire logic (of Until nodes) somewhere in the lifecycle process.
@@ -197,7 +195,7 @@ runNoCreditEvent = script do
   let
     expectedConsumedQuantities = [Instrument.qty 0.001675 cashInstrument]
     expectedProducedQuantities = []
-  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer investor pp custodian observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the first payment date: try to lifecycle and verify that there are no lifecycle effects.
   verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment settlers issuer observableCids
@@ -206,7 +204,7 @@ runNoCreditEvent = script do
   let
     expectedConsumedQuantities = [Instrument.qty 0.0049691667 cashInstrument]
     expectedProducedQuantities = []
-  swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment settlers issuer investor pp custodian observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the maturity: try to lifecycle and verify that there are no lifecycle effects.
   verifyNoLifecycleEffects [publicParty] (addDays maturityDate 1) swapInstrumentAfterSecondPayment settlers issuer observableCids
@@ -247,19 +245,19 @@ runCreditEventAfterMaturity = script do
     settlers = singleton custodian
     expectedConsumedQuantities = [Instrument.qty 0.001675 cashInstrument]
     expectedProducedQuantities = []
-  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer investor pp custodian observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- Second payment date: Lifecycle and verify the lifecycle effects for the fix payment.
   let
     expectedConsumedQuantities = [Instrument.qty 0.0049691667 cashInstrument]
     expectedProducedQuantities = []
-  swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment settlers issuer investor pp custodian observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the maturity: no payment is made, instrument expires
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = []
-  lifecycleAndVerifySwapPaymentEffects [publicParty] (addDays maturityDate 1) swapInstrumentAfterFirstPayment settlers issuer investor pp custodian observableCids expectedConsumedQuantities expectedProducedQuantities
+  lifecycleAndVerifySwapPaymentEffects [publicParty] (addDays maturityDate 1) swapInstrumentAfterFirstPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- TODO check that instrument expires
 
@@ -268,9 +266,9 @@ runCreditEventAfterMaturity = script do
 -- | Setup parties.
 setupParties : Script TestParties
 setupParties = do
-  [custodian, issuer, investor, calendarDataProvider, publicParty] <-
-    createParties ["Custodian", "Issuer", "Investor", "Calendar Data Provider", "PublicParty"]
-  pure $ TestParties with custodian; issuer; investor; calendarDataProvider; publicParty
+  [custodian, issuer, calendarDataProvider, publicParty] <-
+    createParties ["Custodian", "Issuer", "Calendar Data Provider", "PublicParty"]
+  pure $ TestParties with custodian; issuer; calendarDataProvider; publicParty
 
 -- Setup holiday calendar
 holidayCalendarData = HolidayCalendarData with

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Currency.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Currency.daml
@@ -19,8 +19,8 @@ import Daml.Script
 -- Calculate fix rate payments on a currency swap, including lifecycling and creation of new instrument version.
 run : Script ()
 run = script do
-  [custodian, issuer, investor, calendarDataProvider, publicParty] <-
-    createParties ["Custodian", "Issuer", "Investor", "Calendar Data Provider", "PublicParty"]
+  [custodian, issuer, calendarDataProvider, publicParty] <-
+    createParties ["Custodian", "Issuer", "Calendar Data Provider", "PublicParty"]
 
   -- Distribute commercial-bank cash
   now <- getTime
@@ -72,7 +72,7 @@ run = script do
   let
     expectedConsumedQuantities = [Instrument.qty 0.0025 cashInstrumentCid]
     expectedProducedQuantities = [Instrument.qty 0.0018333333 foreignCashInstrumentCid]
-  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer investor observers custodian [] expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer [] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the first payment date: try to lifecycle and verify that there are no lifecycle effects.
   verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment settlers issuer []
@@ -84,6 +84,6 @@ run = script do
   let
     expectedConsumedQuantities = [Instrument.qty 0.0074166667 cashInstrumentCid]
     expectedProducedQuantities = [Instrument.qty 0.0054388889 foreignCashInstrumentCid]
-  lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment settlers issuer investor observers custodian [] expectedConsumedQuantities expectedProducedQuantities
+  lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment settlers issuer [] expectedConsumedQuantities expectedProducedQuantities
 
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/ForeignExchange.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/ForeignExchange.daml
@@ -14,8 +14,8 @@ import Daml.Script
 -- Calculate the fx payments of a foreign exchange swap, including lifecycling and creation of new instrument version.
 run : Script ()
 run = script do
-  [custodian, issuer, investor, publicParty] <-
-    createParties ["Custodian", "Issuer", "Investor", "PublicParty"]
+  [custodian, issuer, publicParty] <-
+    createParties ["Custodian", "Issuer", "PublicParty"]
 
   -- Distribute commercial-bank cash
   now <- getTime
@@ -49,7 +49,7 @@ run = script do
   let
     expectedConsumedQuantities = [Instrument.qty fxRateSameCurrency cashInstrumentCid]
     expectedProducedQuantities = [Instrument.qty firstFxRate foreignCashInstrumentCid]
-  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer investor observers custodian [] expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer [] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the first payment date: try to lifecycle and verify that there are no lifecycle effects.
   verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment settlers issuer []
@@ -61,6 +61,6 @@ run = script do
   let
     expectedConsumedQuantities = [Instrument.qty finalFxRate foreignCashInstrumentCid]
     expectedProducedQuantities = [Instrument.qty fxRateSameCurrency cashInstrumentCid]
-  lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment settlers issuer investor observers custodian [] expectedConsumedQuantities expectedProducedQuantities
+  lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment settlers issuer [] expectedConsumedQuantities expectedProducedQuantities
 
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -23,8 +23,8 @@ import Daml.Script
 -- Calculate interest rate payment on an interest rate swap (represented using FpML swapStreams), including lifecycling and creation of new instrument version.
 run : Script ()
 run = script do
-  [custodian, issuer, investor, calendarDataProvider, publicParty] <-
-    createParties ["Custodian", "Issuer", "Investor", "Calendar Data Provider", "PublicParty"]
+  [custodian, issuer, calendarDataProvider, publicParty] <-
+    createParties ["Custodian", "Issuer", "Calendar Data Provider", "PublicParty"]
 
   -- Distribute commercial-bank cash
   now <- getTime
@@ -195,7 +195,7 @@ run = script do
   let
     expectedConsumedQuantities = [Instrument.qty 0.0014466167 cashInstrumentCid]
     expectedProducedQuantities = []
-  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer investor observers custodian [observableCid] expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the first payment date: try to lifecycle and verify that there are no lifecycle effects.
   verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment settlers issuer [observableCid]
@@ -207,7 +207,7 @@ run = script do
   let
     expectedConsumedQuantities = [Instrument.qty 0.0044660695 cashInstrumentCid]
     expectedProducedQuantities = []
-  lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment settlers issuer investor observers custodian [observableCid] expectedConsumedQuantities expectedProducedQuantities
+  lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment settlers issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
 
   pure ()
 
@@ -215,8 +215,8 @@ run = script do
 -- https://www.isda.org/a/aWkgE/Linear-interpolation-04022022.pdf
 runStubRateInterpolation : Script ()
 runStubRateInterpolation = script do
-  [custodian, issuer, investor, calendarDataProvider, publicParty] <-
-    createParties ["Custodian", "Issuer", "Investor", "Calendar Data Provider", "PublicParty"]
+  [custodian, issuer, calendarDataProvider, publicParty] <-
+    createParties ["Custodian", "Issuer", "Calendar Data Provider", "PublicParty"]
 
   -- Distribute commercial-bank cash
   now <- getTime
@@ -345,15 +345,15 @@ runStubRateInterpolation = script do
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 0.001867875 cashInstrumentCid]  -- interpolated stub rate from the ISDA paper
-  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] (addDays firstRegularPeriodDate 1) swapInstrument settlers issuer investor observers custodian observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] (addDays firstRegularPeriodDate 1) swapInstrument settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   pure ()
 
 -- Test sample trade with two stub periods (intial and final) in the same trade.
 runDualStubSampleTrade : Script ()
 runDualStubSampleTrade = script do
-  [custodian, issuer, investor, calendarDataProvider, publicParty] <-
-    createParties ["Custodian", "Issuer", "Investor", "Calendar Data Provider", "PublicParty"]
+  [custodian, issuer, calendarDataProvider, publicParty] <-
+    createParties ["Custodian", "Issuer", "Calendar Data Provider", "PublicParty"]
 
   -- Distribute commercial-bank cash
   now <- getTime
@@ -545,39 +545,39 @@ runDualStubSampleTrade = script do
   let
     expectedConsumedQuantities = [Instrument.qty 83.3333 cashInstrumentCid]
     expectedProducedQuantities = []
-  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstRegularPeriodDate swapInstrument settlers issuer investor observers custodian observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstRegularPeriodDate swapInstrument settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- Second payment date: Lifecycle and verify the floating payment (regular period, 3M).
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 3791.6667 cashInstrumentCid]
-  swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] secondRegularPeriodDate swapInstrumentAfterFirstPayment settlers issuer investor observers custodian observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] secondRegularPeriodDate swapInstrumentAfterFirstPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- Third payment date: Lifecycle and verify the floating payment (regular period, 3M).
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 3750.0 cashInstrumentCid]
-  swapInstrumentAfterThirdPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] thirdRegularPeriodDate swapInstrumentAfterSecondPayment settlers issuer investor observers custodian observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterThirdPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] thirdRegularPeriodDate swapInstrumentAfterSecondPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- Fourth payment date: Lifecycle and verify the floating payment (regular period, 3M).
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 3833.3333 cashInstrumentCid]
-  swapInstrumentAfterFourthPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] lastRegularPeriodDate swapInstrumentAfterThirdPayment settlers issuer investor observers custodian observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFourthPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] lastRegularPeriodDate swapInstrumentAfterThirdPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- Final payment date: Lifecycle and verify the net fix vs floating payment (stub period).
   let
     expectedConsumedQuantities = [Instrument.qty 17324.3727 cashInstrumentCid]
     expectedProducedQuantities = []
-  swapInstrumentAfterFinalPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFourthPayment settlers issuer investor observers custodian observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFinalPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFourthPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   pure ()
 
 -- Test sample trade with a payment frequency different from the calculation frequency.
 runSeparatePaymentFrequencySampleTrade : Script ()
 runSeparatePaymentFrequencySampleTrade = script do
-  [custodian, issuer, investor, calendarDataProvider, publicParty] <-
-    createParties ["Custodian", "Issuer", "Investor", "Calendar Data Provider", "PublicParty"]
+  [custodian, issuer, calendarDataProvider, publicParty] <-
+    createParties ["Custodian", "Issuer", "Calendar Data Provider", "PublicParty"]
 
   -- Distribute commercial-bank cash
   now <- getTime
@@ -764,30 +764,30 @@ runSeparatePaymentFrequencySampleTrade = script do
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 916.6665 cashInstrumentCid]
-  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstRegularPeriodDate swapInstrument settlers issuer investor observers custodian observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstRegularPeriodDate swapInstrument settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- Lifecycle and verify the fix payment (regular period, 3M).
   let
     expectedConsumedQuantities = [Instrument.qty 25000.0 cashInstrumentCid]
     expectedProducedQuantities = []
-  swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] (date 2023 Jan 26) swapInstrumentAfterFirstPayment settlers issuer investor observers custodian observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] (date 2023 Jan 26) swapInstrumentAfterFirstPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- Lifecycle and verify the fix (regular period, 3M). The 6M float payment is calculated but only paid every 12M.
   let
     expectedConsumedQuantities = [Instrument.qty 25000.0 cashInstrumentCid]
     expectedProducedQuantities = []
-  swapInstrumentAfterThirdPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] (date 2023 Apr 26) swapInstrumentAfterSecondPayment settlers issuer investor observers custodian observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterThirdPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] (date 2023 Apr 26) swapInstrumentAfterSecondPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- Lifecycle and verify the fix payment (regular period, 3M).
   let
     expectedConsumedQuantities = [Instrument.qty 25000.0 cashInstrumentCid]
     expectedProducedQuantities = []
-  swapInstrumentAfterFourthPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] (date 2023 Jul 26) swapInstrumentAfterThirdPayment settlers issuer investor observers custodian observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFourthPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] (date 2023 Jul 26) swapInstrumentAfterThirdPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- Lifecycle and verify the fix payment (regular period, 3M) + floating payment (regular period, 12M).
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 38368.0555 cashInstrumentCid]
-  lifecycleAndVerifySwapPaymentEffects [publicParty] (date 2023 Oct 26) swapInstrumentAfterFourthPayment settlers issuer investor observers custodian observableCids expectedConsumedQuantities expectedProducedQuantities
+  lifecycleAndVerifySwapPaymentEffects [publicParty] (date 2023 Oct 26) swapInstrumentAfterFourthPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/InterestRate.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/InterestRate.daml
@@ -73,7 +73,7 @@ run = script do
   let
     expectedConsumedQuantities = [Instrument.qty 0.0014466167 cashInstrumentCid]
     expectedProducedQuantities = []
-  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer investor observers custodian [observableCid] expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the first payment date: try to lifecycle and verify that there are no lifecycle effects.
   verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment settlers issuer [observableCid]
@@ -85,6 +85,6 @@ run = script do
   let
     expectedConsumedQuantities = [Instrument.qty 0.0044660695 cashInstrumentCid]
     expectedProducedQuantities = []
-  lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment settlers issuer investor observers custodian [observableCid] expectedConsumedQuantities expectedProducedQuantities
+  lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment settlers issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
 
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -139,17 +139,17 @@ verifyNoLifecycleEffects readAs today instrument settlers issuer observableCids 
   assertMsg ("There should be no lifecycle effects on " <> show today) (null effectCids)
 
 -- | Verify the payments from a payment date of a swap (excluding settlement)
-lifecycleAndVerifySwapPaymentEffects : [Party] -> Date -> Instrument.K -> Parties -> Party -> Party -> [(Text, Parties)] -> Party -> [ContractId NumericObservable.I] -> [Instrument.Q] -> [Instrument.Q] -> Script Instrument.K
-lifecycleAndVerifySwapPaymentEffects readAs today swapInstrument settlers issuer investor obs custodian observableCids expectedConsumedQuantities expectedProducedQuantities = do
+lifecycleAndVerifySwapPaymentEffects : [Party] -> Date -> Instrument.K -> Parties -> Party -> [ContractId NumericObservable.I] -> [Instrument.Q] -> [Instrument.Q] -> Script Instrument.K
+lifecycleAndVerifySwapPaymentEffects readAs today swapInstrument settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities = do
   (swapLifecycleCid, effectCids) <- lifecycleInstrument readAs today swapInstrument settlers issuer observableCids
-  let effectCid = head effectCids -- this gives a better error message in case there are no effectss
+  let effectCid = head effectCids -- this gives a better error message in case there are no effects
 
   newSwapInstrumentKey <- submit issuer do
     Instrument.toKey <$> exerciseCmd @Instrument.I (coerceContractId swapLifecycleCid) Instrument.GetView with viewer = issuer
 
   -- Get the effect
-  effectView <- submitMulti [investor] readAs do
-    exerciseCmd effectCid Effect.GetView with viewer = investor
+  effectView <- submit issuer do
+    exerciseCmd effectCid Effect.GetView with viewer = issuer
 
   -- Verify that the consumed/produced quantities match the expected ones
   assertMsg "The consumed quantities do not match the expected ones" (sort expectedConsumedQuantities == sort effectView.consumed)


### PR DESCRIPTION
@markus-da during the implementation of my previous PR, I noticed that the bond and swap tests are now using a few redundant parties. This is an attempt at a cleanup, let me know what you think.

I also noticed that in the bond tests we have two parties, namely `depository` and `custodian`, which are respectively depositories of the cash and bond instrument. In the swap tests, the `custodian` plays both roles. Shall we align?

