### PR TITLE
Fix bug in `Hierarchy.locateParty`

### DIFF
--- a/src/main/daml/Daml/Finance/Settlement/Hierarchy.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Hierarchy.daml
@@ -6,7 +6,7 @@ module Daml.Finance.Settlement.Hierarchy
   , unfoldStep
   ) where
 
-import DA.List (isSuffixOf, stripInfix, stripSuffix, tails)
+import DA.List (dedup, isSuffixOf, stripInfix, stripSuffix, tails)
 import DA.Optional (isSome)
 import Daml.Finance.Interface.Settlement.Types (Step(..))
 
@@ -58,7 +58,7 @@ getRoute senderPath receiverPath =
 locateParty : Party -> Hierarchy -> Optional [Party]
 locateParty p h | p == h.rootCustodian = pure [p, p]
 locateParty p h =
-  case filter isSome $ map (stripInfix [p]) h.pathsToRootCustodian of
-  [Some (_, path)] -> pure $ [p] <> path <> [h.rootCustodian]
+  case dedup . filter isSome $ map (fmap snd . stripInfix [p]) h.pathsToRootCustodian of
+  [Some path] -> pure $ [p] <> path <> [h.rootCustodian]
   [] -> None
-  _ -> error "Multiple paths found"
+  _ -> error $ "Multiple paths to root custodian found for party " <> show p

--- a/src/main/daml/Daml/Finance/Settlement/Hierarchy.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Hierarchy.daml
@@ -3,6 +3,8 @@
 
 module Daml.Finance.Settlement.Hierarchy
   ( Hierarchy(..)
+  , locateParty
+  , getRoute
   , unfoldStep
   ) where
 

--- a/src/test/daml/Daml/Finance/Settlement/Test/Hierarchy.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Hierarchy.daml
@@ -1,0 +1,56 @@
+module Daml.Finance.Settlement.Test.Hierarchy where
+
+import DA.Assert ((===))
+import Daml.Finance.Interface.Instrument.Base.Instrument (qty)
+import Daml.Finance.Interface.Settlement.Types (Step(..))
+import Daml.Finance.Interface.Types.Common (Id(..), InstrumentKey(..))
+import Daml.Finance.Settlement.Hierarchy
+import Daml.Finance.Test.Util.Common (createParties)
+import Daml.Script
+
+--           a
+--         /   \
+--        b     c
+--      /   \    \
+--     d    e     f
+testHierarchyPaths : Script ()
+testHierarchyPaths = do
+
+  [a,b,c,d,e,f,h] <- createParties ["a","b","c","d","e","f","h"]
+
+  let hierarchy = Hierarchy with
+        rootCustodian = a
+        pathsToRootCustodian =
+          [ [d, b]
+          , [e, b]
+          , [f, c]
+          ]
+
+  locateParty a hierarchy === Some [a, a]
+  locateParty b hierarchy === Some [b, a]
+  locateParty c hierarchy === Some [c, a]
+  locateParty d hierarchy === Some [d, b, a]
+  locateParty e hierarchy === Some [e, b, a]
+  locateParty f hierarchy === Some [f, c, a]
+  locateParty h hierarchy === None
+
+  route hierarchy d a === Some [(d,b), (b,a)]
+  route hierarchy d b === Some [(d,b)]
+  route hierarchy b f === Some [(b,c), (c,f)]
+  route hierarchy a d === Some [(a,b), (b,d)]
+  route hierarchy d h === None
+
+  pure ()
+
+-- | Get route between two parties, if it exists.
+route : Hierarchy -> Party -> Party -> Optional [(Party, Party)]
+route h from to = do
+  fromPath <- locateParty from h
+  toPath <- locateParty to h
+  getRoute fromPath toPath
+
+-- | Create a step from sender to receiver for a dummy instrument.
+createStep : Party -> Party -> Step
+createStep sender receiver =
+  let quantity = qty 1.0 $ InstrumentKey with depository = sender; issuer = receiver; id = Id "dummy"; version = "0"
+  in Step with sender; receiver; quantity

--- a/src/test/daml/Daml/Finance/Settlement/Test/Hierarchy.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Hierarchy.daml
@@ -1,13 +1,14 @@
 module Daml.Finance.Settlement.Test.Hierarchy where
 
 import DA.Assert ((===))
-import Daml.Finance.Interface.Instrument.Base.Instrument (qty)
-import Daml.Finance.Interface.Settlement.Types (Step(..))
-import Daml.Finance.Interface.Types.Common (Id(..), InstrumentKey(..))
 import Daml.Finance.Settlement.Hierarchy
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Script
 
+-- Test path-finding within a hierarchy.
+--
+-- Used hierarchy:
+--
 --           a
 --         /   \
 --        b     c
@@ -48,9 +49,3 @@ route h from to = do
   fromPath <- locateParty from h
   toPath <- locateParty to h
   getRoute fromPath toPath
-
--- | Create a step from sender to receiver for a dummy instrument.
-createStep : Party -> Party -> Step
-createStep sender receiver =
-  let quantity = qty 1.0 $ InstrumentKey with depository = sender; issuer = receiver; id = Id "dummy"; version = "0"
-  in Step with sender; receiver; quantity

--- a/src/test/daml/Daml/Finance/Settlement/Test/Hierarchy.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Hierarchy.daml
@@ -1,3 +1,6 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module Daml.Finance.Settlement.Test.Hierarchy where
 
 import DA.Assert ((===))


### PR DESCRIPTION
This fixes a bug in the current implementation.

Assume that we have chains [A -> B -> C] and [ D -> B -> C ] and want to find a path to root custodian.

Previously `locateParty` would throw an error. Now it returns the path [ B -> C ]