### PR TITLE
Rework `FactoryWithIntermediaries`, add example of atomic effect settlement across an account hierarchy

### DIFF
--- a/package/main/daml/Daml.Finance.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Settlement/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.4.0
 name: daml-finance-settlement
 source: daml
-version: 0.1.6
+version: 0.1.7
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
@@ -17,7 +17,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.7/daml-finance-interface-lifecycle-0.1.7.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.1.7/daml-finance-interface-instrument-equity-0.1.7.dar
   - .lib/daml-finance/Daml.Finance.Holding/0.1.5/daml-finance-holding-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/0.1.6/daml-finance-settlement-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/0.1.7/daml-finance-settlement-0.1.7.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.7/daml-finance-lifecycle-0.1.7.dar
   - .lib/daml-finance/Daml.Finance.Data/0.1.6/daml-finance-data-0.1.6.dar
   - .lib/daml-finance/Daml.Finance.Instrument.Equity/0.1.7/daml-finance-instrument-equity-0.1.7.dar

--- a/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
@@ -21,7 +21,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.7/daml-finance-interface-lifecycle-0.1.7.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.7/daml-finance-interface-instrument-generic-0.1.7.dar
   - .lib/daml-finance/Daml.Finance.Holding/0.1.5/daml-finance-holding-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/0.1.6/daml-finance-settlement-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/0.1.7/daml-finance-settlement-0.1.7.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.7/daml-finance-lifecycle-0.1.7.dar
   - .lib/daml-finance/Daml.Finance.Claims/0.1.0/daml-finance-claims-0.1.0.dar
   - .lib/daml-finance/Daml.Finance.Data/0.1.6/daml-finance-data-0.1.6.dar

--- a/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.4.0
 name: daml-finance-settlement-test
 source: daml
-version: 0.1.7
+version: 0.1.8
 dependencies:
   - daml-prim
   - daml-stdlib
@@ -17,7 +17,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.6/daml-finance-interface-settlement-0.1.6.dar
   - .lib/daml-finance/Daml.Finance.Holding/0.1.5/daml-finance-holding-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Account/0.1.0/daml-finance-account-0.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/0.1.6/daml-finance-settlement-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/0.1.7/daml-finance-settlement-0.1.7.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/0.1.7/daml-finance-test-util-0.1.7.dar
 build-options:
   - --target=1.15

--- a/src/main/daml/Daml/Finance/Settlement/Factory.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Factory.daml
@@ -3,14 +3,15 @@
 
 module Daml.Finance.Settlement.Factory where
 
-import DA.List (groupOn, head, isSuffixOf, stripSuffix, tails)
+import DA.List (groupOn, head)
 import DA.Map qualified as M (Map, fromList, lookup)
 import DA.Optional (fromSomeNote)
 import DA.Set (empty)
 import Daml.Finance.Interface.Settlement.Factory qualified as Factory (I, Instruct(..), View(..))
-import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), Step(..))
+import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..))
 import Daml.Finance.Interface.Types.Common (Id(..), Parties)
 import Daml.Finance.Settlement.Batch (Batch(..))
+import Daml.Finance.Settlement.Hierarchy (Hierarchy(..), unfoldStep)
 import Daml.Finance.Settlement.Instruction (Instruction(..))
 import Daml.Finance.Util.Common (mapWithIndex)
 
@@ -48,7 +49,7 @@ template FactoryWithIntermediaries
       -- ^ Party providing the facility to create settlement instructions.
     observers : Parties
       -- ^ Observers.
-    paths : M.Map Text Path
+    paths : M.Map Text Hierarchy
       -- ^ Hierarchical paths used to settle holding transfers. A path is specified for each instrument label.
   where
     signatory provider
@@ -72,36 +73,3 @@ template FactoryWithIntermediaries
         instructionCids <- mapA (fmap toInterfaceContractId . create) instructions
         batchCid <- toInterfaceContractId <$> create Batch with requestors = instructors; settlers; id; description; contextId; stepsWithInstructionId = zip groupedSteps instructionIds
         pure (batchCid, instructionCids)
-
--- | Data type that describes a hierarchical account structure between two parties for holdings on an instrument.
-data Path = Path
-  with
-    senderPath : [Party]
-      -- ^ Path from the sender to the root custodian of the holding. If the sender `p` is the root custodian, it should be `[p, p]`.
-    receiverPath : [Party]
-      -- ^ Path from the receiver to the root custodian of the holding. If the receiver `p` is the root custodian, it should be `[p, p]`.
-  deriving (Eq, Show)
-
--- | HIDE
--- Given a sender path and a receiver path, calculate the route to transfer a holding from sender to receiver.
--- We assume that transfers can only be done between accounts at the same custodian.
--- Returns `None` if no such route can be found. Otherwise, a list of (sender, receiver) pairs is returned.
-getRoute : (Eq a) => [a] -> [a] -> Optional [(a,a)]
-getRoute senderPath receiverPath =
-  case filter (`isSuffixOf` receiverPath) $ tails senderPath of
-  [] -> None
-  h :: _ -> do
-    fromRoute <- stripSuffix h senderPath
-    toRoute <- reverse <$> stripSuffix h receiverPath
-    let fullRoute = fromRoute <> toRoute
-    pure $ zip fullRoute (drop 1 fullRoute)
-
--- | HIDE
--- Given a hierarchical path, unfold a step from sender to receiver (resp. receiver to sender) onto the corresponding route.
--- Returns `None` if no route can be found.
-unfoldStep : Path -> Step -> Optional [Step]
-unfoldStep path step | step.sender == head path.senderPath =
-  map (\(sender, receiver) -> Step with sender; receiver; quantity = step.quantity ) <$> getRoute path.senderPath path.receiverPath
-unfoldStep path step | step.sender == head path.receiverPath =
-  map (\(sender, receiver) -> Step with sender; receiver; quantity = step.quantity ) <$> getRoute path.receiverPath path.senderPath
-unfoldStep _ _ = error "One of the parties is neither the sender, nor the receiver."

--- a/src/main/daml/Daml/Finance/Settlement/Hierarchy.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Hierarchy.daml
@@ -7,7 +7,7 @@ import DA.List (isSuffixOf, stripInfix, stripSuffix, tails)
 import DA.Optional (isSome)
 import Daml.Finance.Interface.Settlement.Types (Step(..))
 
--- | Data type that describes a hierarchical account structure between two parties for holdings on an instrument.
+-- | Data type that describes a hierarchical account structure among multiple parties for holdings on an instrument.
 data Hierarchy = Hierarchy
   with
     rootCustodian : Party

--- a/src/main/daml/Daml/Finance/Settlement/Hierarchy.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Hierarchy.daml
@@ -1,3 +1,6 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module Daml.Finance.Settlement.Hierarchy
   ( Hierarchy(..)
   , unfoldStep
@@ -11,12 +14,12 @@ import Daml.Finance.Interface.Settlement.Types (Step(..))
 data Hierarchy = Hierarchy
   with
     rootCustodian : Party
-      -- ^ Root custodian of the holding.
+      -- ^ Root custodian of the instrument.
     pathsToRootCustodian : [[Party]]
-      -- ^ Paths from "leaf" holder to the root custodian of the holding.
+      -- ^ Paths from "leaf" owners to the root custodian of the instrument.
   deriving (Eq, Show)
 
--- Given a hierarchical path, unfold a step from sender to receiver (resp. receiver to sender) onto the corresponding route.
+-- Given a hierarchy, unfold a step from sender to receiver onto the corresponding route.
 -- Returns `None` if no route can be found.
 unfoldStep : Hierarchy -> Step -> Optional [Step]
 unfoldStep hierarchy step = do

--- a/src/main/daml/Daml/Finance/Settlement/Hierarchy.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Hierarchy.daml
@@ -1,0 +1,61 @@
+module Daml.Finance.Settlement.Hierarchy
+  ( Hierarchy(..)
+  , unfoldStep
+  ) where
+
+import DA.List (isSuffixOf, stripInfix, stripSuffix, tails)
+import DA.Optional (isSome)
+import Daml.Finance.Interface.Settlement.Types (Step(..))
+
+-- | Data type that describes a hierarchical account structure between two parties for holdings on an instrument.
+data Hierarchy = Hierarchy
+  with
+    rootCustodian : Party
+      -- ^ Root custodian of the holding.
+    pathsToRootCustodian : [[Party]]
+      -- ^ Paths from "leaf" holder to the root custodian of the holding.
+  deriving (Eq, Show)
+
+-- Given a hierarchical path, unfold a step from sender to receiver (resp. receiver to sender) onto the corresponding route.
+-- Returns `None` if no route can be found.
+unfoldStep : Hierarchy -> Step -> Optional [Step]
+unfoldStep hierarchy step = do
+  senderPath <- locateParty step.sender hierarchy
+  receiverPath <- locateParty step.receiver hierarchy
+  map (\(sender, receiver) -> Step with sender; receiver; quantity = step.quantity ) <$> getRoute senderPath receiverPath
+
+-- | HIDE
+-- Given a sender path to root custodian and a receiver path to root custodian,
+-- calculate the route to transfer a holding from sender to receiver.
+-- We assume that transfers can only be done between accounts at the same custodian.
+-- Returns `None` if no such route can be found. Otherwise, a list of (sender, receiver) pairs is returned.
+getRoute : (Eq a) => [a] -> [a] -> Optional [(a,a)]
+getRoute senderPath receiverPath | senderPath `isSuffixOf` receiverPath = do
+  -- sending down the chain : cut the receiver path at the sender and flip the chain
+  fullRoute <- reverse <$> stripSuffix (drop 1 senderPath) receiverPath
+  pure $ zip fullRoute (drop 1 fullRoute)
+getRoute senderPath receiverPath | receiverPath `isSuffixOf` senderPath = do
+  -- sending up the chain : cut the sender path at the receiver
+  fullRoute <- stripSuffix (drop 1 receiverPath) senderPath
+  pure $ zip fullRoute (drop 1 fullRoute)
+getRoute senderPath receiverPath =
+  -- sending up and then down the chain
+  case filter (`isSuffixOf` receiverPath) $ tails senderPath of
+  [] -> None
+  h :: _ -> do
+    fromRoute <- stripSuffix h senderPath
+    toRoute <- reverse <$> stripSuffix h receiverPath
+    let fullRoute = fromRoute <> toRoute
+    pure $ zip fullRoute (drop 1 fullRoute)
+
+-- | HIDE
+-- Locate a party within a hierarchy, returning the path to the root custodian.
+-- Returns `None` if no path can could be found.
+-- Returns an error if multiple paths could be found.
+locateParty : Party -> Hierarchy -> Optional [Party]
+locateParty p h | p == h.rootCustodian = pure [p, p]
+locateParty p h =
+  case filter isSome $ map (stripInfix [p]) h.pathsToRootCustodian of
+  [Some (_, path)] -> pure $ [p] <> path <> [h.rootCustodian]
+  [] -> None
+  _ -> error "Multiple paths found"

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
@@ -147,12 +147,12 @@ runIntermediatedLifecyclingNonAtomic = script do
     today = toDateUTC now
 
   (cashInstrument, cashRoute) <- originateCashAndDefineRoute parties now
-  issuerCashTransferableCid <- Account.credit [publicParty] cashInstrument 20_000.0 issuerCashAccount
+  issuerCashHoldingCid <- Account.credit [publicParty] cashInstrument 20_000.0 issuerCashAccount
 
   -- Originate and distribute bond
   (bondInstrument, bondRoute) <- originateSecurityAndDefineRoute parties now cashInstrument
-  csdGenericTransferableCid <- Account.credit [publicParty] bondInstrument 1_000_000.0 csdAccountAtIssuer
-  investorGenericTransferableCid <- Account.credit [publicParty] bondInstrument 1_000_000.0 investorSecuritiesAccount
+  csdBondHoldingCid <- Account.credit [publicParty] bondInstrument 1_000_000.0 csdAccountAtIssuer
+  investorBondHoldingCid <- Account.credit [publicParty] bondInstrument 1_000_000.0 investorSecuritiesAccount
 
   -- create clock and clock update event
   (clockCid, clockEventCid) <- createClockAndEvent (singleton issuer) today empty
@@ -178,8 +178,8 @@ runIntermediatedLifecyclingNonAtomic = script do
   (effectCid, newInstrumentHoldingCid, [cashHolding]) <- submitMulti [issuer] [publicParty] do
     exerciseCmd settle1Cid ClaimAndSettle
       with
-        instrumentHoldingCid = csdGenericTransferableCid
-        cashHoldingCid = issuerCashTransferableCid
+        instrumentHoldingCid = csdBondHoldingCid
+        cashHoldingCid = issuerCashHoldingCid
         effectCid
 
   -- investor claims effect against CSD
@@ -205,14 +205,14 @@ runIntermediatedLifecyclingNonAtomic = script do
   result <- submitMulti [investor] [publicParty] do
     exerciseCmd lifecycleClaimRuleCid Claim.ClaimEffect with
       claimer = investor
-      holdingCids = [investorGenericTransferableCid]
+      holdingCids = [investorBondHoldingCid]
       effectCid
       batchId = Id "CouponSettlement"
 
   let [investorBondInstructionCid, csdBondInstructionCid, csdCashInstructionCid, bankCashInstructionCid] = result.instructionCids
 
   -- Allocate instructions
-  (investorBondInstructionCid, _) <- submit investor do exerciseCmd investorBondInstructionCid Instruction.Allocate with actors = singleton investor; allocation = Pledge $ coerceContractId investorGenericTransferableCid
+  (investorBondInstructionCid, _) <- submit investor do exerciseCmd investorBondInstructionCid Instruction.Allocate with actors = singleton investor; allocation = Pledge $ coerceContractId investorBondHoldingCid
   (csdBondInstructionCid, _) <- submit csd do exerciseCmd csdBondInstructionCid Instruction.Allocate with actors = singleton csd; allocation = CreditReceiver
   (csdCashInstructionCid, _) <- submit csd do exerciseCmd csdCashInstructionCid Instruction.Allocate with actors = singleton csd; allocation = Pledge cashHolding
   (bankCashInstructionCid, _) <- submit bank do exerciseCmd bankCashInstructionCid Instruction.Allocate with actors = singleton bank; allocation = CreditReceiver
@@ -228,13 +228,13 @@ runIntermediatedLifecyclingNonAtomic = script do
     exerciseCmd bankCashInstructionCid Instruction.Approve with actors = singleton investor; approval = TakeDelivery investorCashAccount
 
   -- Settle batch
-  [investorGenericTransferableCid, bankCashTransferableCid, investorCashTransferableCid] <- submitMulti (toList settlers) [publicParty] do exerciseCmd result.batchCid Batch.Settle with actors = settlers
+  [investorBondHoldingCid, bankCashHoldingCid, investorCashHoldingCid] <- submitMulti (toList settlers) [publicParty] do exerciseCmd result.batchCid Batch.Settle with actors = settlers
 
   -- Assert state
   Holding.verifyOwnerOfHolding
-    [ (investor, investorGenericTransferableCid)
-    , (bank, coerceContractId bankCashTransferableCid)
-    , (investor, coerceContractId investorCashTransferableCid)
+    [ (investor, investorBondHoldingCid)
+    , (bank, coerceContractId bankCashHoldingCid)
+    , (investor, coerceContractId investorCashHoldingCid)
     ]
 
   pure ()
@@ -261,12 +261,12 @@ runIntermediatedLifecyclingAtomic = script do
     today = toDateUTC now
 
   (cashInstrument, cashRoute) <- originateCashAndDefineRoute parties now
-  issuerCashTransferableCid <- Account.credit [publicParty] cashInstrument 20_000.0 issuerCashAccount
+  issuerCashHoldingCid <- Account.credit [publicParty] cashInstrument 20_000.0 issuerCashAccount
 
   -- Originate and distribute bond
   (bondInstrument, bondRoute) <- originateSecurityAndDefineRoute parties now cashInstrument
-  csdGenericTransferableCid <- Account.credit [publicParty] bondInstrument 1_000_000.0 csdAccountAtIssuer
-  investorGenericTransferableCid <- Account.credit [publicParty] bondInstrument 1_000_000.0 investorSecuritiesAccount
+  csdBondHoldingCid <- Account.credit [publicParty] bondInstrument 1_000_000.0 csdAccountAtIssuer
+  investorBondHoldingCid <- Account.credit [publicParty] bondInstrument 1_000_000.0 investorSecuritiesAccount
 
   -- create clock and clock update event
   (clockCid, clockEventCid) <- createClockAndEvent (singleton issuer) today empty
@@ -295,7 +295,7 @@ runIntermediatedLifecyclingAtomic = script do
   result <- submit csd do
     exerciseCmd lifecycleClaimRuleCid Claim.ClaimEffect with
       claimer = csd
-      holdingCids = [csdGenericTransferableCid, investorGenericTransferableCid]
+      holdingCids = [csdBondHoldingCid, investorBondHoldingCid]
       effectCid
       batchId = Id "CouponSettlement"
 
@@ -321,10 +321,10 @@ runIntermediatedLifecyclingAtomic = script do
         id = csdCashInstruction.id
 
   -- Allocate instructions
-  (csdBondInstructionCid1, _) <- submit csd do exerciseCmd csdBondInstructionCid1 Instruction.Allocate with actors = singleton csd; allocation = Pledge $ coerceContractId csdGenericTransferableCid
+  (csdBondInstructionCid1, _) <- submit csd do exerciseCmd csdBondInstructionCid1 Instruction.Allocate with actors = singleton csd; allocation = Pledge $ coerceContractId csdBondHoldingCid
   (issuerBondInstructionCid, _) <- submit issuer do exerciseCmd issuerBondInstructionCid Instruction.Allocate with actors = singleton issuer; allocation = CreditReceiver
-  (issuerCashInstructionCid, _) <- submit issuer do exerciseCmd issuerCashInstructionCid Instruction.Allocate with actors = singleton issuer; allocation = Pledge $ coerceContractId issuerCashTransferableCid
-  (investorBondInstructionCid, _) <- submit investor do exerciseCmd investorBondInstructionCid Instruction.Allocate with actors = singleton investor; allocation = Pledge $ coerceContractId investorGenericTransferableCid
+  (issuerCashInstructionCid, _) <- submit issuer do exerciseCmd issuerCashInstructionCid Instruction.Allocate with actors = singleton issuer; allocation = Pledge $ coerceContractId issuerCashHoldingCid
+  (investorBondInstructionCid, _) <- submit investor do exerciseCmd investorBondInstructionCid Instruction.Allocate with actors = singleton investor; allocation = Pledge $ coerceContractId investorBondHoldingCid
   (csdBondInstructionCid2, _) <- submit csd do exerciseCmd csdBondInstructionCid2 Instruction.Allocate with actors = singleton csd; allocation = CreditReceiver
   (csdCashInstructionCid, _) <- submit csd do exerciseCmd csdCashInstructionCid Instruction.Allocate with actors = singleton csd; allocation = PassthroughFrom (csdCashAccount, issuerCashInstructionKey)
   (bankCashInstructionCid, _) <- submit bank do exerciseCmd bankCashInstructionCid Instruction.Allocate with actors = singleton bank; allocation = CreditReceiver
@@ -346,14 +346,14 @@ runIntermediatedLifecyclingAtomic = script do
     exerciseCmd bankCashInstructionCid Instruction.Approve with actors = singleton investor; approval = TakeDelivery investorCashAccount
 
   -- Settle batch
-  [csdGenericTransferableCid, bankCashTransferableCid, investorGenericTransferableCid, investorCashTransferableCid] <- submitMulti (toList settlers) [publicParty] do exerciseCmd result.batchCid Batch.Settle with actors = settlers
+  [csdBondHoldingCid, bankCashHoldingCid, investorBondHoldingCid, investorCashHoldingCid] <- submitMulti (toList settlers) [publicParty] do exerciseCmd result.batchCid Batch.Settle with actors = settlers
 
   -- Assert state
   Holding.verifyOwnerOfHolding
-    [ (csd, csdGenericTransferableCid)
-    , (investor, investorGenericTransferableCid)
-    , (bank, coerceContractId bankCashTransferableCid)
-    , (investor, coerceContractId investorCashTransferableCid)
+    [ (csd, csdBondHoldingCid)
+    , (investor, investorBondHoldingCid)
+    , (bank, coerceContractId bankCashHoldingCid)
+    , (investor, coerceContractId investorCashHoldingCid)
     ]
 
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
@@ -13,17 +13,16 @@ import DA.Set (empty, fromList, singleton, toList)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Instrument.Generic.Test.Util (originateGeneric, mapClaimToUTCTime)
 import Daml.Finance.Interface.Account.Account qualified as Account (K)
-import Daml.Finance.Interface.Account.Util (getOwner)
 import Daml.Finance.Interface.Holding.Base qualified as Base (I)
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I)
-import Daml.Finance.Interface.Holding.Util (getAmount, getInstrument)
+import Daml.Finance.Interface.Holding.Util (getInstrument)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (GetCid(..), R)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (SetProvider(..), GetView(..), I)
 import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), I)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Evolve(..))
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
-import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), Step)
+import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..))
 import Daml.Finance.Interface.Types.Common (Id(..), Parties)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, AddObservers(..))
 import Daml.Finance.Lifecycle.Rule.Claim qualified as Claim (Rule(..))
@@ -322,11 +321,3 @@ template EffectSettlementService
         newEffectCid <- exercise effectCid Effect.SetProvider with newProviders = singleton csd
 
         pure (newEffectCid, Some (toInterfaceContractId newInstrumentHoldingCid), [investorCashTransferableCouponCid])
-
--- | HIDE
--- Matches a holding to a settlement step.
-match : Step -> Base.I -> Bool
-match s h =
-  getOwner h == s.sender &&
-  getAmount h == s.quantity.amount &&
-  getInstrument h == s.quantity.unit

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
@@ -22,11 +22,13 @@ import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffe
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Evolve(..))
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
-import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..))
+import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), InstructionKey(..))
 import Daml.Finance.Interface.Types.Common (Id(..), Parties)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, AddObservers(..))
 import Daml.Finance.Lifecycle.Rule.Claim qualified as Claim (Rule(..))
-import Daml.Finance.Settlement.Factory (Factory(..), FactoryWithIntermediaries(..), Path(..))
+import Daml.Finance.Settlement.Factory (Factory(..), FactoryWithIntermediaries(..))
+import Daml.Finance.Settlement.Hierarchy (Hierarchy(..))
+import Daml.Finance.Settlement.Instruction qualified as Instruction (T)
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit, submitExerciseInterfaceByKeyCmd)
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
@@ -53,12 +55,14 @@ import Daml.Script
                         \
                       Investor
 
-  The lifecycling and settlement happen in three steps:
+  In the "non-atomic" script, the lifecycling and settlement happen in three steps:
     - issuer lifecycles the instrument
     - effects are settled between issuer and CSD
     - effects are settled between CSD and investor(s)
 
   The last step involves moving cash through an account hierarchy.
+
+  In the "atomic" script, the last two steps are executed atomically.
 -}
 
 -- | Parties involved in the test script.
@@ -80,20 +84,22 @@ data TestParties = TestParties
       -- ^ The public party. Every party can readAs the public party.
 
 -- | Originate USD cash instrument and define settlement route.
-originateCashAndDefineRoute : TestParties -> Time -> Script (BaseInstrument.K, (Text, Path))
-originateCashAndDefineRoute TestParties{bank, centralBank, csd, investor, publicParty} now = do
+originateCashAndDefineRoute : TestParties -> Time -> Script (BaseInstrument.K, (Text, Hierarchy))
+originateCashAndDefineRoute TestParties{bank, centralBank, csd, investor, issuer, publicParty} now = do
   let
     pp = [("PublicParty", singleton publicParty)]
     label = "USD"
-    route = ( label , Path with
-                senderPath = [csd, centralBank]
-                receiverPath = [investor, bank, centralBank]
-            )
+    route =
+      ( label
+      , Hierarchy with
+          rootCustodian = centralBank
+          pathsToRootCustodian = [[investor, bank], [csd], [issuer]]
+      )
   instrument <- BaseInstrument.originate centralBank centralBank "USD" "United States Dollar" pp now
   pure (instrument, route)
 
 -- | Originate bond instrument and define settlement route.
-originateSecurityAndDefineRoute : TestParties -> Time -> BaseInstrument.K -> Script (BaseInstrument.K, (Text, Path))
+originateSecurityAndDefineRoute : TestParties -> Time -> BaseInstrument.K -> Script (BaseInstrument.K, (Text, Hierarchy))
 originateSecurityAndDefineRoute TestParties{bank, csd, investor, issuer, publicParty} now cashInstrument = do
   -- CREATE_CC_INSTRUMENT_VARIABLES_BEGIN
   let
@@ -110,12 +116,19 @@ originateSecurityAndDefineRoute TestParties{bank, csd, investor, issuer, publicP
   -- CREATE_CC_INSTRUMENT_BEGIN
   instrument <- originateGeneric csd issuer bondLabel "Bond" now claims pp now
   -- CREATE_CC_INSTRUMENT_END
-  let route = ( bondLabel , Path with senderPath = [csd]; receiverPath = [investor] )
+  let
+    route =
+      ( bondLabel
+      , Hierarchy with
+          rootCustodian = issuer
+          pathsToRootCustodian = [[investor, csd]]
+      )
   pure (instrument, route)
 
 -- | Penultimate coupon payment on a bond showing creation of new instrument version.
-run : Script ()
-run = script do
+-- Settlement of effects does not happen atomically.
+runIntermediatedLifecyclingNonAtomic : Script ()
+runIntermediatedLifecyclingNonAtomic = script do
   parties@TestParties{..} <- setupParties
 
   -- Setup security accounts
@@ -220,6 +233,125 @@ run = script do
   -- Assert state
   Holding.verifyOwnerOfHolding
     [ (investor, investorGenericTransferableCid)
+    , (bank, coerceContractId bankCashTransferableCid)
+    , (investor, coerceContractId investorCashTransferableCid)
+    ]
+
+  pure ()
+
+-- | Penultimate coupon payment on a bond showing creation of new instrument version.
+-- The effect is claimed and settled atomically across the entire chain.
+runIntermediatedLifecyclingAtomic : Script ()
+runIntermediatedLifecyclingAtomic = script do
+  parties@TestParties{..} <- setupParties
+
+  -- Setup security accounts
+  [investorSecuritiesAccount] <- setupAccounts "Securities Account" csd publicParty [investor]
+  [csdAccountAtIssuer] <- setupAccounts "Securities Account" issuer publicParty [csd]
+
+  -- Setup cash accounts at central bank
+  [issuerCashAccount, bankCashAccount, csdCashAccount] <- setupAccounts "Cash Account" centralBank publicParty [issuer, bank, csd]
+
+  -- Setup investor's cash account at Bank
+  [investorCashAccount] <- setupAccounts "Cash Account" bank publicParty [investor]
+
+  -- Originate and distribute central-bank cash
+  now <- getTime
+  let
+    today = toDateUTC now
+
+  (cashInstrument, cashRoute) <- originateCashAndDefineRoute parties now
+  issuerCashTransferableCid <- Account.credit [publicParty] cashInstrument 20_000.0 issuerCashAccount
+
+  -- Originate and distribute bond
+  (bondInstrument, bondRoute) <- originateSecurityAndDefineRoute parties now cashInstrument
+  csdGenericTransferableCid <- Account.credit [publicParty] bondInstrument 1_000_000.0 csdAccountAtIssuer
+  investorGenericTransferableCid <- Account.credit [publicParty] bondInstrument 1_000_000.0 investorSecuritiesAccount
+
+  -- create clock and clock update event
+  (clockCid, clockEventCid) <- createClockAndEvent (singleton issuer) today empty
+
+  -- Lifecycle bond
+  (_, [effectCid]) <- BaseInstrument.submitExerciseInterfaceByKeyCmd @Lifecycle.I [issuer] [] bondInstrument Lifecycle.Evolve with eventCid = clockEventCid; observableCids = []; ruleName = "Time"; timeObservableCid = clockCid
+
+  -- Define settlement routes from CSD to Investor and create batch factory
+  let routes = M.fromList [cashRoute, bondRoute]
+
+  settlementFactoryCid <- submit csd do
+    toInterfaceContractId <$> createCmd FactoryWithIntermediaries
+      with
+        provider = csd
+        paths = routes
+        observers = fromList [investor]
+
+  lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [csd] [] do
+    createCmd Claim.Rule
+      with
+        providers = fromList [csd]
+        claimers = singleton csd
+        settlers
+        settlementFactoryCid
+
+  result <- submit csd do
+    exerciseCmd lifecycleClaimRuleCid Claim.ClaimEffect with
+      claimer = csd
+      holdingCids = [csdGenericTransferableCid, investorGenericTransferableCid]
+      effectCid
+      batchId = Id "CouponSettlement"
+
+  let [   csdBondInstructionCid1      -- old bond from CSD to issuer
+        , issuerBondInstructionCid    -- new bond from issuer to CSD
+        , issuerCashInstructionCid    -- coupon payment from issuer to CSD
+        , investorBondInstructionCid  -- old bond from investor to CSD
+        , csdBondInstructionCid2      -- new bond from CSD to investor
+        , csdCashInstructionCid       -- coupon payment from CSD to investor's bank
+        , bankCashInstructionCid      -- coupon payment from investor's bank to investor
+        ] = result.instructionCids
+
+  Some issuerCashInstruction <- queryContractId csd $ fromInterfaceContractId @Instruction.T issuerCashInstructionCid
+  let issuerCashInstructionKey = InstructionKey with
+        requestors = issuerCashInstruction.requestors
+        batchId = issuerCashInstruction.batchId
+        id = issuerCashInstruction.id
+
+  Some csdCashInstruction <- queryContractId csd $ fromInterfaceContractId @Instruction.T csdCashInstructionCid
+  let csdCashInstructionKey = InstructionKey with
+        requestors = csdCashInstruction.requestors
+        batchId = csdCashInstruction.batchId
+        id = csdCashInstruction.id
+
+  -- Allocate instructions
+  (csdBondInstructionCid1, _) <- submit csd do exerciseCmd csdBondInstructionCid1 Instruction.Allocate with actors = singleton csd; allocation = Pledge $ coerceContractId csdGenericTransferableCid
+  (issuerBondInstructionCid, _) <- submit issuer do exerciseCmd issuerBondInstructionCid Instruction.Allocate with actors = singleton issuer; allocation = CreditReceiver
+  (issuerCashInstructionCid, _) <- submit issuer do exerciseCmd issuerCashInstructionCid Instruction.Allocate with actors = singleton issuer; allocation = Pledge $ coerceContractId issuerCashTransferableCid
+  (investorBondInstructionCid, _) <- submit investor do exerciseCmd investorBondInstructionCid Instruction.Allocate with actors = singleton investor; allocation = Pledge $ coerceContractId investorGenericTransferableCid
+  (csdBondInstructionCid2, _) <- submit csd do exerciseCmd csdBondInstructionCid2 Instruction.Allocate with actors = singleton csd; allocation = CreditReceiver
+  (csdCashInstructionCid, _) <- submit csd do exerciseCmd csdCashInstructionCid Instruction.Allocate with actors = singleton csd; allocation = PassthroughFrom (csdCashAccount, issuerCashInstructionKey)
+  (bankCashInstructionCid, _) <- submit bank do exerciseCmd bankCashInstructionCid Instruction.Allocate with actors = singleton bank; allocation = CreditReceiver
+
+  -- Approve instructions
+  csdBondInstructionCid1 <- submit issuer do
+    exerciseCmd csdBondInstructionCid1 Instruction.Approve with actors = singleton issuer; approval = DebitSender
+  issuerBondInstructionCid <- submit csd do
+    exerciseCmd issuerBondInstructionCid Instruction.Approve with actors = singleton csd; approval = TakeDelivery csdAccountAtIssuer
+  issuerCashInstructionCid <- submit csd do
+    exerciseCmd issuerCashInstructionCid Instruction.Approve with actors = singleton csd; approval = PassthroughTo (csdCashAccount, csdCashInstructionKey)
+  investorBondInstructionCid <- submit csd do
+    exerciseCmd investorBondInstructionCid Instruction.Approve with actors = singleton csd; approval = DebitSender
+  csdBondInstructionCid2 <- submit investor do
+    exerciseCmd csdBondInstructionCid2 Instruction.Approve with actors = singleton investor; approval = TakeDelivery investorSecuritiesAccount
+  csdCashInstructionCid <- submit bank do
+    exerciseCmd csdCashInstructionCid Instruction.Approve with actors = singleton bank; approval = TakeDelivery bankCashAccount
+  bankCashInstructionCid <- submit investor do
+    exerciseCmd bankCashInstructionCid Instruction.Approve with actors = singleton investor; approval = TakeDelivery investorCashAccount
+
+  -- Settle batch
+  [csdGenericTransferableCid, bankCashTransferableCid, investorGenericTransferableCid, investorCashTransferableCid] <- submitMulti (toList settlers) [publicParty] do exerciseCmd result.batchCid Batch.Settle with actors = settlers
+
+  -- Assert state
+  Holding.verifyOwnerOfHolding
+    [ (csd, csdGenericTransferableCid)
+    , (investor, investorGenericTransferableCid)
     , (bank, coerceContractId bankCashTransferableCid)
     , (investor, coerceContractId investorCashTransferableCid)
     ]

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
@@ -16,7 +16,7 @@ import Daml.Finance.Interface.Account.Account qualified as Account (K)
 import Daml.Finance.Interface.Holding.Base qualified as Base (I)
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I)
 import Daml.Finance.Interface.Holding.Util (getInstrument)
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (GetCid(..), R)
+import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (K)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (SetProvider(..), GetView(..), I)
 import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), I)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Evolve(..))
@@ -79,18 +79,44 @@ data TestParties = TestParties
     publicParty : Party
       -- ^ The public party. Every party can readAs the public party.
 
--- | Setup a set of accounts.
-setupAccounts : Text -> Party -> Party -> [Party] -> Script [Account.K]
-setupAccounts description custodian publicParty owners = do
-  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory custodian []
-  holdingFactoryCid <- toInterfaceContractId <$> submit custodian do
-    createCmd Fungible.Factory with provider= custodian; observers = M.fromList [("PublicParty", singleton publicParty)]
-  forA owners $ Account.createAccount description [] accountFactoryCid holdingFactoryCid [] Account.Owner custodian
+-- | Originate USD cash instrument and define settlement route.
+originateCashAndDefineRoute : TestParties -> Time -> Script (BaseInstrument.K, (Text, Path))
+originateCashAndDefineRoute TestParties{bank, centralBank, csd, investor, publicParty} now = do
+  let
+    pp = [("PublicParty", singleton publicParty)]
+    label = "USD"
+    route = ( label , Path with
+                senderPath = [csd, centralBank]
+                receiverPath = [investor, bank, centralBank]
+            )
+  instrument <- BaseInstrument.originate centralBank centralBank "USD" "United States Dollar" pp now
+  pure (instrument, route)
+
+-- | Originate bond instrument and define settlement route.
+originateSecurityAndDefineRoute : TestParties -> Time -> BaseInstrument.K -> Script (BaseInstrument.K, (Text, Path))
+originateSecurityAndDefineRoute TestParties{bank, csd, investor, issuer, publicParty} now cashInstrument = do
+  -- CREATE_CC_INSTRUMENT_VARIABLES_BEGIN
+  let
+    today = toDateUTC now
+    expiry = addDays today 180
+    bondLabel = "ABC.DE 2% " <> show expiry <> " Corp"
+    claims = mapClaimToUTCTime $ mconcat
+      [ when (TimeGte $ today) $ scale (Const 0.02) $ one cashInstrument
+      , when (TimeGte $ expiry) $ scale (Const 0.02) $ one cashInstrument
+      , when (TimeGte $ expiry) $ scale (Const 1.0) $ one cashInstrument
+      ]
+  -- CREATE_CC_INSTRUMENT_VARIABLES_END
+  let pp = [("PublicParty", singleton publicParty)]
+  -- CREATE_CC_INSTRUMENT_BEGIN
+  instrument <- originateGeneric csd issuer bondLabel "Bond" now claims pp now
+  -- CREATE_CC_INSTRUMENT_END
+  let route = ( bondLabel , Path with senderPath = [csd]; receiverPath = [investor] )
+  pure (instrument, route)
 
 -- | Penultimate coupon payment on a bond showing creation of new instrument version.
 run : Script ()
 run = script do
-  TestParties{..} <- setupParties
+  parties@TestParties{..} <- setupParties
 
   -- Setup security accounts
   [investorSecuritiesAccount] <- setupAccounts "Securities Account" csd publicParty [investor]
@@ -102,38 +128,24 @@ run = script do
   -- Setup investor's cash account at Bank
   [investorCashAccount] <- setupAccounts "Cash Account" bank publicParty [investor]
 
-  -- Distribute central-bank cash
+  -- Originate and distribute central-bank cash
   now <- getTime
-  let pp = [("PublicParty", singleton publicParty)]
-  cashInstrument <- BaseInstrument.originate centralBank centralBank "USD" "United States Dollar" pp now
-  issuerCashTransferableCid <- Account.credit [publicParty] cashInstrument 20_000.0 issuerCashAccount
-
-  -- CREATE_CC_INSTRUMENT_VARIABLES_BEGIN
-  -- Create and distribute bond
   let
     today = toDateUTC now
-    expiry = addDays today 180
-    bondLabel = "ABC.DE 2% " <> show expiry <> " Corp"
-    claims = mapClaimToUTCTime $ mconcat
-      [ when (TimeGte $ today) $ scale (Const 0.02) $ one cashInstrument
-      , when (TimeGte $ expiry) $ scale (Const 0.02) $ one cashInstrument
-      , when (TimeGte $ expiry) $ scale (Const 1.0) $ one cashInstrument
-      ]
-  -- CREATE_CC_INSTRUMENT_VARIABLES_END
 
-  -- CREATE_CC_INSTRUMENT_BEGIN
-  genericInstrument <- originateGeneric csd issuer bondLabel "Bond" now claims pp now
-  -- CREATE_CC_INSTRUMENT_END
-  csdGenericTransferableCid <- Account.credit [publicParty] genericInstrument 1_000_000.0 csdAccountAtIssuer
-  investorGenericTransferableCid <- Account.credit [publicParty] genericInstrument 1_000_000.0 investorSecuritiesAccount
+  (cashInstrument, cashRoute) <- originateCashAndDefineRoute parties now
+  issuerCashTransferableCid <- Account.credit [publicParty] cashInstrument 20_000.0 issuerCashAccount
 
-  genericLifecycleCid <- submit issuer do exerciseByKeyCmd @BaseInstrument.R genericInstrument BaseInstrument.GetCid with viewer = issuer
+  -- Originate and distribute bond
+  (bondInstrument, bondRoute) <- originateSecurityAndDefineRoute parties now cashInstrument
+  csdGenericTransferableCid <- Account.credit [publicParty] bondInstrument 1_000_000.0 csdAccountAtIssuer
+  investorGenericTransferableCid <- Account.credit [publicParty] bondInstrument 1_000_000.0 investorSecuritiesAccount
 
   -- create clock and clock update event
   (clockCid, clockEventCid) <- createClockAndEvent (singleton issuer) today empty
 
   -- Lifecycle bond
-  (genericLifecycleCid2, [effectCid]) <- BaseInstrument.submitExerciseInterfaceByKeyCmd @Lifecycle.I [issuer] [] genericInstrument Lifecycle.Evolve with eventCid = clockEventCid; observableCids = []; ruleName = "Time"; timeObservableCid = clockCid
+  (_, [effectCid]) <- BaseInstrument.submitExerciseInterfaceByKeyCmd @Lifecycle.I [issuer] [] bondInstrument Lifecycle.Evolve with eventCid = clockEventCid; observableCids = []; ruleName = "Time"; timeObservableCid = clockCid
 
   -- Setup settlement contract between issuer and CSD
   -- In order for the workflow to be successful, we need to disclose the CSD's cash account to the Issuer.
@@ -144,7 +156,7 @@ run = script do
       with
         csd
         issuer
-        instrumentId = Id bondLabel
+        instrumentId = bondInstrument.id
         securitiesAccount = csdAccountAtIssuer
         issuerCashAccount
         csdCashAccount
@@ -160,23 +172,13 @@ run = script do
   -- investor claims effect against CSD
 
   -- Define settlement routes from CSD to Investor and create batch factory
-  let routes =
-        [
-          ( "USD" , Path with
-              senderPath = [csd, centralBank]
-              receiverPath = [investor, bank, centralBank]
-          ),
-          ( bondLabel , Path with
-              senderPath = [csd]
-              receiverPath = [investor]
-          )
-        ]
+  let routes = M.fromList [cashRoute, bondRoute]
 
   settlementFactoryCid <- submit csd do
     toInterfaceContractId <$> createCmd FactoryWithIntermediaries
       with
         provider = csd
-        paths = M.fromList routes
+        paths = routes
         observers = fromList [investor]
 
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submitMulti [csd, investor] [] do
@@ -223,11 +225,6 @@ run = script do
     ]
 
   pure ()
-
-setupParties : Script TestParties
-setupParties = do
-  [bank, centralBank, csd, issuer, investor, settler, publicParty] <- createParties ["Bank", "CentralBank", "CSD", "Issuer", "Investor", "Settler", "PublicParty"]
-  pure $ TestParties with bank; centralBank; csd; issuer; investor; settlers = singleton settler; publicParty
 
 -- | Service template that allows to claim an effect and settle the corresponding transactions atomically.
 template EffectSettlementService
@@ -321,3 +318,19 @@ template EffectSettlementService
         newEffectCid <- exercise effectCid Effect.SetProvider with newProviders = singleton csd
 
         pure (newEffectCid, Some (toInterfaceContractId newInstrumentHoldingCid), [investorCashTransferableCouponCid])
+
+-- | HIDE
+setupParties : Script TestParties
+setupParties = do
+  [bank, centralBank, csd, issuer, investor, settler, publicParty] <- createParties ["Bank", "CentralBank", "CSD", "Issuer", "Investor", "Settler", "PublicParty"]
+  pure $ TestParties with bank; centralBank; csd; issuer; investor; settlers = singleton settler; publicParty
+
+-- | HIDE
+-- Setup a set of accounts.
+setupAccounts : Text -> Party -> Party -> [Party] -> Script [Account.K]
+setupAccounts description custodian publicParty owners = do
+  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory custodian []
+  holdingFactoryCid <- toInterfaceContractId <$> submit custodian do
+    createCmd Fungible.Factory with provider= custodian; observers = M.fromList [("PublicParty", singleton publicParty)]
+  forA owners $ Account.createAccount description [] accountFactoryCid holdingFactoryCid [] Account.Owner custodian
+

--- a/src/test/daml/Daml/Finance/Settlement/Test/BatchWithIntermediaries.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/BatchWithIntermediaries.daml
@@ -12,7 +12,8 @@ import Daml.Finance.Interface.Settlement.Factory qualified as Factory (I, Instru
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), Step(..))
 import Daml.Finance.Interface.Types.Common (Id(..))
-import Daml.Finance.Settlement.Factory (FactoryWithIntermediaries(..), Path(..))
+import Daml.Finance.Settlement.Factory (FactoryWithIntermediaries(..))
+import Daml.Finance.Settlement.Hierarchy (Hierarchy(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Holding qualified as Holding (verifyNoObservers, verifyOwnerOfHolding)
@@ -58,14 +59,13 @@ run settleWithOwnAccount = script do
   TestParties{..} <- setupParties
 
   -- Setup security accounts
-  let fp = [("FactoryProvider", singleton publicParty)]
+  let pp = [("PublicParty", singleton publicParty)]
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory csd []
   holdingFactoryCid <- toInterfaceContractId <$> submit csd do
-    createCmd Fungible.Factory with provider = csd; observers = M.fromList fp
+    createCmd Fungible.Factory with provider = csd; observers = M.fromList pp
   [buyerSecurityAccount, sellerSecurityAccount] <- mapA (Account.createAccount "Security Account" [] accountFactoryCid holdingFactoryCid [] Account.Owner csd) [buyer, seller]
 
   -- Setup cash accounts at CB
-  let pp = [("PublicParty", singleton publicParty)]
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory cb []
   holdingFactoryCid <- toInterfaceContractId <$> submit cb do
     createCmd Fungible.Factory with provider = cb; observers = M.fromList pp
@@ -87,8 +87,12 @@ run settleWithOwnAccount = script do
   -- Instruct settlement (by first creating a settlement factory with intermediaries from Buyer to Seller)
   let
     paths = M.fromList
-      [ ("USD", Path with senderPath = [buyer, cb]; receiverPath = [seller, bank, cb])
-      , ("AAPL", Path with senderPath = [seller, csd]; receiverPath = [buyer, csd])
+      [ ("USD", Hierarchy with
+                  rootCustodian = cb
+                  pathsToRootCustodian = [[buyer], [seller, bank]])
+      , ("AAPL", Hierarchy with
+                  rootCustodian = csd
+                  pathsToRootCustodian = [[seller], [buyer]])
       ]
   settlementFactoryCid <- toInterfaceContractId @Factory.I <$> submit buyer do
     createCmd FactoryWithIntermediaries with


### PR DESCRIPTION
If you want to avoid the refactoring noise, feel free to review only the last commit. 

I had added a second script to the `BondCoupon` test where a coupon on a bond is paid across an account hierarchy.

The settlement of the cash leg follows a different hierarchy than the settlement of the security leg.

This is part of https://github.com/digital-asset/daml-finance/issues/282.

We use all of the settlement tricks recently added by @johan-da: DebitSender, CreditReceiver, PassThrough
