### PR TITLE
Improve tutorial: How To Use the Swap Extension Package

### DIFF
--- a/docs/source/concepts/asset-model.rst
+++ b/docs/source/concepts/asset-model.rst
@@ -244,6 +244,8 @@ corresponding Account and Holding contracts.
 It is worth noting that the ``issuer`` of the Equity Instrument has the right to perform certain
 Corporate Actions, such as declaring dividends. This topic is covered in the lifecycling section.
 
+.. _otc-swap-asset-model:
+
 OTC Swap
 ========
 

--- a/docs/source/tutorials/instrument-modeling/swap-extension.rst
+++ b/docs/source/tutorials/instrument-modeling/swap-extension.rst
@@ -44,6 +44,7 @@ We start by defining the terms:
   :end-before: -- CREATE_INTEREST_RATE_SWAP_VARIABLES_END
 
 The floating leg depends on a reference rate, which is defined by the *referenceRateId* variable.
+The value of the reference rate is observed at the beginning of each payment period.
 
 The *issuerPaysFix* variable is used to specify whether the issuer pays the fix or the floating leg.
 This is not needed for bonds, because the regular payments are always in one direction (from the
@@ -59,6 +60,14 @@ Just as for bonds, we can use these variables to create a
   :start-after: -- CREATE_SWAP_PERIODIC_SCHEDULE_BEGIN
   :end-before: -- CREATE_SWAP_PERIODIC_SCHEDULE_END
 
+Note that this instrument only has one periodic schedule, which is used for both the fixed and the
+floating leg.
+It is also used for both the calculation period (to determine which floating rate to be used) and
+the payment period (to determine when payments are done). The FpML swap template below offers more
+flexibility here. It has individual schedules, both for the fixed/floating leg and for the
+calculation/payment periods. That would allow you to specify whether payments should be made
+e.g. after each calculation period or only after every second calculation period.
+
 Now that we have defined the terms we can create the swap instrument:
 
 .. literalinclude:: ../../../../src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -66,9 +75,10 @@ Now that we have defined the terms we can create the swap instrument:
   :start-after: -- CREATE_INTEREST_RATE_SWAP_INSTRUMENT_BEGIN
   :end-before: -- CREATE_INTEREST_RATE_SWAP_INSTRUMENT_END
 
-Once the instrument is created, you can book a holding on it using ``Account.credit``. Since the
-issuer pays the floating leg in our example, the owner of the holding receives the floating leg (and
-pays the fix leg).
+Once the instrument is created, you can book a holding on it using
+:ref:`Account.credit <module-daml-finance-interface-account-account-92922>`.
+Since the issuer pays the floating leg in our example, the owner of the holding receives the
+floating leg (and pays the fix leg).
 
 Currency
 ========
@@ -96,6 +106,10 @@ In this example, the issuer pays the foreign currency leg.
 In order to calculate the interest rate payments, a notional is required in each currency. The
 quantity of the holding refers to the notional of the base currency. The notional of the foreign
 currency is defined as the quantity of the holding multiplied by the specified *fxRate*.
+
+Note that this template is limited to fixed rates. It also does not support exchange of notionals.
+If you need floating rates or exchange of notionals, please use the the FpML swap template below.
+It supports both of those features.
 
 Here is how we create the currency swap instrument, using the two currencies defined above:
 
@@ -153,7 +167,8 @@ Credit Default
 
 A credit default swap (CDS) pays a protection amount in case of a credit default event, in exchange
 for a fix rate at the end of every payment period. The protection amount is defined as
-*1-recoveryRate*.
+*1-recoveryRate*. The *recoveryRate* is defined as the amount recovered when a borrower defaults,
+expressed as a percentage of notional.
 
 If a credit event occurs, the swap expires after the protection amount has been paid, i.e., no more
 rate payments are required afterwards.
@@ -230,8 +245,8 @@ FpML
 Unlike the other swap types above, the FpML swap template is not a new type of payoff. Instead, it
 allows you to input other types of swaps using the
 `FpML schema <https://www.fpml.org/spec/fpml-5-11-3-lcwd-1/html/confirmation/schemaDocumentation/schemas/fpml-ird-5-11_xsd/complexTypes/Swap.html>`_.
-Currently, only interest rate swaps are supported, but the template can quite easily be extended to
-currency swaps and FX swaps.
+Currently, interest rate swaps and currency swaps are supported.
+The template can quite easily be extended to FX swaps.
 
 Specifically, it allows you to specify one
 `swapStream <https://www.fpml.org/spec/fpml-5-11-3-lcwd-1/html/confirmation/schemaDocumentation/schemas/fpml-ird-5-11_xsd/complexTypes/Swap/swapStream.html>`_
@@ -256,7 +271,9 @@ schema:
   :start-after: -- CREATE_FPML_SWAP_FIX_LEG_BEGIN
   :end-before: -- CREATE_FPML_SWAP_FIX_LEG_END
 
-As you can see, the Daml ``SwapStream`` data type matches the `swapStream FpML schema <https://www.fpml.org/spec/fpml-5-11-3-lcwd-1/html/confirmation/schemaDocumentation/schemas/fpml-ird-5-11_xsd/complexTypes/Swap/swapStream.html>`_.
+As you can see, the
+:ref:`Daml SwapStream data type <type-daml-finance-interface-instrument-swap-fpml-fpmltypes-swapstream-38811>`
+matches the `swapStream FpML schema <https://www.fpml.org/spec/fpml-5-11-3-lcwd-1/html/confirmation/schemaDocumentation/schemas/fpml-ird-5-11_xsd/complexTypes/Swap/swapStream.html>`_.
 Please note that the actual parsing from FpML to Daml is not done by this template. It has to be
 implemented on the client side.
 
@@ -300,3 +317,6 @@ practice one of the counterparties is often a swap dealer, who shares some of th
 a bond issuer. For the purpose of lifecycling in Daml Finance, we require one of the counterparties
 to take the role as issuer. This counterparty will serve as calculation agent and provide the
 observables required to calculate the swap payments.
+
+The documentation of the Daml Finance asset model contains an
+:ref:`OTC swap example <otc-swap-asset-model>`.

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/ForeignExchange.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/ForeignExchange.daml
@@ -33,10 +33,10 @@ run = script do
     issueDate = date 2019 Jan 16
     firstPaymentDate = date 2019 Feb 15
     maturityDate = date 2019 May 15
-    fxRateSameCurrency = 1.0
     firstFxRate = 1.1
     finalFxRate = 1.2
     -- CREATE_FX_SWAP_VARIABLES_END
+    fxRateSameCurrency = 1.0
 
   swapInstrument <- originateForeignExchangeSwap custodian issuer "SwapTest1" "Foreign exchange swap" observers now issueDate firstPaymentDate maturityDate cashInstrumentCid foreignCashInstrumentCid firstFxRate finalFxRate
 


### PR DESCRIPTION
- Link to other parts of the documentation: the asset model (OTC Swap), account.credit, SwapStream data type
- Specify functionality supported in interest rate / currency swap vs FpML swap
- Improve some explanations