### PR TITLE
contingent claims: make failed elections non-effectful

### DIFF
--- a/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
+++ b/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.5.0-snapshot.20221201.11065.0.caac1d10
 name: contingent-claims-lifecycle
 source: daml
-version: 0.1.2
+version: 0.1.3
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/main/daml/Daml.Finance.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Claims/daml.yaml
@@ -10,7 +10,7 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/0.1.2/contingent-claims-core-0.1.2.dar
-  - .lib/daml-finance/ContingentClaims.Lifecycle/0.1.2/contingent-claims-lifecycle-0.1.2.dar
+  - .lib/daml-finance/ContingentClaims.Lifecycle/0.1.3/contingent-claims-lifecycle-0.1.3.dar
   - .lib/daml-finance/Daml.Finance.Data/0.1.10/daml-finance-data-0.1.10.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.9/daml-finance-interface-claims-0.1.9.dar
   - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.9/daml-finance-interface-data-0.1.9.dar

--- a/package/test/daml/ContingentClaims.Test/daml.yaml
+++ b/package/test/daml/ContingentClaims.Test/daml.yaml
@@ -12,7 +12,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-ctl/v2.3.0/daml-ctl-2.3.0.dar
   - .lib/daml-finance/ContingentClaims.Core/0.1.2/contingent-claims-core-0.1.2.dar
-  - .lib/daml-finance/ContingentClaims.Lifecycle/0.1.2/contingent-claims-lifecycle-0.1.2.dar
+  - .lib/daml-finance/ContingentClaims.Lifecycle/0.1.3/contingent-claims-lifecycle-0.1.3.dar
   - .lib/daml-finance/ContingentClaims.Valuation/0.1.2/contingent-claims-valuation-0.1.2.dar
 build-options:
   - --target=1.15

--- a/src/main/daml/ContingentClaims/Lifecycle/Lifecycle.daml
+++ b/src/main/daml/ContingentClaims/Lifecycle/Lifecycle.daml
@@ -215,8 +215,7 @@ exercise spot election claim acquisitionTime today =
     acquireThenExercise =
       fmap (exercise' election today)
       . sequence
-      . fmap (sequence . (Prelude.fst &&& effectfulAcquire))
-    effectfulAcquire = fmap (expire' . fixAcquisitionTime') <$> acquire' spot today
+      . fmap (sequence . (Prelude.fst &&& acquire' spot today))
 
 -- | Carrier type used for `exercise`. It consists of a claim, its acquisition time and a flag
 -- keeping track of who is the entitled to the election (`True = bearer`).

--- a/src/test/daml/ContingentClaims/Test/Lifecycle.daml
+++ b/src/test/daml/ContingentClaims/Test/Lifecycle.daml
@@ -431,10 +431,10 @@ testAmericanPut = script do
   t <- getDate
 
   remaining <- Lifecycle.exercise observe25 (bearer, payoff) option t0 t
-  remaining === zero -- past maturity; no exercise possible, contract is worthless
+  remaining === option -- past maturity; no exercise possible
 
   Lifecycle.Result{pending, remaining} <- Lifecycle.lifecycle observe25 option t0 t
-  remaining === zero
+  remaining === zero -- past maturity; contract is now worthless
   pending === []
 
 -- | Ensure that acquisition time is propagated correctly (deterministic time)


### PR DESCRIPTION
Fixes https://github.com/digital-asset/contingent-claims/issues/86 and https://github.com/digital-asset/contingent-claims/issues/73.

This change ensures that a failed `exercise` will result in an unchanged claim. This has the benefit that it is very easy to check if an election has failed by checking `input == output`

On the other hand, it means that often we will need to apply a `lifecycle` immediately after an `exercise`. This is already the default behaviour in `Daml.Finance.Claims`, but could potentially also be made the default behaviour on the contingent claims layer.

Happy to hear your thoughts