### PR TITLE
New daml ctl version

### DIFF
--- a/daml.yaml
+++ b/daml.yaml
@@ -10,7 +10,7 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-ctl/v2.2.2/daml-ctl-2.2.2.dar
+  - .lib/daml-ctl/v2.2.3/daml-ctl-2.2.3.dar
 build-options:
   - --target=1.15
   - --include=src/main/daml

--- a/daml.yaml
+++ b/daml.yaml
@@ -10,7 +10,7 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-ctl/v2.2.3/daml-ctl-2.2.3.dar
+  - .lib/daml-ctl/v2.3.0/daml-ctl-2.3.0.dar
 build-options:
   - --target=1.15
   - --include=src/main/daml

--- a/package/main/daml/ContingentClaims.Core/daml.yaml
+++ b/package/main/daml/ContingentClaims.Core/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.4.0
 name: contingent-claims-core
 source: daml
-version: 3.0.0.20221007.1
+version: 3.0.0.20221026.1
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/main/daml/ContingentClaims.Core/daml.yaml
+++ b/package/main/daml/ContingentClaims.Core/daml.yaml
@@ -9,6 +9,6 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-ctl/v2.2.2/daml-ctl-2.2.2.dar
+  - .lib/daml-ctl/v2.3.0/daml-ctl-2.3.0.dar
 build-options:
   - --target=1.15

--- a/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
+++ b/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
@@ -4,12 +4,12 @@
 sdk-version: 2.4.0
 name: contingent-claims-lifecycle
 source: daml
-version: 3.0.0.20221007.1
+version: 3.0.0.20221026.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
   - .lib/daml-ctl/v2.3.0/daml-ctl-2.3.0.dar
-  - .lib/contingent-claims-core/ContingentClaims.Core/3.0.0.20221007.1/contingent-claims-core-3.0.0.20221007.1.dar
+  - .lib/contingent-claims-core/ContingentClaims.Core/3.0.0.20221026.1/contingent-claims-core-3.0.0.20221026.1.dar
 build-options:
   - --target=1.15

--- a/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
+++ b/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
@@ -9,7 +9,7 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-ctl/v2.2.2/daml-ctl-2.2.2.dar
+  - .lib/daml-ctl/v2.3.0/daml-ctl-2.3.0.dar
   - .lib/contingent-claims-core/ContingentClaims.Core/3.0.0.20221007.1/contingent-claims-core-3.0.0.20221007.1.dar
 build-options:
   - --target=1.15

--- a/package/main/daml/ContingentClaims.Valuation/daml.yaml
+++ b/package/main/daml/ContingentClaims.Valuation/daml.yaml
@@ -10,6 +10,6 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-ctl/v2.3.0/daml-ctl-2.3.0.dar
-  - .lib/contingent-claims-core/ContingentClaims.Core/3.0.0.20221007.1/contingent-claims-core-3.0.0.20221007.1.dar
+  - .lib/contingent-claims-core/ContingentClaims.Core/3.0.0.20221026.1/contingent-claims-core-3.0.0.20221026.1.dar
 build-options:
   - --target=1.15

--- a/package/main/daml/ContingentClaims.Valuation/daml.yaml
+++ b/package/main/daml/ContingentClaims.Valuation/daml.yaml
@@ -9,7 +9,7 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-ctl/v2.2.2/daml-ctl-2.2.2.dar
+  - .lib/daml-ctl/v2.3.0/daml-ctl-2.3.0.dar
   - .lib/contingent-claims-core/ContingentClaims.Core/3.0.0.20221007.1/contingent-claims-core-3.0.0.20221007.1.dar
 build-options:
   - --target=1.15

--- a/package/main/daml/Daml.Finance.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Claims/daml.yaml
@@ -4,15 +4,15 @@
 sdk-version: 2.4.0
 name: daml-finance-claims
 source: daml
-version: 0.1.0
+version: 0.1.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/contingent-claims-core/ContingentClaims.Core/3.0.0.20221007.1/contingent-claims-core-3.0.0.20221007.1.dar
-  - .lib/contingent-claims-lifecycle/ContingentClaims.Lifecycle/3.0.0.20221007.1/contingent-claims-lifecycle-3.0.0.20221007.1.dar
+  - .lib/contingent-claims-core/ContingentClaims.Core/3.0.0.20221026.1/contingent-claims-core-3.0.0.20221026.1.dar
+  - .lib/contingent-claims-lifecycle/ContingentClaims.Lifecycle/3.0.0.20221026.1/contingent-claims-lifecycle-3.0.0.20221026.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.5/daml-finance-interface-claims-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.6/daml-finance-interface-claims-0.1.6.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.5/daml-finance-interface-instrument-base-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.5/daml-finance-interface-data-0.1.5.dar
 build-options:

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -9,14 +9,14 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/contingent-claims-core/ContingentClaims.Core/3.0.0.20221007.1/contingent-claims-core-3.0.0.20221007.1.dar
+  - .lib/contingent-claims-core/ContingentClaims.Core/3.0.0.20221026.1/contingent-claims-core-3.0.0.20221026.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.5/daml-finance-interface-instrument-base-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.7/daml-finance-interface-lifecycle-0.1.7.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.7/daml-finance-interface-instrument-generic-0.1.7.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/0.1.5/daml-finance-interface-instrument-bond-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.5/daml-finance-interface-claims-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.6/daml-finance-interface-claims-0.1.6.dar
   - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.7/daml-finance-instrument-generic-0.1.7.dar
   - .lib/daml-finance/Daml.Finance.Util/0.1.5/daml-finance-util-0.1.5.dar
 build-options:

--- a/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
@@ -9,17 +9,17 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/contingent-claims-core/ContingentClaims.Core/3.0.0.20221007.1/contingent-claims-core-3.0.0.20221007.1.dar
+  - .lib/contingent-claims-core/ContingentClaims.Core/3.0.0.20221026.1/contingent-claims-core-3.0.0.20221026.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.5/daml-finance-interface-data-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.5/daml-finance-interface-holding-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.0/daml-finance-interface-account-0.1.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.5/daml-finance-interface-instrument-base-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.5/daml-finance-interface-claims-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.6/daml-finance-interface-claims-0.1.6.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.7/daml-finance-interface-lifecycle-0.1.7.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.7/daml-finance-interface-instrument-generic-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Claims/0.1.0/daml-finance-claims-0.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Claims/0.1.1/daml-finance-claims-0.1.1.dar
   - .lib/daml-finance/Daml.Finance.Data/0.1.6/daml-finance-data-0.1.6.dar
   - .lib/daml-finance/Daml.Finance.Util/0.1.5/daml-finance-util-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.7/daml-finance-lifecycle-0.1.7.dar

--- a/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
@@ -9,12 +9,12 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/contingent-claims-core/ContingentClaims.Core/3.0.0.20221007.1/contingent-claims-core-3.0.0.20221007.1.dar
+  - .lib/contingent-claims-core/ContingentClaims.Core/3.0.0.20221026.1/contingent-claims-core-3.0.0.20221026.1.dar
   - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.7/daml-finance-instrument-generic-0.1.7.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.5/daml-finance-interface-instrument-base-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.5/daml-finance-interface-claims-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.6/daml-finance-interface-claims-0.1.6.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.7/daml-finance-interface-lifecycle-0.1.7.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.7/daml-finance-interface-instrument-generic-0.1.7.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.1.6/daml-finance-interface-instrument-swap-0.1.6.dar

--- a/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
@@ -4,12 +4,12 @@
 sdk-version: 2.4.0
 name: daml-finance-interface-claims
 source: daml
-version: 0.1.5
+version: 0.1.6
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/contingent-claims-core/ContingentClaims.Core/3.0.0.20221007.1/contingent-claims-core-3.0.0.20221007.1.dar
+  - .lib/contingent-claims-core/ContingentClaims.Core/3.0.0.20221026.1/contingent-claims-core-3.0.0.20221026.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.5/daml-finance-interface-instrument-base-0.1.5.dar

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
@@ -9,10 +9,10 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/contingent-claims-core/ContingentClaims.Core/3.0.0.20221007.1/contingent-claims-core-3.0.0.20221007.1.dar
+  - .lib/contingent-claims-core/ContingentClaims.Core/3.0.0.20221026.1/contingent-claims-core-3.0.0.20221026.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.5/daml-finance-interface-claims-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.6/daml-finance-interface-claims-0.1.6.dar
   - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.5/daml-finance-interface-data-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.5/daml-finance-interface-instrument-base-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.7/daml-finance-interface-lifecycle-0.1.7.dar

--- a/package/test/daml/ContingentClaims.Test/daml.yaml
+++ b/package/test/daml/ContingentClaims.Test/daml.yaml
@@ -11,8 +11,8 @@ dependencies:
   - daml-script
 data-dependencies:
   - .lib/daml-ctl/v2.3.0/daml-ctl-2.3.0.dar
-  - .lib/contingent-claims-core/ContingentClaims.Core/3.0.0.20221007.1/contingent-claims-core-3.0.0.20221007.1.dar
-  - .lib/contingent-claims-lifecycle/ContingentClaims.Lifecycle/3.0.0.20221007.1/contingent-claims-lifecycle-3.0.0.20221007.1.dar
+  - .lib/contingent-claims-core/ContingentClaims.Core/3.0.0.20221026.1/contingent-claims-core-3.0.0.20221026.1.dar
+  - .lib/contingent-claims-lifecycle/ContingentClaims.Lifecycle/3.0.0.20221026.1/contingent-claims-lifecycle-3.0.0.20221026.1.dar
   - .lib/contingent-claims-valuation/ContingentClaims.Valuation/3.0.0.20221024.1/contingent-claims-valuation-3.0.0.20221024.1.dar
 build-options:
   - --target=1.15

--- a/package/test/daml/ContingentClaims.Test/daml.yaml
+++ b/package/test/daml/ContingentClaims.Test/daml.yaml
@@ -10,7 +10,7 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-ctl/v2.2.2/daml-ctl-2.2.2.dar
+  - .lib/daml-ctl/v2.3.0/daml-ctl-2.3.0.dar
   - .lib/contingent-claims-core/ContingentClaims.Core/3.0.0.20221007.1/contingent-claims-core-3.0.0.20221007.1.dar
   - .lib/contingent-claims-lifecycle/ContingentClaims.Lifecycle/3.0.0.20221007.1/contingent-claims-lifecycle-3.0.0.20221007.1.dar
   - .lib/contingent-claims-valuation/ContingentClaims.Valuation/3.0.0.20221024.1/contingent-claims-valuation-3.0.0.20221024.1.dar

--- a/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
@@ -14,7 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.5/daml-finance-interface-data-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.5/daml-finance-interface-holding-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.5/daml-finance-interface-instrument-base-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.5/daml-finance-interface-claims-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.6/daml-finance-interface-claims-0.1.6.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.7/daml-finance-interface-lifecycle-0.1.7.dar
   - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.7/daml-finance-instrument-generic-0.1.7.dar
   - .lib/daml-finance/Daml.Finance.Holding/0.1.5/daml-finance-holding-0.1.5.dar

--- a/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
@@ -10,20 +10,20 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/contingent-claims-core/ContingentClaims.Core/3.0.0.20221007.1/contingent-claims-core-3.0.0.20221007.1.dar
+  - .lib/contingent-claims-core/ContingentClaims.Core/3.0.0.20221026.1/contingent-claims-core-3.0.0.20221026.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.5/daml-finance-interface-holding-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.0/daml-finance-interface-account-0.1.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.5/daml-finance-interface-instrument-base-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.5/daml-finance-interface-claims-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.6/daml-finance-interface-claims-0.1.6.dar
   - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.6/daml-finance-interface-settlement-0.1.6.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.7/daml-finance-interface-lifecycle-0.1.7.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.7/daml-finance-interface-instrument-generic-0.1.7.dar
   - .lib/daml-finance/Daml.Finance.Holding/0.1.5/daml-finance-holding-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Settlement/0.1.6/daml-finance-settlement-0.1.6.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.7/daml-finance-lifecycle-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Claims/0.1.0/daml-finance-claims-0.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Claims/0.1.1/daml-finance-claims-0.1.1.dar
   - .lib/daml-finance/Daml.Finance.Data/0.1.6/daml-finance-data-0.1.6.dar
   - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.7/daml-finance-instrument-generic-0.1.7.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/0.1.7/daml-finance-test-util-0.1.7.dar


### PR DESCRIPTION
I have updated the daml-ctl version to make sure `build-options` are aligned (target=1.15), since this is required for java codegen.