### PR TITLE
Add id and description to `Lifecycle` interface

### DIFF
--- a/src/main/daml/Daml/Finance/Claims/Lifecycle/Rule.daml
+++ b/src/main/daml/Daml/Finance/Claims/Lifecycle/Rule.daml
@@ -14,7 +14,7 @@ import Daml.Finance.Interface.Claims.Claim qualified as Claim (getAcquisitionTim
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (R, exerciseInterfaceByKey, getKey)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Evolve(..), View(..))
 import Daml.Finance.Interface.Claims.Dynamic.Instrument qualified as DynamicInstrument (I, CreateNewVersion(..), GetView(..))
-import Daml.Finance.Interface.Types.Common (Parties, PartiesMap)
+import Daml.Finance.Interface.Types.Common (Id(..), Parties, PartiesMap)
 import Daml.Finance.Interface.Util.Common (fetchInterfaceByKey)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, flattenObservers)
 import Daml.Finance.Lifecycle.Effect (Effect(..))
@@ -29,12 +29,16 @@ template Rule
       -- ^ Party performing the lifecycling.
     observers : PartiesMap
       -- ^ Observers of the distribution rule.
+    id : Id
+      -- ^ Identifier for the rule contract.
+    description : Text
+      -- ^ Textual description.
   where
     signatory providers
     observer Disclosure.flattenObservers observers, lifecycler
 
     interface instance Lifecycle.I for Rule where
-      view = Lifecycle.View with lifecycler
+      view = Lifecycle.View with lifecycler; id; description
       -- BOND_PROCESS_CLOCK_UPDATE_INITAL_CLAIMS_BEGIN
       evolve Lifecycle.Evolve{eventCid; observableCids; instrument} = do
         claimInstrument <- fetchInterfaceByKey @BaseInstrument.R instrument

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Lifecycle/Rule.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Lifecycle/Rule.daml
@@ -17,7 +17,7 @@ import Daml.Finance.Interface.Claims.Types (C)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (K, R, createReference, getKey)
 import Daml.Finance.Interface.Instrument.Generic.Election qualified as Election (ApplyElection(..), Exercisable(..), ExercisableView(..), getElectionTime)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Evolve(..), View(..))
-import Daml.Finance.Interface.Types.Common (Parties, PartiesMap)
+import Daml.Finance.Interface.Types.Common (Id(..), Parties, PartiesMap)
 import Daml.Finance.Interface.Util.Common (fetchInterfaceByKey)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, SetObservers(..), View(..), flattenObservers)
 import Daml.Finance.Instrument.Generic.Instrument (Instrument(..))
@@ -34,12 +34,16 @@ template Rule
       -- ^ Party performing the lifecycling.
     observers : PartiesMap
       -- ^ Observers of the distribution rule.
+    id : Id
+      -- ^ Identifier for the rule contract.
+    description : Text
+      -- ^ Textual description.
   where
     signatory providers
     observer Disclosure.flattenObservers observers, lifecycler
 
     interface instance Lifecycle.I for Rule where
-      view = Lifecycle.View with lifecycler
+      view = Lifecycle.View with lifecycler; id; description
       evolve Lifecycle.Evolve{eventCid; observableCids; instrument} = do
 
         -- fetch event

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Rule/Lifecycle.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Rule/Lifecycle.daml
@@ -7,6 +7,7 @@ import Daml.Finance.Interface.Data.NumericObservable qualified as NumericObserva
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument(K)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (I)
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I)
+import Daml.Finance.Interface.Types.Common (Id(..))
 
 -- | Type synonym for `Lifecycle`.
 type I = Lifecycle
@@ -17,6 +18,10 @@ type V = View
 -- | View for `Lifecycle`.
 data View = View
   with
+    id : Id
+      -- ^ Identifier for the rule contract.
+    description : Text
+      -- ^ Textual description.
     lifecycler : Party
       -- ^ Party performing the lifecycling.
   deriving (Eq, Show)

--- a/src/main/daml/Daml/Finance/Lifecycle/Rule/Distribution.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Rule/Distribution.daml
@@ -4,7 +4,7 @@
 module Daml.Finance.Lifecycle.Rule.Distribution where
 
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (Evolve(..), HasImplementation, I, View(..))
-import Daml.Finance.Interface.Types.Common (Parties)
+import Daml.Finance.Interface.Types.Common (Id(..), Parties)
 import Daml.Finance.Lifecycle.Effect (Effect(..))
 import Daml.Finance.Lifecycle.Event.Distribution qualified as Distribution (Event)
 
@@ -23,12 +23,16 @@ template Rule
       -- ^ Party performing the lifecycling.
     observers : Parties
       -- ^ Observers of the distribution rule.
+    id : Id
+      -- ^ Identifier for the rule contract.
+    description : Text
+      -- ^ Textual description.
   where
     signatory providers
     observer observers, lifecycler
 
     interface instance Lifecycle.I for Rule where
-      view = Lifecycle.View with lifecycler
+      view = Lifecycle.View with lifecycler; id; description
       evolve Lifecycle.Evolve{eventCid; instrument} = do
         distribution <- fetch $ fromInterfaceContractId @Distribution.Event eventCid
         assertMsg "The input instrument does not match the distribution's target instrument" $ instrument == distribution.targetInstrument

--- a/src/main/daml/Daml/Finance/Lifecycle/Rule/Replacement.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Rule/Replacement.daml
@@ -4,7 +4,7 @@
 module Daml.Finance.Lifecycle.Rule.Replacement where
 
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (Evolve(..), HasImplementation, I, View(..))
-import Daml.Finance.Interface.Types.Common (Parties)
+import Daml.Finance.Interface.Types.Common (Id(..), Parties)
 import Daml.Finance.Lifecycle.Effect (Effect(..))
 import Daml.Finance.Lifecycle.Event.Replacement qualified as Replacement (Event)
 
@@ -23,12 +23,16 @@ template Rule
       -- ^ Party performing the lifecycling.
     observers : Parties
       -- ^ Observers.
+    id : Id
+      -- ^ Identifier for the rule contract.
+    description : Text
+      -- ^ Textual description.
   where
     signatory providers
     observer observers, lifecycler
 
     interface instance Lifecycle.I for Rule where
-      view = Lifecycle.View with lifecycler
+      view = Lifecycle.View with lifecycler; id; description
       evolve Lifecycle.Evolve{eventCid; instrument} = do
         replacement <- fetch $ fromInterfaceContractId @Replacement.Event eventCid
         assertMsg "The input instrument does not match the replacement's target instrument" $ instrument == replacement.targetInstrument

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
@@ -136,7 +136,12 @@ lifecycleInstrument readAs today instrument issuer observableCids = do
   -- LIFECYCLE_BOND_BEGIN
   -- Create a lifecycle rule
   lifecycleRuleCid : ContractId Lifecycle.I <- toInterfaceContractId <$> submit issuer do
-    createCmd Rule with providers = singleton issuer; observers= M.empty; lifecycler = issuer
+    createCmd Rule with
+      providers = singleton issuer
+      observers= M.empty
+      lifecycler = issuer
+      id = Id "LifecycleRule"
+      description = "Rule to lifecycle bond instruments"
 
   -- Try to lifecycle instrument
   (lifecycleCid, effectCids) <- submitMulti [issuer] readAs do

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
@@ -57,7 +57,12 @@ run = script do
   -- Create cash dividend event
   distributionRuleCid <- toInterfaceContractId @Lifecycle.I <$> submit issuer do
     createCmd Distribution.Rule with
-      providers = singleton issuer; lifecycler = issuer; observers = singleton public
+      providers = singleton issuer
+      lifecycler = issuer
+      observers = singleton public
+      id = Id "LifecycleRule"
+      description = "Rule to lifecycle an instrument following a distribution event"
+
   distributionEventCid <-
     Instrument.submitExerciseInterfaceByKeyCmd @Equity.I [issuer] [] cumEquityInstrument
       Equity.DeclareDividend with

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Merger.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Merger.daml
@@ -46,7 +46,11 @@ run = script do
   -- Create lifecycle rules
   replacementRuleCid <- toInterfaceContractId @Lifecycle.I <$> submit merging do
     createCmd Replacement.Rule with
-      providers = singleton merging; lifecycler = merging; observers = singleton public
+      providers = singleton merging
+      lifecycler = merging
+      observers = singleton public
+      id = Id "LifecycleRule"
+      description = "Rule to lifecycle an instrument following a replacement event"
 
   -- Originate instruments
   now <- getTime

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/StockSplit.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/StockSplit.daml
@@ -44,7 +44,11 @@ run = script do
   -- Create lifecycle rule
   replacementRuleCid <- toInterfaceContractId @Lifecycle.I <$> submit issuer do
     createCmd Replacement.Rule with
-      providers = singleton issuer; lifecycler = issuer; observers = singleton public
+      providers = singleton issuer
+      lifecycler = issuer
+      observers = singleton public
+      id = Id "LifecycleRule"
+      description = "Rule to lifecycle an instrument following a replacement event"
 
   -- Originate instruments
   now <- getTime

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
@@ -132,7 +132,12 @@ run = script do
 
   -- Apply election to generate new instrument version + effects
   lifecycleRuleCid <- toInterfaceContractId <$> submit bank do
-    createCmd Lifecycle.Rule with providers = singleton bank; observers= M.empty; lifecycler = issuer
+    createCmd Lifecycle.Rule with
+      providers = singleton bank
+      observers= M.empty
+      lifecycler = issuer
+      id = Id "LifecycleRule"
+      description = "Rule to lifecycle a generic instrument"
 
   (_, [effectCid]) <- submit issuer do
     exerciseCmd callBondCid Election.Apply

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/EuropeanOption.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/EuropeanOption.daml
@@ -152,7 +152,13 @@ run = script do
 
   -- Apply election to generate new instrument version + effects
   lifecycleRuleCid <- toInterfaceContractId <$> submit bank do
-    createCmd Lifecycle.Rule with providers = singleton bank; observers= M.empty; lifecycler = broker
+    createCmd Lifecycle.Rule with
+      providers = singleton bank
+      observers= M.empty
+      lifecycler = broker
+      id = Id "LifecycleRule"
+      description = "Rule to lifecycle a generic instrument"
+
 
   (_, [effectCid]) <- submit broker do
     exerciseCmd exerciseOptionCid Election.Apply

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardCash.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardCash.daml
@@ -88,7 +88,12 @@ run = script do
 
   -- Lifecycle derivative
   lifecycleRuleCid : ContractId Lifecycle.I <- toInterfaceContractId <$> submit bank do
-    createCmd Lifecycle.Rule with providers = singleton bank; observers= M.empty; lifecycler = broker
+    createCmd Lifecycle.Rule with
+      providers = singleton bank
+      observers= M.empty
+      lifecycler = broker
+      id = Id "LifecycleRule"
+      description = "Rule to lifecycle a generic instrument"
 
   (_, [effectCid]) <- submit broker do
     exerciseCmd lifecycleRuleCid Lifecycle.Evolve

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardPhysical.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardPhysical.daml
@@ -89,7 +89,12 @@ run = script do
 
   -- Lifecycle a generic derivative
   lifecycleRuleCid : ContractId Lifecycle.I <- toInterfaceContractId <$> submit bank do
-    createCmd Lifecycle.Rule with providers = singleton bank; observers= M.empty; lifecycler = broker
+    createCmd Lifecycle.Rule with
+      providers = singleton bank
+      observers= M.empty
+      lifecycler = broker
+      id = Id "LifecycleRule"
+      description = "Rule to lifecycle a generic instrument"
 
   (_, [effectCid]) <- submit broker do
     exerciseCmd lifecycleRuleCid Lifecycle.Evolve with

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
@@ -170,7 +170,12 @@ runIntermediatedLifecyclingNonAtomic = script do
 
   -- Lifecycle bond
   lifecycleRuleCid : ContractId Lifecycle.I <- toInterfaceContractId <$> submit csd do
-    createCmd Lifecycle.Rule with providers = singleton csd; observers= M.empty; lifecycler = issuer
+    createCmd Lifecycle.Rule with
+      providers = singleton csd
+      observers= M.empty
+      lifecycler = issuer
+      id = Id "LifecycleRule"
+      description = "Rule to lifecycle a generic instrument"
 
   (_, [effectCid]) <- submit issuer do
     exerciseCmd lifecycleRuleCid Lifecycle.Evolve with
@@ -314,7 +319,12 @@ runIntermediatedLifecyclingAtomic = script do
 
   -- Lifecycle bond
   lifecycleRuleCid : ContractId Lifecycle.I <- toInterfaceContractId <$> submit csd do
-    createCmd Lifecycle.Rule with providers = singleton csd; observers= M.empty; lifecycler = issuer
+    createCmd Lifecycle.Rule with
+      providers = singleton csd
+      observers= M.empty
+      lifecycler = issuer
+      id = Id "LifecycleRule"
+      description = "Rule to lifecycle a generic instrument"
 
   (_, [effectCid]) <- submit issuer do
     exerciseCmd lifecycleRuleCid Lifecycle.Evolve with

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -179,7 +179,12 @@ lifecycleInstrument readAs today instrument issuer observableCids = do
 
   -- Create a lifecycle rule
   lifecycleRuleCid : ContractId Lifecycle.I <- toInterfaceContractId <$> submit issuer do
-    createCmd Rule with providers = S.singleton issuer; observers= M.empty; lifecycler = issuer
+    createCmd Rule with
+      providers = S.singleton issuer
+      observers= M.empty
+      lifecycler = issuer
+      id = Id "LifecycleRule"
+      description = "Rule to lifecycle a swap instrument"
 
   -- Try to lifecycle instrument
   (lifecycleCid, effectCids) <- submitMulti [issuer] readAs do


### PR DESCRIPTION
This allows client applications to disambiguate when handling multiple instruments