### PR TITLE
Update packages

### DIFF
--- a/package/main/daml/ContingentClaims.Core/daml.yaml
+++ b/package/main/daml/ContingentClaims.Core/daml.yaml
@@ -12,3 +12,4 @@ data-dependencies:
   - .lib/daml-ctl/v2.3.0/daml-ctl-2.3.0.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
+++ b/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
@@ -13,3 +13,4 @@ data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/0.1.0/contingent-claims-core-0.1.0.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/ContingentClaims.Valuation/daml.yaml
+++ b/package/main/daml/ContingentClaims.Valuation/daml.yaml
@@ -13,3 +13,4 @@ data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/0.1.0/contingent-claims-core-0.1.0.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Account/daml.yaml
@@ -4,16 +4,17 @@
 sdk-version: 2.4.0
 name: daml-finance-account
 source: daml
-version: 0.1.1
+version: 0.1.2
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.6/daml-finance-interface-holding-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.1/daml-finance-interface-account-0.1.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.6/daml-finance-interface-instrument-base-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Holding/0.1.6/daml-finance-holding-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Holding/0.1.7/daml-finance-holding-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.2/daml-finance-interface-account-0.1.2.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.7/daml-finance-interface-holding-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.7/daml-finance-interface-instrument-base-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.6/daml-finance-interface-util-0.1.6.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Claims/daml.yaml
@@ -4,16 +4,17 @@
 sdk-version: 2.4.0
 name: daml-finance-claims
 source: daml
-version: 0.1.2
+version: 0.1.3
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/0.1.0/contingent-claims-core-0.1.0.dar
   - .lib/daml-finance/ContingentClaims.Lifecycle/0.1.0/contingent-claims-lifecycle-0.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.6/daml-finance-interface-claims-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.6/daml-finance-interface-instrument-base-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.5/daml-finance-interface-data-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.7/daml-finance-interface-claims-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.6/daml-finance-interface-data-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.7/daml-finance-interface-instrument-base-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Data/daml.yaml
@@ -4,14 +4,15 @@
 sdk-version: 2.4.0
 name: daml-finance-data
 source: daml
-version: 0.1.6
+version: 0.1.7
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.5/daml-finance-interface-data-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.7/daml-finance-lifecycle-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.6/daml-finance-interface-data-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.6/daml-finance-interface-util-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.9/daml-finance-lifecycle-0.1.9.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Holding/daml.yaml
@@ -4,15 +4,15 @@
 sdk-version: 2.4.0
 name: daml-finance-holding
 source: daml
-version: 0.1.6
+version: 0.1.7
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.6/daml-finance-interface-holding-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.1/daml-finance-interface-account-0.1.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.6/daml-finance-interface-instrument-base-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.2/daml-finance-interface-account-0.1.2.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.7/daml-finance-interface-holding-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.6/daml-finance-interface-util-0.1.6.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -4,20 +4,20 @@
 sdk-version: 2.4.0
 name: daml-finance-instrument-bond
 source: daml
-version: 0.1.7
+version: 0.1.8
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/0.1.0/contingent-claims-core-0.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.6/daml-finance-interface-instrument-base-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.7/daml-finance-interface-lifecycle-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.7/daml-finance-interface-instrument-generic-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/0.1.6/daml-finance-interface-instrument-bond-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.6/daml-finance-interface-claims-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.7/daml-finance-instrument-generic-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Util/0.1.5/daml-finance-util-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.8/daml-finance-instrument-generic-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.7/daml-finance-interface-claims-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.7/daml-finance-interface-instrument-base-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/0.1.7/daml-finance-interface-instrument-bond-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.8/daml-finance-interface-lifecycle-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.6/daml-finance-interface-util-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Util/0.1.6/daml-finance-util-0.1.6.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
@@ -4,15 +4,16 @@
 sdk-version: 2.4.0
 name: daml-finance-instrument-equity
 source: daml
-version: 0.1.8
+version: 0.1.9
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.6/daml-finance-interface-instrument-base-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.1.7/daml-finance-interface-instrument-equity-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.8/daml-finance-lifecycle-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.7/daml-finance-interface-instrument-base-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.1.8/daml-finance-interface-instrument-equity-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.6/daml-finance-interface-util-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.9/daml-finance-lifecycle-0.1.9.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
@@ -4,24 +4,25 @@
 sdk-version: 2.4.0
 name: daml-finance-instrument-generic
 source: daml
-version: 0.1.7
+version: 0.1.8
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/0.1.0/contingent-claims-core-0.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.5/daml-finance-interface-data-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.6/daml-finance-interface-holding-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.1/daml-finance-interface-account-0.1.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.6/daml-finance-interface-instrument-base-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.6/daml-finance-interface-claims-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.7/daml-finance-interface-lifecycle-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.7/daml-finance-interface-instrument-generic-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Claims/0.1.1/daml-finance-claims-0.1.1.dar
-  - .lib/daml-finance/Daml.Finance.Data/0.1.6/daml-finance-data-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Util/0.1.5/daml-finance-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.7/daml-finance-lifecycle-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Claims/0.1.3/daml-finance-claims-0.1.3.dar
+  - .lib/daml-finance/Daml.Finance.Data/0.1.7/daml-finance-data-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.2/daml-finance-interface-account-0.1.2.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.7/daml-finance-interface-claims-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.6/daml-finance-interface-data-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.7/daml-finance-interface-holding-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.7/daml-finance-interface-instrument-base-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.8/daml-finance-interface-instrument-generic-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.8/daml-finance-interface-lifecycle-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.6/daml-finance-interface-util-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.9/daml-finance-lifecycle-0.1.9.dar
+  - .lib/daml-finance/Daml.Finance.Util/0.1.6/daml-finance-util-0.1.6.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
@@ -4,20 +4,20 @@
 sdk-version: 2.4.0
 name: daml-finance-instrument-swap
 source: daml
-version: 0.1.7
+version: 0.1.8
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/0.1.0/contingent-claims-core-0.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.7/daml-finance-instrument-generic-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.6/daml-finance-interface-instrument-base-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.6/daml-finance-interface-claims-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.7/daml-finance-interface-lifecycle-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.7/daml-finance-interface-instrument-generic-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.1.7/daml-finance-interface-instrument-swap-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Util/0.1.5/daml-finance-util-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.8/daml-finance-instrument-generic-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.7/daml-finance-interface-claims-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.7/daml-finance-interface-instrument-base-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.1.8/daml-finance-interface-instrument-swap-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.8/daml-finance-interface-lifecycle-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.6/daml-finance-interface-util-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Util/0.1.6/daml-finance-util-0.1.6.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
@@ -4,14 +4,15 @@
 sdk-version: 2.4.0
 name: daml-finance-instrument-token
 source: daml
-version: 0.1.6
+version: 0.1.7
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.6/daml-finance-interface-instrument-base-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/0.1.6/daml-finance-interface-instrument-token-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.7/daml-finance-interface-instrument-base-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/0.1.7/daml-finance-interface-instrument-token-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.6/daml-finance-interface-util-0.1.6.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
@@ -4,13 +4,14 @@
 sdk-version: 2.4.0
 name: daml-finance-interface-account
 source: daml
-version: 0.1.1
+version: 0.1.2
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.6/daml-finance-interface-holding-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.7/daml-finance-interface-holding-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.6/daml-finance-interface-util-0.1.6.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
@@ -4,14 +4,15 @@
 sdk-version: 2.4.0
 name: daml-finance-interface-claims
 source: daml
-version: 0.1.6
+version: 0.1.7
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/0.1.0/contingent-claims-core-0.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.6/daml-finance-interface-instrument-base-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.7/daml-finance-interface-instrument-base-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.6/daml-finance-interface-util-0.1.6.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
@@ -4,11 +4,12 @@
 sdk-version: 2.4.0
 name: daml-finance-interface-data
 source: daml
-version: 0.1.5
+version: 0.1.6
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
@@ -4,12 +4,13 @@
 sdk-version: 2.4.0
 name: daml-finance-interface-holding
 source: daml
-version: 0.1.6
+version: 0.1.7
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.6/daml-finance-interface-util-0.1.6.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
@@ -4,13 +4,14 @@
 sdk-version: 2.4.0
 name: daml-finance-interface-instrument-base
 source: daml
-version: 0.1.6
+version: 0.1.7
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.6/daml-finance-interface-holding-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.7/daml-finance-interface-holding-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.6/daml-finance-interface-util-0.1.6.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
@@ -4,13 +4,14 @@
 sdk-version: 2.4.0
 name: daml-finance-interface-instrument-bond
 source: daml
-version: 0.1.6
+version: 0.1.7
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.6/daml-finance-interface-instrument-base-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.7/daml-finance-interface-instrument-base-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.6/daml-finance-interface-util-0.1.6.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
@@ -4,14 +4,15 @@
 sdk-version: 2.4.0
 name: daml-finance-interface-instrument-equity
 source: daml
-version: 0.1.7
+version: 0.1.8
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.6/daml-finance-interface-instrument-base-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.7/daml-finance-interface-lifecycle-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.7/daml-finance-interface-instrument-base-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.8/daml-finance-interface-lifecycle-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.6/daml-finance-interface-util-0.1.6.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
@@ -4,17 +4,17 @@
 sdk-version: 2.4.0
 name: daml-finance-interface-instrument-generic
 source: daml
-version: 0.1.7
+version: 0.1.8
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/ContingentClaims.Core/0.1.0/contingent-claims-core-0.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.6/daml-finance-interface-claims-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.5/daml-finance-interface-data-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.6/daml-finance-interface-instrument-base-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.7/daml-finance-interface-lifecycle-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.7/daml-finance-interface-claims-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.6/daml-finance-interface-data-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.7/daml-finance-interface-instrument-base-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.8/daml-finance-interface-lifecycle-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.6/daml-finance-interface-util-0.1.6.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
@@ -4,13 +4,14 @@
 sdk-version: 2.4.0
 name: daml-finance-interface-instrument-swap
 source: daml
-version: 0.1.7
+version: 0.1.8
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.6/daml-finance-interface-instrument-base-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.7/daml-finance-interface-instrument-base-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.6/daml-finance-interface-util-0.1.6.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
@@ -4,13 +4,14 @@
 sdk-version: 2.4.0
 name: daml-finance-interface-instrument-token
 source: daml
-version: 0.1.6
+version: 0.1.7
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.6/daml-finance-interface-instrument-base-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.7/daml-finance-interface-instrument-base-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.6/daml-finance-interface-util-0.1.6.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
@@ -4,15 +4,16 @@
 sdk-version: 2.4.0
 name: daml-finance-interface-lifecycle
 source: daml
-version: 0.1.7
+version: 0.1.8
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.5/daml-finance-interface-data-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.6/daml-finance-interface-holding-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.6/daml-finance-interface-instrument-base-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.7/daml-finance-interface-settlement-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.6/daml-finance-interface-data-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.7/daml-finance-interface-holding-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.7/daml-finance-interface-instrument-base-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.8/daml-finance-interface-settlement-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
@@ -4,14 +4,15 @@
 sdk-version: 2.4.0
 name: daml-finance-interface-settlement
 source: daml
-version: 0.1.7
+version: 0.1.8
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.6/daml-finance-interface-holding-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.6/daml-finance-interface-instrument-base-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.7/daml-finance-interface-holding-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.7/daml-finance-interface-instrument-base-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.6/daml-finance-interface-util-0.1.6.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
@@ -4,11 +4,12 @@
 sdk-version: 2.4.0
 name: daml-finance-interface-util
 source: daml
-version: 0.1.5
+version: 0.1.6
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
@@ -4,18 +4,19 @@
 sdk-version: 2.4.0
 name: daml-finance-lifecycle
 source: daml
-version: 0.1.8
+version: 0.1.9
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.6/daml-finance-interface-holding-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.1/daml-finance-interface-account-0.1.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.6/daml-finance-interface-instrument-base-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.7/daml-finance-interface-settlement-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.7/daml-finance-interface-lifecycle-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.5/daml-finance-interface-data-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.2/daml-finance-interface-account-0.1.2.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.6/daml-finance-interface-data-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.7/daml-finance-interface-holding-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.7/daml-finance-interface-instrument-base-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.8/daml-finance-interface-lifecycle-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.8/daml-finance-interface-settlement-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.6/daml-finance-interface-util-0.1.6.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Settlement/daml.yaml
@@ -4,16 +4,17 @@
 sdk-version: 2.4.0
 name: daml-finance-settlement
 source: daml
-version: 0.1.7
+version: 0.1.8
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.6/daml-finance-interface-holding-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.1/daml-finance-interface-account-0.1.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.7/daml-finance-interface-settlement-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Util/0.1.5/daml-finance-util-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.2/daml-finance-interface-account-0.1.2.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.7/daml-finance-interface-holding-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.8/daml-finance-interface-settlement-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.6/daml-finance-interface-util-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Util/0.1.6/daml-finance-util-0.1.6.dar
 build-options:
   - --target=1.15
+

--- a/package/main/daml/Daml.Finance.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Util/daml.yaml
@@ -4,11 +4,12 @@
 sdk-version: 2.4.0
 name: daml-finance-util
 source: daml
-version: 0.1.5
+version: 0.1.6
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
 build-options:
   - --target=1.15
+

--- a/package/packages.yaml
+++ b/package/packages.yaml
@@ -11,8 +11,8 @@ remote:
           organisation: digital-asset
           name: daml-ctl
         base-module: Daml.Control
-        tag: v2.2.2
-        dar-name: daml-ctl-2.2.2.dar
+        tag: v2.3.0
+        dar-name: daml-ctl-2.3.0.dar
 local:
   repo:
     host: github.com

--- a/package/test/daml/ContingentClaims.Test/daml.yaml
+++ b/package/test/daml/ContingentClaims.Test/daml.yaml
@@ -16,3 +16,4 @@ data-dependencies:
   - .lib/daml-finance/ContingentClaims.Valuation/0.1.0/contingent-claims-valuation-0.1.0.dar
 build-options:
   - --target=1.15
+

--- a/package/test/daml/Daml.Finance.Account.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Account.Test/daml.yaml
@@ -10,11 +10,12 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.6/daml-finance-interface-holding-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.1/daml-finance-interface-account-0.1.1.dar
-  - .lib/daml-finance/Daml.Finance.Holding/0.1.6/daml-finance-holding-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/0.1.8/daml-finance-test-util-0.1.8.dar
   - .lib/daml-finance/Daml.Finance.Holding.Test/0.1.7/daml-finance-holding-test-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Holding/0.1.7/daml-finance-holding-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.2/daml-finance-interface-account-0.1.2.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.7/daml-finance-interface-holding-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/0.1.8/daml-finance-test-util-0.1.8.dar
 build-options:
   - --target=1.15
+

--- a/package/test/daml/Daml.Finance.Data.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Data.Test/daml.yaml
@@ -10,9 +10,9 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Data/0.1.6/daml-finance-data-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Data/0.1.7/daml-finance-data-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/0.1.8/daml-finance-test-util-0.1.8.dar
 build-options:
   - --target=1.15
+

--- a/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
@@ -10,12 +10,13 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.6/daml-finance-interface-holding-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.1/daml-finance-interface-account-0.1.1.dar
-  - .lib/daml-finance/Daml.Finance.Holding/0.1.6/daml-finance-holding-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Account/0.1.1/daml-finance-account-0.1.1.dar
+  - .lib/daml-finance/Daml.Finance.Account/0.1.2/daml-finance-account-0.1.2.dar
+  - .lib/daml-finance/Daml.Finance.Holding/0.1.7/daml-finance-holding-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.2/daml-finance-interface-account-0.1.2.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.7/daml-finance-interface-holding-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.6/daml-finance-interface-util-0.1.6.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/0.1.8/daml-finance-test-util-0.1.8.dar
 build-options:
   - --target=1.15
+

--- a/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
@@ -10,17 +10,16 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.5/daml-finance-interface-data-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.6/daml-finance-interface-holding-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.6/daml-finance-interface-instrument-base-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.6/daml-finance-interface-claims-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.7/daml-finance-interface-lifecycle-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.7/daml-finance-instrument-generic-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Holding/0.1.6/daml-finance-holding-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.7/daml-finance-lifecycle-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Data/0.1.6/daml-finance-data-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Bond/0.1.7/daml-finance-instrument-bond-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Data/0.1.7/daml-finance-data-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Holding/0.1.7/daml-finance-holding-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Bond/0.1.8/daml-finance-instrument-bond-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.8/daml-finance-instrument-generic-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.7/daml-finance-interface-claims-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.6/daml-finance-interface-data-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.7/daml-finance-interface-instrument-base-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.8/daml-finance-interface-lifecycle-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/0.1.8/daml-finance-test-util-0.1.8.dar
 build-options:
   - --target=1.15
+

--- a/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
@@ -10,17 +10,16 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.6/daml-finance-interface-instrument-base-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.7/daml-finance-interface-settlement-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.7/daml-finance-interface-lifecycle-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.1.7/daml-finance-interface-instrument-equity-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Holding/0.1.6/daml-finance-holding-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/0.1.7/daml-finance-settlement-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.8/daml-finance-lifecycle-0.1.8.dar
-  - .lib/daml-finance/Daml.Finance.Data/0.1.6/daml-finance-data-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Equity/0.1.8/daml-finance-instrument-equity-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Holding/0.1.7/daml-finance-holding-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Equity/0.1.9/daml-finance-instrument-equity-0.1.9.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.7/daml-finance-interface-instrument-base-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.1.8/daml-finance-interface-instrument-equity-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.8/daml-finance-interface-lifecycle-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.8/daml-finance-interface-settlement-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.9/daml-finance-lifecycle-0.1.9.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/0.1.8/daml-finance-settlement-0.1.8.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/0.1.8/daml-finance-test-util-0.1.8.dar
 build-options:
   - --target=1.15
+

--- a/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
@@ -11,21 +11,22 @@ dependencies:
   - daml-script
 data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/0.1.0/contingent-claims-core-0.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.6/daml-finance-interface-holding-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.1/daml-finance-interface-account-0.1.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.6/daml-finance-interface-instrument-base-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.6/daml-finance-interface-claims-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.7/daml-finance-interface-settlement-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.7/daml-finance-interface-lifecycle-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.7/daml-finance-interface-instrument-generic-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Holding/0.1.6/daml-finance-holding-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/0.1.7/daml-finance-settlement-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.8/daml-finance-lifecycle-0.1.8.dar
-  - .lib/daml-finance/Daml.Finance.Claims/0.1.1/daml-finance-claims-0.1.1.dar
-  - .lib/daml-finance/Daml.Finance.Data/0.1.6/daml-finance-data-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.7/daml-finance-instrument-generic-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Claims/0.1.3/daml-finance-claims-0.1.3.dar
+  - .lib/daml-finance/Daml.Finance.Data/0.1.7/daml-finance-data-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Holding/0.1.7/daml-finance-holding-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.8/daml-finance-instrument-generic-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.2/daml-finance-interface-account-0.1.2.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.7/daml-finance-interface-claims-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.7/daml-finance-interface-holding-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.7/daml-finance-interface-instrument-base-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.8/daml-finance-interface-instrument-generic-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.8/daml-finance-interface-lifecycle-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.8/daml-finance-interface-settlement-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.6/daml-finance-interface-util-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.9/daml-finance-lifecycle-0.1.9.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/0.1.8/daml-finance-settlement-0.1.8.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/0.1.8/daml-finance-test-util-0.1.8.dar
 build-options:
   - --target=1.15
+

--- a/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
@@ -10,14 +10,15 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.7/daml-finance-instrument-generic-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.5/daml-finance-interface-data-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.6/daml-finance-interface-instrument-base-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.1.7/daml-finance-interface-instrument-swap-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.7/daml-finance-interface-lifecycle-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Data/0.1.6/daml-finance-data-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Swap/0.1.7/daml-finance-instrument-swap-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Data/0.1.7/daml-finance-data-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Generic/0.1.8/daml-finance-instrument-generic-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Swap/0.1.8/daml-finance-instrument-swap-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.6/daml-finance-interface-data-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.7/daml-finance-interface-instrument-base-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.1.8/daml-finance-interface-instrument-swap-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.8/daml-finance-interface-lifecycle-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/0.1.8/daml-finance-test-util-0.1.8.dar
 build-options:
   - --target=1.15
+

--- a/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
@@ -10,14 +10,15 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.6/daml-finance-interface-holding-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.6/daml-finance-interface-instrument-base-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.7/daml-finance-interface-settlement-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Holding/0.1.6/daml-finance-holding-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Account/0.1.1/daml-finance-account-0.1.1.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/0.1.7/daml-finance-settlement-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Account/0.1.2/daml-finance-account-0.1.2.dar
+  - .lib/daml-finance/Daml.Finance.Holding/0.1.7/daml-finance-holding-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.7/daml-finance-interface-holding-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.7/daml-finance-interface-instrument-base-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.8/daml-finance-interface-settlement-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.6/daml-finance-interface-util-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/0.1.8/daml-finance-settlement-0.1.8.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/0.1.8/daml-finance-test-util-0.1.8.dar
 build-options:
   - --target=1.15
+

--- a/package/test/daml/Daml.Finance.Test.Util/daml.yaml
+++ b/package/test/daml/Daml.Finance.Test.Util/daml.yaml
@@ -10,17 +10,17 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.5/daml-finance-interface-util-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.6/daml-finance-interface-holding-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.1/daml-finance-interface-account-0.1.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.6/daml-finance-interface-instrument-base-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.5/daml-finance-interface-data-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.7/daml-finance-interface-lifecycle-0.1.7.dar
-  - .lib/daml-finance/Daml.Finance.Holding/0.1.6/daml-finance-holding-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Account/0.1.1/daml-finance-account-0.1.1.dar
-  - .lib/daml-finance/Daml.Finance.Data/0.1.6/daml-finance-data-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Token/0.1.6/daml-finance-instrument-token-0.1.6.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.7/daml-finance-lifecycle-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Account/0.1.2/daml-finance-account-0.1.2.dar
+  - .lib/daml-finance/Daml.Finance.Data/0.1.7/daml-finance-data-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Token/0.1.7/daml-finance-instrument-token-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.2/daml-finance-interface-account-0.1.2.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.6/daml-finance-interface-data-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.7/daml-finance-interface-holding-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.7/daml-finance-interface-instrument-base-0.1.7.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.8/daml-finance-interface-lifecycle-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.6/daml-finance-interface-util-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.9/daml-finance-lifecycle-0.1.9.dar
 build-options:
   - --target=1.15
+

--- a/package/test/daml/Daml.Finance.Util.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Util.Test/daml.yaml
@@ -10,7 +10,8 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.5/daml-finance-interface-types-0.1.5.dar
-  - .lib/daml-finance/Daml.Finance.Util/0.1.5/daml-finance-util-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types/0.1.6/daml-finance-interface-types-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Util/0.1.6/daml-finance-util-0.1.6.dar
 build-options:
   - --target=1.15
+


### PR DESCRIPTION
1. Ran `packell data-dependencies update`
2. This updated the package data-dependencies based off their each package source's daml imports. `Daml.Finance.Interface.Types` data-dependencies got updated to the latest version (0.1.6).
3. Manually updated package versions which depended on the previous `Daml.Finance.Interface.Types` version.
4. Ran `packell data-dependencies update` again to pick up all the package version updates which updated all references in data-dependencies
5. Ran `make headers-update`