### PR TITLE
Remove unnecessary signatory constraints

### DIFF
--- a/src/main/daml/Daml/Finance/Lifecycle/Rule/Claim.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Rule/Claim.daml
@@ -40,8 +40,6 @@ template Rule
         holdings <- mapA fetch holdingCids
         forA_ holdings \h -> do
           assertMsg "The provided holding does not reference the expected instrument." $ getInstrument h == effectView.targetInstrument
-          assertMsg "The settlement rule is missing the signature of a holding custodian" $ getCustodian h `member` providers
-          assertMsg "The settlement rule is missing the signature of a holding owner" $ getOwner h `member` providers
 
         -- Calculate settlement steps
         let


### PR DESCRIPTION
Now that we the instrument holding is not upgraded immediately, we no longer need the `owner` and `custodian` as signatories of the `Claim` rule.