### PR TITLE
Remove time contraMap from `mapParams`

### DIFF
--- a/src/main/daml/ContingentClaims/Core/Claim.daml
+++ b/src/main/daml/ContingentClaims/Core/Claim.daml
@@ -105,14 +105,13 @@ instance Monoid (Claim t x a o) where
   -- ^ A more efficient `O(1)` version of (<>) for lists.
 
 -- | Replace parameters in an `Claim` with actual values.
-mapParams :  (t -> i)
-          -> (i -> t)
+mapParams :  (i -> t)
           -> (a -> a')
           -> (o -> o')
           -> (x -> x')
           -> Claim i x a o -> Claim t x' a' o'
-mapParams ft' ft fa fk fv =
-  let f = Observation.mapParams ft' fk fv
+mapParams ft fa fk fv =
+  let f = Observation.mapParams fk fv
   in cata \case
     ZeroF -> Zero
     OneF a -> One $ fa a

--- a/src/main/daml/ContingentClaims/Core/Observation.daml
+++ b/src/main/daml/ContingentClaims/Core/Observation.daml
@@ -80,15 +80,13 @@ eval doObserve obs t = cataM alg obs
 
 -- | The functor map operation _and_ also map any parameters to keys.
 -- For example, could map the param "spot" to an ISIN code "GB123456789".
--- Also contra-maps time parameter, i.e. from relative time values to absolute ones.
 --
 -- @ mapParams identity = bimap
 --
-mapParams : (t -> i)
-          -> (o -> o')
+mapParams :  (o -> o')
           -> (x -> x')
           -> Observation i x o -> Observation t x' o'
-mapParams _ g f = cata \case
+mapParams g f = cata \case
   ConstF x -> Const (f x)
   ObserveF key -> Observe (g key)
   AddF (b, b') -> Add (b, b')

--- a/src/main/daml/Daml/Finance/Claims/Util.daml
+++ b/src/main/daml/Daml/Finance/Claims/Util.daml
@@ -24,12 +24,8 @@ isZero' = all $ CC.isZero . (.claim)
 
 -- | Maps the time parameter in a `Claim` to `Time`. As `Time` is generally understood to express UTC time, we recommend mapping to UTC time.
 toTime : HasUTCTimeConversion t => Claim t x a o -> Claim Time x a o
-toTime =
-  let contraMap _ = error "Inverse mapping from `Time` is not provided" -- currently the contramap from `Time` back to `a` is not used, because `Observation`\s do not depend on time explicitly
-  in mapParams contraMap toUTCTime identity identity identity
+toTime = mapParams toUTCTime identity identity identity
 
 -- | Maps the time parameter in a `Claim` to `Time`. As `Time` is generally understood to express UTC time, we recommend mapping to UTC time.
 toTime' : (t -> Time) -> Claim t x a o -> Claim Time x a o
-toTime' forwardMap c =
-  let contraMap _ = error "Inverse mapping from `Time` is not provided" -- currently the contramap from `Time` back to `a` is not used, because `Observation`\s do not depend on time explicitly
-  in mapParams contraMap forwardMap identity identity identity c
+toTime' forwardMap c = mapParams forwardMap identity identity identity c

--- a/src/test/daml/ContingentClaims/Test/Templating.daml
+++ b/src/test/daml/ContingentClaims/Test/Templating.daml
@@ -41,6 +41,6 @@ demoTemplate = script do
       assets : Map.Map Text Text = Map.fromList [(ccy, usd)]
       observables : Map.Map Text Text = Map.fromList [("s", "VOD.L")]
       get dict k = fromSomeNote ("failed to template " <> k) (Map.lookup k dict)
-      f = mapParams (`subDate` today) (today `addDays`) (get assets) (get observables) (get constants)
+      f = mapParams (today `addDays`) (get assets) (get observables) (get constants)
 
   f aTemplate === when (TimeGte $ date 2021 Jul 15) (scale (O.observe "VOD.L" - O.pure 99.8) (one usd) `or` zero)


### PR DESCRIPTION
Re-proposing this PR from the Contingent Claims repo.

This PR removes the unused "inverse mapping" `t -> i` from mapParams.

In fairness, we could entirely remove the time parameter `t` from `Observation t x o` as the time dependency is always implicit and introduced when the observation is "reified".

I am however unsure whether removing the time parameter from observation is desirable as it is intuitive to have that type parameter there.

Happy to hear your thoughts @lucianojoublanc-da.