### PR TITLE
Remove unused `settlers` from Effect

### DIFF
--- a/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate/Instrument.daml
@@ -87,9 +87,9 @@ template Instrument
 
     interface instance Lifecycle.I for Instrument where
       view = Lifecycle.View with lifecycler = issuer
-      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; timeObservableCid; observableCids} self =
+      evolve Lifecycle.Evolve{ruleName; eventCid; timeObservableCid; observableCids} self =
         case ruleName of
-          "Time" -> processClockUpdate issuer settlers eventCid timeObservableCid self this observableCids
+          "Time" -> processClockUpdate issuer eventCid timeObservableCid self this observableCids
           other -> abort $ "Unknown lifecycle rule " <> other
 
     interface instance Disclosure.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate/Instrument.daml
@@ -89,9 +89,9 @@ template Instrument
 
     interface instance Lifecycle.I for Instrument where
       view = Lifecycle.View with lifecycler = issuer
-      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; timeObservableCid; observableCids} self =
+      evolve Lifecycle.Evolve{ruleName; eventCid; timeObservableCid; observableCids} self =
         case ruleName of
-          "Time" -> processClockUpdate issuer settlers eventCid timeObservableCid self this observableCids
+          "Time" -> processClockUpdate issuer eventCid timeObservableCid self this observableCids
           other -> abort $ "Unknown lifecycle rule " <> other
 
     interface instance Disclosure.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Bond/InflationLinked/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/InflationLinked/Instrument.daml
@@ -111,9 +111,9 @@ template Instrument
 
     interface instance Lifecycle.I for Instrument where
       view = Lifecycle.View with lifecycler = issuer
-      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; timeObservableCid; observableCids} self =
+      evolve Lifecycle.Evolve{ruleName; eventCid; timeObservableCid; observableCids} self =
         case ruleName of
-          "Time" -> processClockUpdate issuer settlers eventCid timeObservableCid self this observableCids
+          "Time" -> processClockUpdate issuer eventCid timeObservableCid self this observableCids
           other -> abort $ "Unknown lifecycle rule " <> other
 
     interface instance Disclosure.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Bond/ZeroCoupon/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/ZeroCoupon/Instrument.daml
@@ -72,9 +72,9 @@ template Instrument
 
     interface instance Lifecycle.I for Instrument where
       view = Lifecycle.View with lifecycler = issuer
-      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; timeObservableCid; observableCids} self =
+      evolve Lifecycle.Evolve{ruleName; eventCid; timeObservableCid; observableCids} self =
         case ruleName of
-          "Time" -> processClockUpdate issuer settlers eventCid timeObservableCid self this observableCids
+          "Time" -> processClockUpdate issuer eventCid timeObservableCid self this observableCids
           other -> abort $ "Unknown lifecycle rule " <> other
 
     interface instance Disclosure.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Instrument.daml
@@ -18,7 +18,7 @@ import Daml.Finance.Interface.Instrument.Generic.Instrument qualified as Generic
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (I)
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Evolve(..), View(..))
-import Daml.Finance.Interface.Types.Common (Id, InstrumentKey(..), Parties, PartiesMap)
+import Daml.Finance.Interface.Types.Common (Id, InstrumentKey(..), PartiesMap)
 import Daml.Finance.Interface.Types.Date.Classes (toUTCTime)
 import Daml.Finance.Interface.Util.Common (verify)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, SetObservers(..), View(..), flattenObservers)
@@ -79,9 +79,9 @@ template Instrument
 
     interface instance Lifecycle.I for Instrument where
       view = Lifecycle.View with lifecycler = issuer
-      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; timeObservableCid; observableCids} self =
+      evolve Lifecycle.Evolve{ruleName; eventCid; timeObservableCid; observableCids} self =
         case ruleName of
-          "Time" -> processClockUpdate issuer settlers eventCid timeObservableCid self this observableCids
+          "Time" -> processClockUpdate issuer eventCid timeObservableCid self this observableCids
           other -> abort $ "Unknown lifecycle rule " <> other
 
     interface instance Disclosure.I for Instrument where
@@ -94,7 +94,7 @@ template Instrument
     interface instance Election.Exercisable for Instrument where
       asLifecycle = toInterface @Lifecycle.I this
       view = Election.ExercisableView with lifecycler
-      applyElection Election.ApplyElection{clockCid; electionCid; observableCids; settlers} self = do
+      applyElection Election.ApplyElection{clockCid; electionCid; observableCids} self = do
         currentTime <- toUTCTime <$> fetch clockCid
         election <- fetch electionCid
         instrumentClaim <- Claim.getClaims (toInterface @Claim.I this) $ Claim.GetClaims with actor = lifecycler
@@ -125,7 +125,6 @@ template Instrument
           let (consumed, produced) = splitPending pending
           effectCid <- toInterfaceContractId <$> create ElectionEffect with
             providers = fromList [this.issuer, this.depository]
-            settlers
             custodian = if v.electorIsOwner then v.counterparty else v.elector
             owner = if v.electorIsOwner then v.elector else v.counterparty
             id = v.id
@@ -141,8 +140,8 @@ template Instrument
 
 -- | HIDE
 -- | Rule to process a time update event.
-processClockUpdate : Party -> Parties -> ContractId Event.I -> ContractId TimeObservable.I -> ContractId Lifecycle.I -> Instrument -> [ContractId NumericObservable.I] -> Update (ContractId Lifecycle.I, [ContractId Effect.I])
-processClockUpdate actor settlers eventCid _ self instrument observableCids = do
+processClockUpdate : Party -> ContractId Event.I -> ContractId TimeObservable.I -> ContractId Lifecycle.I -> Instrument -> [ContractId NumericObservable.I] -> Update (ContractId Lifecycle.I, [ContractId Effect.I])
+processClockUpdate actor eventCid _ self instrument observableCids = do
   v <- view <$> fetch eventCid
   claims <- Claim.getClaims (toInterface @Claim.I instrument) $ Claim.GetClaims with actor
   (remaining, pending) <- lifecycle actor observableCids (toInterface instrument) [timeEvent v.eventTime]
@@ -167,7 +166,6 @@ processClockUpdate actor settlers eventCid _ self instrument observableCids = do
     let (consumed, produced) = splitPending pending
     effectCid <- toInterfaceContractId <$> create Effect with
       providers = fromList [instrument.issuer, instrument.depository]
-      settlers
       id = v.id
       description = v.description
       targetInstrument = currentKey

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Util.daml
@@ -20,7 +20,7 @@ import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (I)
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I)
-import Daml.Finance.Interface.Types.Common (Id, Parties)
+import Daml.Finance.Interface.Types.Common (Id)
 import Daml.Finance.Interface.Types.Date.Calendar
 import Daml.Finance.Interface.Types.Date.Classes (toUTCTime)
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
@@ -172,8 +172,8 @@ mapClaimToUTCTime =
 
 -- BOND_PROCESS_CLOCK_UPDATE_INITAL_CLAIMS_BEGIN
 -- | Rule to process a clock update event.
-processClockUpdate : IsBond t => Party -> Parties -> ContractId Event.I -> ContractId TimeObservable.I -> ContractId Lifecycle.I -> t -> [ContractId NumericObservable.I] -> Update (ContractId Lifecycle.I, [ContractId Effect.I])
-processClockUpdate actor settlers eventCid _ self instrument observableCids = do
+processClockUpdate : IsBond t => Party -> ContractId Event.I -> ContractId TimeObservable.I -> ContractId Lifecycle.I -> t -> [ContractId NumericObservable.I] -> Update (ContractId Lifecycle.I, [ContractId Effect.I])
+processClockUpdate actor eventCid _ self instrument observableCids = do
   v <- view <$> fetch eventCid
   let
     claimInstrument = toInterface @Claim.I instrument
@@ -202,7 +202,6 @@ processClockUpdate actor settlers eventCid _ self instrument observableCids = do
     Instrument.createReference instrument.issuer $ toInterfaceContractId newInstrumentCid
     effectCid <- toInterfaceContractId <$> create Effect with
       providers = fromList [currentKey.issuer, currentKey.depository]
-      settlers
       id = v.id
       description = v.description
       targetInstrument = currentKey

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Asset/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Asset/Instrument.daml
@@ -90,9 +90,9 @@ template Instrument
 
     interface instance Lifecycle.I for Instrument where
       view = Lifecycle.View with lifecycler = issuer
-      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; timeObservableCid; observableCids} self =
+      evolve Lifecycle.Evolve{ruleName; eventCid; timeObservableCid; observableCids} self =
         case ruleName of
-          "Time" -> processClockUpdate issuer settlers eventCid timeObservableCid self this observableCids
+          "Time" -> processClockUpdate issuer eventCid timeObservableCid self this observableCids
           other -> abort $ "Unknown lifecycle rule " <> other
 
     interface instance Disclosure.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault/Instrument.daml
@@ -89,9 +89,9 @@ template Instrument
 
     interface instance Lifecycle.I for Instrument where
       view = Lifecycle.View with lifecycler = issuer
-      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; timeObservableCid; observableCids} self =
+      evolve Lifecycle.Evolve{ruleName; eventCid; timeObservableCid; observableCids} self =
         case ruleName of
-          "Time" -> processClockUpdate issuer settlers eventCid timeObservableCid self this observableCids
+          "Time" -> processClockUpdate issuer eventCid timeObservableCid self this observableCids
           other -> abort $ "Unknown lifecycle rule " <> other
 
     interface instance Disclosure.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Currency/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Currency/Instrument.daml
@@ -96,9 +96,9 @@ template Instrument
 
     interface instance Lifecycle.I for Instrument where
       view = Lifecycle.View with lifecycler = issuer
-      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; timeObservableCid; observableCids} self =
+      evolve Lifecycle.Evolve{ruleName; eventCid; timeObservableCid; observableCids} self =
         case ruleName of
-          "Time" -> processClockUpdate issuer settlers eventCid timeObservableCid self this observableCids
+          "Time" -> processClockUpdate issuer eventCid timeObservableCid self this observableCids
           other -> abort $ "Unknown lifecycle rule " <> other
 
     interface instance Disclosure.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange/Instrument.daml
@@ -86,9 +86,9 @@ template Instrument
 
     interface instance Lifecycle.I for Instrument where
       view = Lifecycle.View with lifecycler = issuer
-      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; timeObservableCid; observableCids} self =
+      evolve Lifecycle.Evolve{ruleName; eventCid; timeObservableCid; observableCids} self =
         case ruleName of
-          "Time" -> processClockUpdate issuer settlers eventCid timeObservableCid self this observableCids
+          "Time" -> processClockUpdate issuer eventCid timeObservableCid self this observableCids
           other -> abort $ "Unknown lifecycle rule " <> other
 
     interface instance Disclosure.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
@@ -107,9 +107,9 @@ template Instrument
 
     interface instance Lifecycle.I for Instrument where
       view = Lifecycle.View with lifecycler = issuer
-      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; timeObservableCid; observableCids} self =
+      evolve Lifecycle.Evolve{ruleName; eventCid; timeObservableCid; observableCids} self =
         case ruleName of
-          "Time" -> processClockUpdate issuer settlers eventCid timeObservableCid self this observableCids
+          "Time" -> processClockUpdate issuer eventCid timeObservableCid self this observableCids
           other -> abort $ "Unknown lifecycle rule " <> other
 
     interface instance Disclosure.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate/Instrument.daml
@@ -88,9 +88,9 @@ template Instrument
 
     interface instance Lifecycle.I for Instrument where
       view = Lifecycle.View with lifecycler = issuer
-      evolve Lifecycle.Evolve{ruleName; settlers; eventCid; timeObservableCid; observableCids} self =
+      evolve Lifecycle.Evolve{ruleName; eventCid; timeObservableCid; observableCids} self =
         case ruleName of
-          "Time" -> processClockUpdate issuer settlers eventCid timeObservableCid self this observableCids
+          "Time" -> processClockUpdate issuer eventCid timeObservableCid self this observableCids
           other -> abort $ "Unknown lifecycle rule " <> other
 
     interface instance Disclosure.I for Instrument where

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Generic/Election.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Generic/Election.daml
@@ -10,7 +10,7 @@ import Daml.Finance.Interface.Data.TimeObservable qualified as TimeObservable (I
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (I)
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I, Implementation, getEventTime)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Implementation)
-import Daml.Finance.Interface.Types.Common (Id, Parties, PartiesMap)
+import Daml.Finance.Interface.Types.Common (Id, PartiesMap)
 
 -- | Type synonym for `Election`.
 type I = Election
@@ -62,15 +62,13 @@ interface Election where
       pure $ view this
 
   nonconsuming choice Apply : (ContractId Lifecycle.I, [ContractId Effect.I])
-    -- ^ applies the election to the instrument, returning the new instrument as well
+    -- ^ Applies the election to the instrument, returning the new instrument as well
     -- as the corresponding effects. The election is archived as part of this choice.
     with
       clockCid : ContractId TimeObservable.I
-        -- ^ current time.
+        -- ^ Current time.
       observableCids : [ContractId NumericObservable.I]
-        -- ^ set of observables
-      settlers : Parties
-        -- ^ parties responsible for settling effects
+        -- ^ Set of observables.
     controller (view this).provider
     do
       let v = view this
@@ -78,7 +76,6 @@ interface Election where
         with
           clockCid
           observableCids
-          settlers
           electionCid = toInterfaceContractId self
       archive' this self -- this is needed as we can't write postconsuming choices on interfaces
       pure (newInstrumentCid, effects)
@@ -127,8 +124,6 @@ interface Exercisable where
         -- ^ The election.
       observableCids : [ContractId NumericObservable.I]
         -- ^ Set of observables.
-      settlers : Parties
-        -- ^ The party settling the transaction.
     controller (view this).lifecycler
     do
       (instrument, effects) <- applyElection this arg self

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Effect.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Effect.daml
@@ -18,8 +18,6 @@ data View = View
   with
     providers : Parties
       -- ^ The parties providing the claim processing.
-    settlers : Parties
-      -- ^ The parties that can settle the consequence of the effect.
     targetInstrument : Instrument.K
       -- ^ A holding on this instrument is required to claim the effect.
     producedInstrument : Optional Instrument.K

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Rule/Lifecycle.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Rule/Lifecycle.daml
@@ -7,7 +7,6 @@ import Daml.Finance.Interface.Data.NumericObservable qualified as NumericObserva
 import Daml.Finance.Interface.Data.TimeObservable qualified as TimeObservable (I)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (I)
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I)
-import Daml.Finance.Interface.Types.Common (Parties)
 
 -- | Type synonym for `Lifecycle`.
 type I = Lifecycle
@@ -43,8 +42,6 @@ interface Lifecycle where
     with
       ruleName : Text
         -- ^ The lifecycle rule to be processed.
-      settlers : Parties
-        -- ^ The party settling the effects.
       eventCid : ContractId Event.I
         -- ^ The event.
       timeObservableCid : ContractId TimeObservable.I

--- a/src/main/daml/Daml/Finance/Lifecycle/Effect.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Effect.daml
@@ -19,8 +19,6 @@ template Effect
   with
     providers : Parties
       -- ^ The effect provider.
-    settlers : Parties
-      -- ^ Any of the parties can settle the effect's consequences.
     id : Id
       -- ^ The effect's identifier.
     description : Text
@@ -42,7 +40,7 @@ template Effect
     observer observers
 
     interface instance Effect.I for Effect where
-      view = Effect.View with providers; settlers; id; description; targetInstrument; producedInstrument; consumed; produced; settlementDate
+      view = Effect.View with providers; id; description; targetInstrument; producedInstrument; consumed; produced; settlementDate
 
       calculate Effect.Calculate{holdingCid} _ = do
         holding <- fetch holdingCid

--- a/src/main/daml/Daml/Finance/Lifecycle/ElectionEffect.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/ElectionEffect.daml
@@ -21,8 +21,6 @@ template ElectionEffect
   with
     providers : Parties
       -- ^ The effect provider.
-    settlers : Parties
-      -- ^ Any of the parties can settle the effect's consequences.
     custodian : Party
       -- ^ The custodian of the holding put forward for election.
     owner : Party
@@ -50,7 +48,7 @@ template ElectionEffect
     observer Disclosure.flattenObservers observers
 
     interface instance Effect.I for ElectionEffect where
-      view = Effect.View with providers; settlers; id; description; targetInstrument; producedInstrument; consumed; produced; settlementDate
+      view = Effect.View with providers; id; description; targetInstrument; producedInstrument; consumed; produced; settlementDate
 
       calculate Effect.Calculate{actor; holdingCid} self = do
         holding <- fetch holdingCid

--- a/src/main/daml/Daml/Finance/Lifecycle/Rule/Distribution.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Rule/Distribution.daml
@@ -30,7 +30,7 @@ template Rule
 
     interface instance Lifecycle.I for Rule where
       view = Lifecycle.View with lifecycler
-      evolve Lifecycle.Evolve{settlers; eventCid; timeObservableCid} self = do
+      evolve Lifecycle.Evolve{eventCid; timeObservableCid} self = do
         distribution <- fetch $ fromInterfaceContractId @Distribution.Event eventCid
         clockTime <- toDateUTC . (.time) <$> exercise timeObservableCid TimeObservable.GetView with viewer = lifecycler
         if clockTime >= distribution.effectiveDate
@@ -38,7 +38,6 @@ template Rule
           effectCid <- toInterfaceContractId <$> create Effect
             with
               providers
-              settlers
               id = distribution.id
               description = distribution.description
               targetInstrument = distribution.targetInstrument

--- a/src/main/daml/Daml/Finance/Lifecycle/Rule/Replacement.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Rule/Replacement.daml
@@ -30,7 +30,7 @@ template Rule
 
     interface instance Lifecycle.I for Rule where
       view = Lifecycle.View with lifecycler
-      evolve Lifecycle.Evolve{settlers; eventCid; timeObservableCid} self = do
+      evolve Lifecycle.Evolve{eventCid; timeObservableCid} self = do
         replacement <- fetch $ fromInterfaceContractId @Replacement.Event eventCid
         clockTime <- toDateUTC . (.time) <$> exercise timeObservableCid TimeObservable.GetView with viewer = lifecycler
         if clockTime >= replacement.effectiveDate
@@ -38,7 +38,6 @@ template Rule
           effectCid <- toInterfaceContractId <$> create Effect
             with
               providers = replacement.providers
-              settlers
               id = replacement.id
               description = replacement.description
               targetInstrument = replacement.targetInstrument

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/FixedRate.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/FixedRate.daml
@@ -21,9 +21,8 @@ import Daml.Script
 -- Penultimate coupon payment on a bond showing creation of new instrument version
 run : Script ()
 run = script do
-  [depository, custodian, issuer, investor, calendarDataProvider, settler, publicParty] <-
-    createParties ["CSD", "Custodian", "Issuer", "Investor", "Calendar Data Provider", "Settler", "PublicParty"]
-  let settlers = singleton settler
+  [depository, custodian, issuer, investor, calendarDataProvider, publicParty] <-
+    createParties ["CSD", "Custodian", "Issuer", "Investor", "Calendar Data Provider", "PublicParty"]
 
   -- Account and holding factory
   let pp = [("FactoryProvider", singleton publicParty)]
@@ -86,27 +85,27 @@ run = script do
   -- CREDIT_ACCOUNT_FIXED_RATE_BOND_END
 
   -- One day before the first coupon date: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (subtractDays firstCouponDate 1) bondInstrument settlers issuer []
+  verifyNoLifecycleEffects [publicParty] (subtractDays firstCouponDate 1) bondInstrument issuer []
 
   -- First coupon date: Lifecycle and verify that there is an effect for one coupon.
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 0.0035863014 cashInstrumentCid]
-  bondInstrumentAfterFirstCoupon <- lifecycleAndVerifyBondPaymentEffects [publicParty] firstCouponDate bondInstrument settlers issuer [] expectedConsumedQuantities expectedProducedQuantities
+  bondInstrumentAfterFirstCoupon <- lifecycleAndVerifyBondPaymentEffects [publicParty] firstCouponDate bondInstrument issuer [] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the first coupon date: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (addDays firstCouponDate 1) bondInstrumentAfterFirstCoupon settlers issuer []
+  verifyNoLifecycleEffects [publicParty] (addDays firstCouponDate 1) bondInstrumentAfterFirstCoupon issuer []
 
   -- One day before expiry: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (subtractDays maturityDate 1) bondInstrumentAfterFirstCoupon settlers issuer []
+  verifyNoLifecycleEffects [publicParty] (subtractDays maturityDate 1) bondInstrumentAfterFirstCoupon issuer []
 
   -- Lifecycle on the expiry date. Verify the lifecycle effects for one coupon and the redemption amount
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 1.011030137 cashInstrumentCid]
-  bondInstrumentAfterRedemption <- lifecycleAndVerifyBondPaymentEffects [publicParty] maturityDate bondInstrumentAfterFirstCoupon settlers issuer [] expectedConsumedQuantities expectedProducedQuantities
+  bondInstrumentAfterRedemption <- lifecycleAndVerifyBondPaymentEffects [publicParty] maturityDate bondInstrumentAfterFirstCoupon issuer [] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after expiry: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (addDays maturityDate 1) bondInstrumentAfterRedemption settlers issuer []
+  verifyNoLifecycleEffects [publicParty] (addDays maturityDate 1) bondInstrumentAfterRedemption issuer []
 
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/FloatingRate.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/FloatingRate.daml
@@ -66,27 +66,27 @@ run = script do
   bondInstrument <- originateFloatingRateBond custodian issuer "BONDTEST1" "Floating Rate Bond" pp now issueDate holidayCalendarId calendarDataProvider firstCouponDate maturityDate dayCountConvention businessDayConvention couponRate couponPeriod couponPeriodMultiplier cashInstrumentCid referenceRateId
 
   -- One day before the first coupon date: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (subtractDays firstCouponDate 1) bondInstrument settlers issuer [observableCid]
+  verifyNoLifecycleEffects [publicParty] (subtractDays firstCouponDate 1) bondInstrument issuer [observableCid]
 
   -- First coupon date: Lifecycle and verify that there is an effect for one coupon.
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 0.0006484932 cashInstrumentCid]
-  bondInstrumentAfterFirstCoupon <- lifecycleAndVerifyBondPaymentEffects [publicParty] firstCouponDate bondInstrument settlers issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
+  bondInstrumentAfterFirstCoupon <- lifecycleAndVerifyBondPaymentEffects [publicParty] firstCouponDate bondInstrument issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the first coupon date: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (addDays firstCouponDate 1) bondInstrumentAfterFirstCoupon settlers issuer [observableCid]
+  verifyNoLifecycleEffects [publicParty] (addDays firstCouponDate 1) bondInstrumentAfterFirstCoupon issuer [observableCid]
 
   -- One day before expiry: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (subtractDays maturityDate 1) bondInstrumentAfterFirstCoupon settlers issuer [observableCid]
+  verifyNoLifecycleEffects [publicParty] (subtractDays maturityDate 1) bondInstrumentAfterFirstCoupon issuer [observableCid]
 
   -- Lifecycle on the expiry date. Verify the lifecycle effects for one coupon and the redemption amount
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 1.002033589 cashInstrumentCid]
-  bondInstrumentAfterRedemption <- lifecycleAndVerifyBondPaymentEffects [publicParty] maturityDate bondInstrumentAfterFirstCoupon settlers issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
+  bondInstrumentAfterRedemption <- lifecycleAndVerifyBondPaymentEffects [publicParty] maturityDate bondInstrumentAfterFirstCoupon issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after expiry: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (addDays maturityDate 1) bondInstrumentAfterRedemption settlers issuer [observableCid]
+  verifyNoLifecycleEffects [publicParty] (addDays maturityDate 1) bondInstrumentAfterRedemption issuer [observableCid]
 
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/InflationLinked.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/InflationLinked.daml
@@ -22,9 +22,8 @@ import Daml.Script
 -- Penultimate coupon payment on a bond showing creation of new instrument version
 run : Script ()
 run = script do
-  [depository, custodian, issuer, calendarDataProvider, settler, publicParty] <-
-    createParties ["CSD", "Custodian", "Issuer", "Calendar Data Provider", "Settler", "PublicParty"]
-  let settlers = singleton settler
+  [depository, custodian, issuer, calendarDataProvider, publicParty] <-
+    createParties ["CSD", "Custodian", "Issuer", "Calendar Data Provider", "PublicParty"]
 
   -- Distribute commercial-bank cash
   now <- getTime
@@ -68,27 +67,27 @@ run = script do
   bondInstrument <- originateInflationLinkedBond custodian issuer "BONDTEST1" "Inflation Linked Bond" pp now issueDate holidayCalendarId calendarDataProvider firstCouponDate maturityDate dayCountConvention businessDayConvention couponRate couponPeriod couponPeriodMultiplier cashInstrumentCid inflationIndexId inflationIndexBaseValue
 
   -- One day before the first coupon date: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (subtractDays firstCouponDate 1) bondInstrument settlers issuer [observableCid]
+  verifyNoLifecycleEffects [publicParty] (subtractDays firstCouponDate 1) bondInstrument issuer [observableCid]
 
   -- First coupon date: Lifecycle and verify that there is an effect for one coupon.
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 0.0009493151 cashInstrumentCid]
-  bondInstrumentAfterFirstCoupon <- lifecycleAndVerifyBondPaymentEffects [publicParty] firstCouponDate bondInstrument settlers issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
+  bondInstrumentAfterFirstCoupon <- lifecycleAndVerifyBondPaymentEffects [publicParty] firstCouponDate bondInstrument issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the first coupon date: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (addDays firstCouponDate 1) bondInstrumentAfterFirstCoupon settlers issuer [observableCid]
+  verifyNoLifecycleEffects [publicParty] (addDays firstCouponDate 1) bondInstrumentAfterFirstCoupon issuer [observableCid]
 
   -- One day before expiry: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (subtractDays maturityDate 1) bondInstrumentAfterFirstCoupon settlers issuer [observableCid]
+  verifyNoLifecycleEffects [publicParty] (subtractDays maturityDate 1) bondInstrumentAfterFirstCoupon issuer [observableCid]
 
   -- Lifecycle on the expiry date. Verify the lifecycle effects for one coupon and the inflation-adjusted redemption amount
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 1.102950411 cashInstrumentCid]
-  bondInstrumentAfterRedemption <- lifecycleAndVerifyBondPaymentEffects [publicParty] maturityDate bondInstrumentAfterFirstCoupon settlers issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
+  bondInstrumentAfterRedemption <- lifecycleAndVerifyBondPaymentEffects [publicParty] maturityDate bondInstrumentAfterFirstCoupon issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after expiry: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (addDays maturityDate 1) bondInstrumentAfterRedemption settlers issuer [observableCid]
+  verifyNoLifecycleEffects [publicParty] (addDays maturityDate 1) bondInstrumentAfterRedemption issuer [observableCid]
 
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
@@ -91,8 +91,8 @@ originateInflationLinkedBond depository issuer label description observers lastE
   createReference cid depository issuer observers
 
 -- | Lifecycle the instrument as of this date. This is a general function that can be used for both bonds and swaps.
-lifecycleInstrument : [Party] -> Date -> Instrument.K -> Parties -> Party -> [ContractId NumericObservable.I] -> Script (ContractId Lifecycle.I, [ContractId Effect.I])
-lifecycleInstrument readAs today instrument settlers issuer observableCids = do
+lifecycleInstrument : [Party] -> Date -> Instrument.K -> Party -> [ContractId NumericObservable.I] -> Script (ContractId Lifecycle.I, [ContractId Effect.I])
+lifecycleInstrument readAs today instrument issuer observableCids = do
   -- CREATE_CLOCK_FOR_BOND_LIFECYCLING_BEGIN
   -- create clock and clock update event
   (clockCid, clockEventCid) <- createClockAndEvent (singleton issuer) today empty
@@ -101,21 +101,21 @@ lifecycleInstrument readAs today instrument settlers issuer observableCids = do
   -- LIFECYCLE_BOND_BEGIN
   -- Try to lifecycle instrument
   (lifecycleCid, effectCids) <- Instrument.submitExerciseInterfaceByKeyCmd @Lifecycle.I [issuer] readAs instrument
-    Lifecycle.Evolve with settlers; eventCid = clockEventCid; observableCids; ruleName = "Time"; timeObservableCid = clockCid
+    Lifecycle.Evolve with eventCid = clockEventCid; observableCids; ruleName = "Time"; timeObservableCid = clockCid
   -- LIFECYCLE_BOND_END
 
   pure (lifecycleCid, effectCids)
 
 -- | Verify a that there are no lifecycle effects of the instrument on this date. This is a general function that can be used for both bonds and swaps.
-verifyNoLifecycleEffects : [Party] -> Date -> Instrument.K -> Parties -> Party -> [ContractId NumericObservable.I] -> Script ()
-verifyNoLifecycleEffects readAs today instrument settlers issuer observableCids = do
-  (bondLifecycleCid2, effectCids) <- lifecycleInstrument readAs today instrument settlers issuer observableCids
+verifyNoLifecycleEffects : [Party] -> Date -> Instrument.K -> Party -> [ContractId NumericObservable.I] -> Script ()
+verifyNoLifecycleEffects readAs today instrument issuer observableCids = do
+  (bondLifecycleCid2, effectCids) <- lifecycleInstrument readAs today instrument issuer observableCids
   assertMsg ("There should be no lifecycle effects on " <> show today) (null effectCids)
 
 -- | Verify the payments from a payment date of a bond (excluding settlement)
-lifecycleAndVerifyBondPaymentEffects : [Party] -> Date -> Instrument.K -> Parties -> Party -> [ContractId NumericObservable.I] -> [Instrument.Q] -> [Instrument.Q] -> Script Instrument.K
-lifecycleAndVerifyBondPaymentEffects readAs today instrument settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities = do
-  (bondLifecycleCid, [effectCid]) <- lifecycleInstrument readAs today instrument settlers issuer observableCids
+lifecycleAndVerifyBondPaymentEffects : [Party] -> Date -> Instrument.K -> Party -> [ContractId NumericObservable.I] -> [Instrument.Q] -> [Instrument.Q] -> Script Instrument.K
+lifecycleAndVerifyBondPaymentEffects readAs today instrument issuer observableCids expectedConsumedQuantities expectedProducedQuantities = do
+  (bondLifecycleCid, [effectCid]) <- lifecycleInstrument readAs today instrument issuer observableCids
 
   newBondInstrumentKey <- submit issuer do
     Instrument.toKey <$> exerciseCmd @Instrument.I (coerceContractId bondLifecycleCid) Instrument.GetView with viewer = issuer

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/ZeroCoupon.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/ZeroCoupon.daml
@@ -14,9 +14,8 @@ import Daml.Script
 -- Test creation and lifecycling of a zero coupon bond
 run : Script ()
 run = script do
-  [depository, custodian, issuer, settler, publicParty] <-
-    createParties ["CSD", "Custodian", "Issuer", "Settler", "PublicParty"]
-  let settlers = singleton settler
+  [depository, custodian, issuer, publicParty] <-
+    createParties ["CSD", "Custodian", "Issuer", "PublicParty"]
 
   -- Distribute commercial-bank cash
   now <- getTime
@@ -34,15 +33,15 @@ run = script do
   bondInstrument <- originateZeroCouponBond custodian issuer "BONDTEST1" "Zero Coupon Bond" pp now issueDate maturityDate cashInstrumentCid
 
   -- One day before expiry: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (subtractDays maturityDate 1) bondInstrument settlers issuer []
+  verifyNoLifecycleEffects [publicParty] (subtractDays maturityDate 1) bondInstrument issuer []
 
   -- Lifecycle on the expiry date. Verify the lifecycle effect for the redemption amount
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 1.0 cashInstrumentCid]
-  bondInstrumentAfterRedemption <- lifecycleAndVerifyBondPaymentEffects [publicParty] maturityDate bondInstrument settlers issuer [] expectedConsumedQuantities expectedProducedQuantities
+  bondInstrumentAfterRedemption <- lifecycleAndVerifyBondPaymentEffects [publicParty] maturityDate bondInstrument issuer [] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after expiry: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (addDays maturityDate 1) bondInstrumentAfterRedemption settlers issuer []
+  verifyNoLifecycleEffects [publicParty] (addDays maturityDate 1) bondInstrumentAfterRedemption issuer []
 
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
@@ -77,7 +77,7 @@ run = script do
       perUnitDistribution = [Instrument.qty 2.0 cashInstrument]
 
   -- Lifecycle cash dividend
-  (_, [effectCid]) <- submit issuer do exerciseCmd distributionRuleCid Lifecycle.Evolve with ruleName = "Dividend"; settlers = singleton investor; observableCids = []; eventCid = distributionEventCid; timeObservableCid = clockCid
+  (_, [effectCid]) <- submit issuer do exerciseCmd distributionRuleCid Lifecycle.Evolve with ruleName = "Dividend"; observableCids = []; eventCid = distributionEventCid; timeObservableCid = clockCid
 
   -- Claim effect
   result <- submitMulti [investor] [public] do

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Merger.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Merger.daml
@@ -72,7 +72,7 @@ run = script do
       perUnitReplacement = [Instrument.qty 0.5 mergedInstrument]
 
   -- Lifecycle replacement event
-  (_, [effectCid]) <- submit merging do exerciseCmd replacementRuleCid Lifecycle.Evolve with ruleName = "Merger"; settlers = singleton investor; eventCid = replacementEventCid; observableCids = []; timeObservableCid = clockCid
+  (_, [effectCid]) <- submit merging do exerciseCmd replacementRuleCid Lifecycle.Evolve with ruleName = "Merger"; eventCid = replacementEventCid; observableCids = []; timeObservableCid = clockCid
 
   -- Claim effect
   result <- submitMulti [investor] [public] do

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/StockSplit.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/StockSplit.daml
@@ -70,7 +70,7 @@ run = script do
       adjustmentFactor = 0.5
 
   -- Lifecycle stock split
-  (_, [effectCid]) <- submit issuer do exerciseCmd replacementRuleCid Lifecycle.Evolve with ruleName = "Dividend"; settlers = singleton investor; observableCids = []; eventCid = replacementEventCid; timeObservableCid = clockCid
+  (_, [effectCid]) <- submit issuer do exerciseCmd replacementRuleCid Lifecycle.Evolve with ruleName = "Dividend"; observableCids = []; eventCid = replacementEventCid; timeObservableCid = clockCid
 
   -- Claim effect
   result <- submitMulti [investor] [public] do

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
@@ -130,7 +130,6 @@ run = script do
     exerciseCmd callBondCid Election.Apply
       with
         clockCid
-        settlers
         observableCids = []
 
   -- Create settlement factory

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/EuropeanOption.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/EuropeanOption.daml
@@ -146,7 +146,6 @@ run = script do
     exerciseCmd exerciseOptionCid Election.Apply
       with
         clockCid
-        settlers
         observableCids = [observableCid]
 
   -- Create settlement factory
@@ -213,7 +212,6 @@ run = script do
     exerciseCmd expireOptionCid Election.Apply
       with
         clockCid
-        settlers
         observableCids = [observableCid]
 
   -- Create settlement factory

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardCash.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardCash.daml
@@ -77,7 +77,7 @@ run = script do
   (clockCid, clockEventCid) <- createClockAndEvent (singleton broker) maturity empty
 
   -- Lifecycle derivative
-  (_, [effectCid]) <- Instrument.submitExerciseInterfaceByKeyCmd @Lifecycle.I [broker] [] genericInstrument Lifecycle.Evolve with settlers; eventCid = clockEventCid; observableCids = [observableCid]; ruleName = "Time"; timeObservableCid = clockCid
+  (_, [effectCid]) <- Instrument.submitExerciseInterfaceByKeyCmd @Lifecycle.I [broker] [] genericInstrument Lifecycle.Evolve with eventCid = clockEventCid; observableCids = [observableCid]; ruleName = "Time"; timeObservableCid = clockCid
 
   -- Create settlement factory
   settlementFactoryCid <- toInterfaceContractId <$> submit investor do createCmd Factory with provider = investor; observers = empty

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardPhysical.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardPhysical.daml
@@ -77,7 +77,7 @@ run = script do
   (clockCid, clockEventCid) <- createClockAndEvent (singleton broker) maturity empty
 
   -- Lifecycle a generic derivative
-  (_, [effectCid]) <- Instrument.submitExerciseInterfaceByKeyCmd @Lifecycle.I [broker] [] genericInstrument Lifecycle.Evolve with settlers; eventCid = clockEventCid; observableCids = []; ruleName = "Time"; timeObservableCid = clockCid
+  (_, [effectCid]) <- Instrument.submitExerciseInterfaceByKeyCmd @Lifecycle.I [broker] [] genericInstrument Lifecycle.Evolve with eventCid = clockEventCid; observableCids = []; ruleName = "Time"; timeObservableCid = clockCid
 
   -- Create settlement factory
   settlementFactoryCid <- toInterfaceContractId <$> submit investor do createCmd Factory with provider = investor; observers = empty

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
@@ -134,7 +134,7 @@ run = script do
   (clockCid, clockEventCid) <- createClockAndEvent (singleton issuer) today empty
 
   -- Lifecycle bond
-  (genericLifecycleCid2, [effectCid]) <- BaseInstrument.submitExerciseInterfaceByKeyCmd @Lifecycle.I [issuer] [] genericInstrument Lifecycle.Evolve with settlers; eventCid = clockEventCid; observableCids = []; ruleName = "Time"; timeObservableCid = clockCid
+  (genericLifecycleCid2, [effectCid]) <- BaseInstrument.submitExerciseInterfaceByKeyCmd @Lifecycle.I [issuer] [] genericInstrument Lifecycle.Evolve with eventCid = clockEventCid; observableCids = []; ruleName = "Time"; timeObservableCid = clockCid
 
   -- Setup settlement contract between issuer and CSD
   -- In order for the workflow to be successful, we need to disclose the CSD's cash account to the Issuer.

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Asset.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Asset.daml
@@ -66,25 +66,24 @@ run = script do
   swapInstrument <- originateAssetSwap custodian issuer "SwapTest1" "Asset swap" observers now issueDate holidayCalendarId calendarDataProvider firstPaymentDate maturityDate dayCountConvention businessDayConvention fixRate paymentPeriod paymentPeriodMultiplier cashInstrumentCid referenceAssetId issuerPaysFix
 
   -- One day before the first payment date: try to lifecycle and verify that there are no lifecycle effects.
-  let settlers = singleton custodian
-  verifyNoLifecycleEffects [publicParty] (subtractDays firstPaymentDate 1) swapInstrument settlers issuer [observableCid]
+  verifyNoLifecycleEffects [publicParty] (subtractDays firstPaymentDate 1) swapInstrument issuer [observableCid]
 
   -- First payment date: Lifecycle and verify the lifecycle effects for fix rate and asset performance payments.
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 0.0784811777 cashInstrumentCid]
-  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the first payment date: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment settlers issuer [observableCid]
+  verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment issuer [observableCid]
 
   -- One day before expiry: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (subtractDays maturityDate 1) swapInstrumentAfterFirstPayment settlers issuer [observableCid]
+  verifyNoLifecycleEffects [publicParty] (subtractDays maturityDate 1) swapInstrumentAfterFirstPayment issuer [observableCid]
 
   -- Lifecycle on the second payment date, which is also the expiry date. Verify the lifecycle effects for fix rate and asset performance payments.
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 0.0322411245 cashInstrumentCid]
-  lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment settlers issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
+  lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
 
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/CreditDefault.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/CreditDefault.daml
@@ -79,29 +79,28 @@ runCreditEvent = script do
   let observableCids = [observableDefaultProbabilityCid, observableRecoveryRateCid]
 
   -- One day before the first payment date: try to lifecycle and verify that there are no lifecycle effects.
-  let settlers = singleton custodian
-  verifyNoLifecycleEffects [publicParty] (subtractDays firstPaymentDate 1) swapInstrument settlers issuer observableCids
+  verifyNoLifecycleEffects [publicParty] (subtractDays firstPaymentDate 1) swapInstrument issuer observableCids
 
   -- First payment date: Lifecycle and verify the lifecycle effects for the fix payment.
   let
     expectedConsumedQuantities = [Instrument.qty 0.001675 cashInstrument]
     expectedProducedQuantities = []
-  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the first payment date: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment settlers issuer observableCids
+  verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment issuer observableCids
 
   -- Credit event date: Lifecycle and verify that there is a lifecycle effect for the (1-recoveryRate) payment.
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 0.4 cashInstrument]
-  swapInstrumentAfterCreditEvent <- lifecycleAndVerifySwapPaymentEffects [publicParty] creditEventDate swapInstrumentAfterFirstPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterCreditEvent <- lifecycleAndVerifySwapPaymentEffects [publicParty] creditEventDate swapInstrumentAfterFirstPayment issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after credit event date: try to lifecycle and verify that the instrument has automatically expired.
   -- TODO: implement this after having included expire logic (of Until nodes) somewhere in the lifecycle process.
 
   -- Second payment date: try to lifecycle and verify that there are no lifecycle effects (because a credit event has happened).
-  verifyNoLifecycleEffects [publicParty] maturityDate swapInstrumentAfterCreditEvent settlers issuer observableCids
+  verifyNoLifecycleEffects [publicParty] maturityDate swapInstrumentAfterCreditEvent issuer observableCids
 
   pure ()
 
@@ -139,19 +138,18 @@ runCreditEventOnPaymentDate = script do
 
   -- First payment date: Lifecycle and verify the lifecycle effects for the fix payment.
   let
-    settlers = singleton custodian
     expectedConsumedQuantities = [Instrument.qty 0.001675 cashInstrument]
     expectedProducedQuantities = []
-  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the first payment date: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment settlers issuer observableCids
+  verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment issuer observableCids
 
   -- Credit event date: Lifecycle and verify that there is a lifecycle effect for the (1-recoveryRate) payment.
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 0.4 cashInstrument]
-  swapInstrumentAfterCreditEvent <- lifecycleAndVerifySwapPaymentEffects [publicParty] creditEventDate swapInstrumentAfterFirstPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterCreditEvent <- lifecycleAndVerifySwapPaymentEffects [publicParty] creditEventDate swapInstrumentAfterFirstPayment issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after credit event date: try to lifecycle and verify that the instrument has automatically expired.
   -- TODO: implement this after having included expire logic (of Until nodes) somewhere in the lifecycle process.
@@ -188,26 +186,25 @@ runNoCreditEvent = script do
   let observableCids = [observableDefaultProbabilityCid]
 
   -- One day before the first payment date: try to lifecycle and verify that there are no lifecycle effects.
-  let settlers = singleton custodian
-  verifyNoLifecycleEffects [publicParty] (subtractDays firstPaymentDate 1) swapInstrument settlers issuer observableCids
+  verifyNoLifecycleEffects [publicParty] (subtractDays firstPaymentDate 1) swapInstrument issuer observableCids
 
   -- First payment date: Lifecycle and verify the lifecycle effects for the fix payment.
   let
     expectedConsumedQuantities = [Instrument.qty 0.001675 cashInstrument]
     expectedProducedQuantities = []
-  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the first payment date: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment settlers issuer observableCids
+  verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment issuer observableCids
 
   -- Second payment date: Lifecycle and verify the lifecycle effects for the fix payment.
   let
     expectedConsumedQuantities = [Instrument.qty 0.0049691667 cashInstrument]
     expectedProducedQuantities = []
-  swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the maturity: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (addDays maturityDate 1) swapInstrumentAfterSecondPayment settlers issuer observableCids
+  verifyNoLifecycleEffects [publicParty] (addDays maturityDate 1) swapInstrumentAfterSecondPayment issuer observableCids
 
   -- TODO: same as above, after having included expire logic (of Until nodes) somewhere in the lifecycle process, verify that the instrument automatically expires as expected.
 
@@ -242,22 +239,21 @@ runCreditEventAfterMaturity = script do
 
   -- First payment date: Lifecycle and verify the lifecycle effects for the fix payment.
   let
-    settlers = singleton custodian
     expectedConsumedQuantities = [Instrument.qty 0.001675 cashInstrument]
     expectedProducedQuantities = []
-  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- Second payment date: Lifecycle and verify the lifecycle effects for the fix payment.
   let
     expectedConsumedQuantities = [Instrument.qty 0.0049691667 cashInstrument]
     expectedProducedQuantities = []
-  swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the maturity: no payment is made, instrument expires
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = []
-  lifecycleAndVerifySwapPaymentEffects [publicParty] (addDays maturityDate 1) swapInstrumentAfterFirstPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
+  lifecycleAndVerifySwapPaymentEffects [publicParty] (addDays maturityDate 1) swapInstrumentAfterFirstPayment issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- TODO check that instrument expires
 

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Currency.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Currency.daml
@@ -63,27 +63,25 @@ run = script do
 
   swapInstrument <- originateCurrencySwap custodian issuer "SwapTest1" "Currency swap" observers now issueDate holidayCalendarId calendarDataProvider firstPaymentDate maturityDate dayCountConvention businessDayConvention baseRate foreignRate paymentPeriod paymentPeriodMultiplier cashInstrumentCid foreignCashInstrumentCid fxRate issuerPaysBase
 
-  let settlers = singleton custodian
-
   -- One day before the first payment date: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (subtractDays firstPaymentDate 1) swapInstrument settlers issuer []
+  verifyNoLifecycleEffects [publicParty] (subtractDays firstPaymentDate 1) swapInstrument issuer []
 
   -- First payment date: Lifecycle and verify the lifecycle effects for base currency and foreign currency payments.
   let
     expectedConsumedQuantities = [Instrument.qty 0.0025 cashInstrumentCid]
     expectedProducedQuantities = [Instrument.qty 0.0018333333 foreignCashInstrumentCid]
-  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer [] expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument issuer [] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the first payment date: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment settlers issuer []
+  verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment issuer []
 
   -- One day before expiry: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (subtractDays maturityDate 1) swapInstrumentAfterFirstPayment settlers issuer []
+  verifyNoLifecycleEffects [publicParty] (subtractDays maturityDate 1) swapInstrumentAfterFirstPayment issuer []
 
   -- Lifecycle on the second payment date, which is also the expiry date. Verify the lifecycle effects for base currency and foreign currency payments.
   let
     expectedConsumedQuantities = [Instrument.qty 0.0074166667 cashInstrumentCid]
     expectedProducedQuantities = [Instrument.qty 0.0054388889 foreignCashInstrumentCid]
-  lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment settlers issuer [] expectedConsumedQuantities expectedProducedQuantities
+  lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment issuer [] expectedConsumedQuantities expectedProducedQuantities
 
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/ForeignExchange.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/ForeignExchange.daml
@@ -40,27 +40,25 @@ run = script do
 
   swapInstrument <- originateForeignExchangeSwap custodian issuer "SwapTest1" "Foreign exchange swap" observers now issueDate firstPaymentDate maturityDate cashInstrumentCid foreignCashInstrumentCid firstFxRate finalFxRate
 
-  let settlers = singleton custodian
-
   -- One day before the first payment date: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (subtractDays firstPaymentDate 1) swapInstrument settlers issuer []
+  verifyNoLifecycleEffects [publicParty] (subtractDays firstPaymentDate 1) swapInstrument issuer []
 
   -- First payment date: Lifecycle and verify the lifecycle effects for the fx payments.
   let
     expectedConsumedQuantities = [Instrument.qty fxRateSameCurrency cashInstrumentCid]
     expectedProducedQuantities = [Instrument.qty firstFxRate foreignCashInstrumentCid]
-  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer [] expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument issuer [] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the first payment date: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment settlers issuer []
+  verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment issuer []
 
   -- One day before expiry: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (subtractDays maturityDate 1) swapInstrumentAfterFirstPayment settlers issuer []
+  verifyNoLifecycleEffects [publicParty] (subtractDays maturityDate 1) swapInstrumentAfterFirstPayment issuer []
 
   -- Lifecycle on the second payment date, which is also the expiry date. Verify the lifecycle effects for the fx payments.
   let
     expectedConsumedQuantities = [Instrument.qty finalFxRate foreignCashInstrumentCid]
     expectedProducedQuantities = [Instrument.qty fxRateSameCurrency cashInstrumentCid]
-  lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment settlers issuer [] expectedConsumedQuantities expectedProducedQuantities
+  lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment issuer [] expectedConsumedQuantities expectedProducedQuantities
 
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -188,26 +188,25 @@ run = script do
   swapInstrument <- originateFpmlSwap custodian issuer "SwapTest1" "Interest rate swap" observers now swapStreams calendarDataProvider cashInstrumentCid issuerPartyRef
 
   -- One day before the first payment date: try to lifecycle and verify that there are no lifecycle effects.
-  let settlers = singleton custodian
-  verifyNoLifecycleEffects [publicParty] (subtractDays firstPaymentDate 1) swapInstrument settlers issuer [observableCid]
+  verifyNoLifecycleEffects [publicParty] (subtractDays firstPaymentDate 1) swapInstrument issuer [observableCid]
 
   -- First payment date: Lifecycle and verify the lifecycle effects for fix and floating payments.
   let
     expectedConsumedQuantities = [Instrument.qty 0.0014466167 cashInstrumentCid]
     expectedProducedQuantities = []
-  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the first payment date: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment settlers issuer [observableCid]
+  verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment issuer [observableCid]
 
   -- One day before expiry: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (subtractDays maturityDate 1) swapInstrumentAfterFirstPayment settlers issuer [observableCid]
+  verifyNoLifecycleEffects [publicParty] (subtractDays maturityDate 1) swapInstrumentAfterFirstPayment issuer [observableCid]
 
   -- Lifecycle on the second payment date, which is also the expiry date. Verify the lifecycle effects for fix and floating payments.
   let
     expectedConsumedQuantities = [Instrument.qty 0.0044660695 cashInstrumentCid]
     expectedProducedQuantities = []
-  lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment settlers issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
+  lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
 
   pure ()
 
@@ -339,13 +338,11 @@ runStubRateInterpolation = script do
 
   swapInstrument <- originateFpmlSwap custodian issuer "SwapTest1" "Interest rate swap" observers now swapStreams calendarDataProvider cashInstrumentCid issuerPartyRef
 
-  let settlers = singleton custodian
-
   -- First payment date (after weekend adjustment): Lifecycle stub period and verify the lifecycle effects for floating payment.
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 0.001867875 cashInstrumentCid]  -- interpolated stub rate from the ISDA paper
-  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] (addDays firstRegularPeriodDate 1) swapInstrument settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] (addDays firstRegularPeriodDate 1) swapInstrument issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   pure ()
 
@@ -538,38 +535,37 @@ runDualStubSampleTrade = script do
   swapInstrument <- originateFpmlSwap custodian issuer "SwapTest1" "Interest rate swap" observers now swapStreams calendarDataProvider cashInstrumentCid issuerPartyRef
 
   -- One day before the first payment date: try to lifecycle and verify that there are no lifecycle effects.
-  let settlers = singleton custodian
-  verifyNoLifecycleEffects [publicParty] (subtractDays firstRegularPeriodDate 1) swapInstrument settlers issuer observableCids
+  verifyNoLifecycleEffects [publicParty] (subtractDays firstRegularPeriodDate 1) swapInstrument issuer observableCids
 
   -- First payment date: Lifecycle and verify the net fix vs floating payment (stub period).
   let
     expectedConsumedQuantities = [Instrument.qty 83.3333 cashInstrumentCid]
     expectedProducedQuantities = []
-  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstRegularPeriodDate swapInstrument settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstRegularPeriodDate swapInstrument issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- Second payment date: Lifecycle and verify the floating payment (regular period, 3M).
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 3791.6667 cashInstrumentCid]
-  swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] secondRegularPeriodDate swapInstrumentAfterFirstPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] secondRegularPeriodDate swapInstrumentAfterFirstPayment issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- Third payment date: Lifecycle and verify the floating payment (regular period, 3M).
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 3750.0 cashInstrumentCid]
-  swapInstrumentAfterThirdPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] thirdRegularPeriodDate swapInstrumentAfterSecondPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterThirdPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] thirdRegularPeriodDate swapInstrumentAfterSecondPayment issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- Fourth payment date: Lifecycle and verify the floating payment (regular period, 3M).
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 3833.3333 cashInstrumentCid]
-  swapInstrumentAfterFourthPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] lastRegularPeriodDate swapInstrumentAfterThirdPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFourthPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] lastRegularPeriodDate swapInstrumentAfterThirdPayment issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- Final payment date: Lifecycle and verify the net fix vs floating payment (stub period).
   let
     expectedConsumedQuantities = [Instrument.qty 17324.3727 cashInstrumentCid]
     expectedProducedQuantities = []
-  swapInstrumentAfterFinalPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFourthPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFinalPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFourthPayment issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   pure ()
 
@@ -757,37 +753,36 @@ runSeparatePaymentFrequencySampleTrade = script do
   swapInstrument <- originateFpmlSwap custodian issuer "SwapTest1" "Interest rate swap" observers now swapStreams calendarDataProvider cashInstrumentCid issuerPartyRef
 
   -- One day before the first payment date: try to lifecycle and verify that there are no lifecycle effects.
-  let settlers = singleton custodian
-  verifyNoLifecycleEffects [publicParty] (subtractDays firstRegularPeriodDate 1) swapInstrument settlers issuer observableCids
+  verifyNoLifecycleEffects [publicParty] (subtractDays firstRegularPeriodDate 1) swapInstrument issuer observableCids
 
   -- First payment date: Lifecycle and verify the net fix vs floating payment (stub period).
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 916.6665 cashInstrumentCid]
-  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstRegularPeriodDate swapInstrument settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstRegularPeriodDate swapInstrument issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- Lifecycle and verify the fix payment (regular period, 3M).
   let
     expectedConsumedQuantities = [Instrument.qty 25000.0 cashInstrumentCid]
     expectedProducedQuantities = []
-  swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] (date 2023 Jan 26) swapInstrumentAfterFirstPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] (date 2023 Jan 26) swapInstrumentAfterFirstPayment issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- Lifecycle and verify the fix (regular period, 3M). The 6M float payment is calculated but only paid every 12M.
   let
     expectedConsumedQuantities = [Instrument.qty 25000.0 cashInstrumentCid]
     expectedProducedQuantities = []
-  swapInstrumentAfterThirdPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] (date 2023 Apr 26) swapInstrumentAfterSecondPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterThirdPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] (date 2023 Apr 26) swapInstrumentAfterSecondPayment issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- Lifecycle and verify the fix payment (regular period, 3M).
   let
     expectedConsumedQuantities = [Instrument.qty 25000.0 cashInstrumentCid]
     expectedProducedQuantities = []
-  swapInstrumentAfterFourthPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] (date 2023 Jul 26) swapInstrumentAfterThirdPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFourthPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] (date 2023 Jul 26) swapInstrumentAfterThirdPayment issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   -- Lifecycle and verify the fix payment (regular period, 3M) + floating payment (regular period, 12M).
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities = [Instrument.qty 38368.0555 cashInstrumentCid]
-  lifecycleAndVerifySwapPaymentEffects [publicParty] (date 2023 Oct 26) swapInstrumentAfterFourthPayment settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities
+  lifecycleAndVerifySwapPaymentEffects [publicParty] (date 2023 Oct 26) swapInstrumentAfterFourthPayment issuer observableCids expectedConsumedQuantities expectedProducedQuantities
 
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/InterestRate.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/InterestRate.daml
@@ -66,25 +66,24 @@ run = script do
   swapInstrument <- originateInterestRateSwap custodian issuer "SwapTest1" "Interest rate swap" observers now issueDate holidayCalendarId calendarDataProvider firstPaymentDate maturityDate dayCountConvention businessDayConvention fixRate paymentPeriod paymentPeriodMultiplier cashInstrumentCid referenceRateId issuerPaysFix
 
   -- One day before the first payment date: try to lifecycle and verify that there are no lifecycle effects.
-  let settlers = singleton custodian
-  verifyNoLifecycleEffects [publicParty] (subtractDays firstPaymentDate 1) swapInstrument settlers issuer [observableCid]
+  verifyNoLifecycleEffects [publicParty] (subtractDays firstPaymentDate 1) swapInstrument issuer [observableCid]
 
   -- First payment date: Lifecycle and verify the lifecycle effects for fix and floating payments.
   let
     expectedConsumedQuantities = [Instrument.qty 0.0014466167 cashInstrumentCid]
     expectedProducedQuantities = []
-  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument settlers issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
+  swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty] firstPaymentDate swapInstrument issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
 
   -- One day after the first payment date: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment settlers issuer [observableCid]
+  verifyNoLifecycleEffects [publicParty] (addDays firstPaymentDate 1) swapInstrumentAfterFirstPayment issuer [observableCid]
 
   -- One day before expiry: try to lifecycle and verify that there are no lifecycle effects.
-  verifyNoLifecycleEffects [publicParty] (subtractDays maturityDate 1) swapInstrumentAfterFirstPayment settlers issuer [observableCid]
+  verifyNoLifecycleEffects [publicParty] (subtractDays maturityDate 1) swapInstrumentAfterFirstPayment issuer [observableCid]
 
   -- Lifecycle on the second payment date, which is also the expiry date. Verify the lifecycle effects for fix and floating payments.
   let
     expectedConsumedQuantities = [Instrument.qty 0.0044660695 cashInstrumentCid]
     expectedProducedQuantities = []
-  lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment settlers issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
+  lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
 
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -117,8 +117,8 @@ originateForeignExchangeSwap depository issuer label description observers lastE
   createReference cid depository issuer observers
 
 -- | Lifecycle the instrument as of this date. This is a general function that can be used for both bonds and swaps.
-lifecycleInstrument : [Party] -> Date -> Instrument.K -> Parties -> Party -> [ContractId NumericObservable.I] -> Script (ContractId Lifecycle.I, [ContractId Effect.I])
-lifecycleInstrument readAs today instrument settlers issuer observableCids = do
+lifecycleInstrument : [Party] -> Date -> Instrument.K -> Party -> [ContractId NumericObservable.I] -> Script (ContractId Lifecycle.I, [ContractId Effect.I])
+lifecycleInstrument readAs today instrument issuer observableCids = do
   -- CREATE_CLOCK_FOR_BOND_LIFECYCLING_BEGIN
   -- create clock and clock update event
   (clockCid, clockEventCid) <- createClockAndEvent (S.singleton issuer) today S.empty
@@ -127,21 +127,21 @@ lifecycleInstrument readAs today instrument settlers issuer observableCids = do
   -- LIFECYCLE_BOND_BEGIN
   -- Try to lifecycle instrument
   (lifecycleCid, effectCids) <- Instrument.submitExerciseInterfaceByKeyCmd @Lifecycle.I [issuer] readAs instrument
-    Lifecycle.Evolve with settlers; eventCid = clockEventCid; observableCids; ruleName = "Time"; timeObservableCid = clockCid
+    Lifecycle.Evolve with eventCid = clockEventCid; observableCids; ruleName = "Time"; timeObservableCid = clockCid
   -- LIFECYCLE_BOND_END
 
   pure (lifecycleCid, effectCids)
 
 -- | Verify a that there are no lifecycle effects of the instrument on this date. This is a general function that can be used for both bonds and swaps.
-verifyNoLifecycleEffects : [Party] -> Date -> Instrument.K -> Parties -> Party -> [ContractId NumericObservable.I] -> Script ()
-verifyNoLifecycleEffects readAs today instrument settlers issuer observableCids = do
-  (bondLifecycleCid2, effectCids) <- lifecycleInstrument readAs today instrument settlers issuer observableCids
+verifyNoLifecycleEffects : [Party] -> Date -> Instrument.K -> Party -> [ContractId NumericObservable.I] -> Script ()
+verifyNoLifecycleEffects readAs today instrument issuer observableCids = do
+  (bondLifecycleCid2, effectCids) <- lifecycleInstrument readAs today instrument issuer observableCids
   assertMsg ("There should be no lifecycle effects on " <> show today) (null effectCids)
 
 -- | Verify the payments from a payment date of a swap (excluding settlement)
-lifecycleAndVerifySwapPaymentEffects : [Party] -> Date -> Instrument.K -> Parties -> Party -> [ContractId NumericObservable.I] -> [Instrument.Q] -> [Instrument.Q] -> Script Instrument.K
-lifecycleAndVerifySwapPaymentEffects readAs today swapInstrument settlers issuer observableCids expectedConsumedQuantities expectedProducedQuantities = do
-  (swapLifecycleCid, effectCids) <- lifecycleInstrument readAs today swapInstrument settlers issuer observableCids
+lifecycleAndVerifySwapPaymentEffects : [Party] -> Date -> Instrument.K -> Party -> [ContractId NumericObservable.I] -> [Instrument.Q] -> [Instrument.Q] -> Script Instrument.K
+lifecycleAndVerifySwapPaymentEffects readAs today swapInstrument issuer observableCids expectedConsumedQuantities expectedProducedQuantities = do
+  (swapLifecycleCid, effectCids) <- lifecycleInstrument readAs today swapInstrument issuer observableCids
   let effectCid = head effectCids -- this gives a better error message in case there are no effects
 
   newSwapInstrumentKey <- submit issuer do


### PR DESCRIPTION
We had `settlers` both in the `Effect` as well as in the rule to claim the `Effect`. 

I removed it from the former, as in principle `Effect`s can be used without the settlement layer of the library