### PR TITLE
Use time on effects instead of Date

### DIFF
--- a/docs/code-samples/getting-started/daml/Scripts/Lifecycling.daml
+++ b/docs/code-samples/getting-started/daml/Scripts/Lifecycling.daml
@@ -1,6 +1,5 @@
 module Scripts.Lifecycling where
 
-import DA.Date (toDateUTC)
 import DA.Map qualified as M (empty)
 import DA.Set qualified as S (empty, fromList, singleton)
 import Daml.Script
@@ -90,7 +89,7 @@ runLifecycling = do
       providers = S.singleton bank
       id = Id "DISTRIBUTION"
       description = "Profit distribution"
-      effectiveDate = toDateUTC now
+      effectiveTime = now
       targetInstrument = tokenInstrument
       newInstrument = newTokenInstrument
       perUnitDistribution = [Instrument.qty 0.02 usdInstrument]

--- a/src/main/daml/Daml/Finance/Claims/Lifecycle/Rule.daml
+++ b/src/main/daml/Daml/Finance/Claims/Lifecycle/Rule.daml
@@ -5,7 +5,6 @@ module Daml.Finance.Claims.Lifecycle.Rule
   ( Rule(..)
   ) where
 
-import DA.Date (toDateUTC)
 import DA.Set (fromList)
 import DA.Text (sha256)
 import Daml.Finance.Claims.Util (isZero')
@@ -68,7 +67,6 @@ template Rule
         else do
           let
             currentKey = BaseInstrument.getKey $ toInterface claimInstrument
-            settlementDate = toDateUTC v.eventTime
             newKey = currentKey with version = sha256 $ show remaining
             producedInstrument = if isZero' remaining then None else Some newKey
 
@@ -84,7 +82,7 @@ template Rule
             producedInstrument
             otherConsumed
             otherProduced
-            settlementDate
+            settlementTime = Some v.eventTime
             observers = Disclosure.flattenObservers . (.observers) . view $
               toInterface @Disclosure.I claimInstrument
           pure (producedInstrument, [effectCid])

--- a/src/main/daml/Daml/Finance/Instrument/Equity/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Equity/Instrument.daml
@@ -49,37 +49,37 @@ template Instrument
       asBaseInstrument = toInterface @BaseInstrument.I this
       view = Equity.View with instrument = instrumentKey
       declareDividend
-        Equity.DeclareDividend{id; description; effectiveDate; newInstrument; perUnitDistribution} =
+        Equity.DeclareDividend{id; description; effectiveTime; newInstrument; perUnitDistribution} =
           toInterfaceContractId <$>
             create Distribution.Event with
               providers = fromList [issuer, depository]
               id
               description
-              effectiveDate
+              effectiveTime
               targetInstrument = instrumentKey
               newInstrument
               perUnitDistribution
               observers = Disclosure.flattenObservers observers
       declareStockSplit
-        Equity.DeclareStockSplit{id; description; adjustmentFactor; newInstrument; effectiveDate} =
+        Equity.DeclareStockSplit{id; description; adjustmentFactor; newInstrument; effectiveTime} =
           toInterfaceContractId <$>
             -- NOTE: Doesn't handle conversion of fractional shares into cash
             create Replacement.Event with
               providers = fromList [issuer, depository]
               id
               description
-              effectiveDate
+              effectiveTime
               targetInstrument = instrumentKey
               perUnitReplacement = [BaseInstrument.qty (1.0 / adjustmentFactor) newInstrument]
               observers = Disclosure.flattenObservers observers
       declareReplacement
-        Equity.DeclareReplacement{id; description; effectiveDate; perUnitReplacement} =
+        Equity.DeclareReplacement{id; description; effectiveTime; perUnitReplacement} =
           toInterfaceContractId <$>
             create Replacement.Event with
               providers = fromList [issuer, depository]
               id
               description
-              effectiveDate
+              effectiveTime
               targetInstrument = instrumentKey
               perUnitReplacement
               observers = Disclosure.flattenObservers observers

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Lifecycle/Rule.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Lifecycle/Rule.daml
@@ -5,7 +5,6 @@ module Daml.Finance.Instrument.Generic.Lifecycle.Rule
   ( Rule(..)
   ) where
 
-import DA.Date (toDateUTC)
 import DA.Foldable (forA_)
 import DA.Optional (fromSome)
 import DA.Set (fromList)
@@ -64,7 +63,6 @@ template Rule
         else do
           let
             instrumentT : Instrument = fromSome $ fromInterface claimInstrument
-            settlementDate = toDateUTC eventTime
             currentKey = BaseInstrument.getKey $ toInterface claimInstrument
             [claim] = fmap (.claim) remaining
             newKey = currentKey with version = sha256 $ show remaining
@@ -80,7 +78,7 @@ template Rule
               producedInstrument
               otherConsumed
               otherProduced
-              settlementDate
+              settlementTime = Some eventTime
               observers = Disclosure.flattenObservers instrumentT.observers
           pure (producedInstrument, [effectCid])
 
@@ -109,7 +107,6 @@ template Rule
         else do
           let
             instrumentT : Instrument = fromSome $ fromInterface claimInstrument
-            settlementDate = toDateUTC electionTime
             currentKey = BaseInstrument.getKey $ toInterface claimInstrument
             newKey = currentKey with version = sha256 $ show remaining
             [claim] = fmap (.claim) remaining
@@ -128,7 +125,7 @@ template Rule
               amount = v.amount
               otherConsumed
               otherProduced
-              settlementDate
+              settlementTime = Some electionTime
               observers = v.observers
           pure (producedInstrument, [effectCid])
 

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Equity/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Equity/Instrument.daml
@@ -50,8 +50,8 @@ interface Instrument where
         -- ^ Event identifier of the dividend distribution.
       description : Text
         -- ^ Description of the dividend event.
-      effectiveDate : Date
-        -- ^ Date at which the dividend is distributed.
+      effectiveTime : Time
+        -- ^ Time at which the dividend is distributed.
       newInstrument : BaseInstrument.K
         -- ^ Instrument held after the dividend distribution (i.e. "ex-dividend" stock).
       perUnitDistribution : [BaseInstrument.Q]
@@ -67,8 +67,8 @@ interface Instrument where
         -- ^ Event identifier of the stock split.
       description : Text
         -- ^ Description of the stock split event.
-      effectiveDate : Date
-        -- ^ Date at which the stock split is effective.
+      effectiveTime : Time
+        -- ^ Time at which the stock split is effective.
       newInstrument : BaseInstrument.K
         -- ^ Instrument to be held after the stock split is executed.
       adjustmentFactor : Decimal
@@ -89,8 +89,8 @@ interface Instrument where
         -- ^ Distribution Id.
       description : Text
         -- ^ Description of the replacement event.
-      effectiveDate : Date
-        -- ^ Date the replacement is to be executed.
+      effectiveTime : Time
+        -- ^ Time the replacement is to be executed.
       perUnitReplacement : [BaseInstrument.Q]
         -- ^ Payout offered to shareholders per held share.
     controller (view $ asBaseInstrument this).issuer

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Effect.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Effect.daml
@@ -26,8 +26,8 @@ data View = View
       -- ^ A textual identifier.
     description : Text
       -- ^ A human readable description of the Effect.
-    settlementDate : Date
-      -- ^ The effect's settlement date.
+    settlementTime : Optional Time
+      -- ^ The effect's settlement time (if any).
     otherConsumed : [Instrument.Q]
       -- ^ Consumed quantities (in addition to the target instrument).
     otherProduced : [Instrument.Q]

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Event/Distribution.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Event/Distribution.daml
@@ -15,8 +15,8 @@ type V = View
 -- | View for `Event`.
 data View = View
   with
-    effectiveDate : Date
-      -- ^ Date on which the distribution is effectuated.
+    effectiveTime : Time
+      -- ^ Time on which the distribution is effectuated.
     targetInstrument : Instrument.K
       -- ^ Instrument the distribution event applies to.
     newInstrument : Instrument.K

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Event/Replacement.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Event/Replacement.daml
@@ -15,8 +15,8 @@ type V = View
 -- | View for `Event`.
 data View = View
   with
-    effectiveDate : Date
-      -- ^ Date on which the replacement is effectuated.
+    effectiveTime : Time
+      -- ^ Time on which the replacement is effectuated.
     targetInstrument : Instrument.K
       -- ^ Instrument the replacement event applies to.
     perUnitReplacement : [Instrument.Q]

--- a/src/main/daml/Daml/Finance/Lifecycle/Effect.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Effect.daml
@@ -32,8 +32,8 @@ template Effect
       -- ^ Consumed quantities (in addition to the target instrument).
     otherProduced : [Instrument.Q]
       -- ^ Produced quantities (in additon to the produced instrument).
-    settlementDate : Date
-      -- ^ The effect's settlement date.
+    settlementTime : Optional Time
+      -- ^ The effect's settlement time (if any).
     observers : Parties
       -- ^ Observers.
   where
@@ -43,7 +43,7 @@ template Effect
     interface instance Effect.I for Effect where
       view = Effect.View with
         providers; id; description; targetInstrument; producedInstrument; otherConsumed
-        otherProduced; settlementDate
+        otherProduced; settlementTime
 
       calculate Effect.Calculate{holdingCid} _ = do
         holding <- fetch holdingCid

--- a/src/main/daml/Daml/Finance/Lifecycle/ElectionEffect.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/ElectionEffect.daml
@@ -39,8 +39,8 @@ template ElectionEffect
       -- ^ Consumed quantities (not including the target instrument).
     otherProduced : [Instrument.Q]
       -- ^ Produced quantities (not including the produced instrument).
-    settlementDate : Date
-      -- ^ The effect's settlement date.
+    settlementTime : Optional Time
+      -- ^ The effect's settlement time (if any).
     observers : PartiesMap
       -- ^ Observers.
   where
@@ -56,7 +56,7 @@ template ElectionEffect
         producedInstrument
         otherConsumed
         otherProduced
-        settlementDate
+        settlementTime
 
       calculate Effect.Calculate{actor; holdingCid} self = do
         holding <- fetch holdingCid

--- a/src/main/daml/Daml/Finance/Lifecycle/Event/Distribution.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Event/Distribution.daml
@@ -3,7 +3,6 @@
 
 module Daml.Finance.Lifecycle.Event.Distribution where
 
-import DA.Time (time)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (K, Q)
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I, View(..))
 import Daml.Finance.Interface.Lifecycle.Event.Distribution qualified as Distribution (HasImplementation, I, View(..))
@@ -24,8 +23,8 @@ template Event
       -- ^ Event Identifier.
     description : Text
       -- ^ Event description.
-    effectiveDate : Date
-      -- ^ Date on which the distribution is effectuated.
+    effectiveTime : Time
+      -- ^ Time on which the distribution is effectuated.
     targetInstrument : Instrument.K
       -- ^ Instrument the distribution event applies to.
     newInstrument : Instrument.K
@@ -43,9 +42,9 @@ template Event
       && targetInstrument.id == newInstrument.id
 
     interface instance Event.I for Event where
-      view = Event.View with providers; id; description; eventTime = time effectiveDate 0 0 0
+      view = Event.View with providers; id; description; eventTime = effectiveTime
 
     interface instance Distribution.I for Event where
       view = Distribution.View with
-        effectiveDate; targetInstrument; newInstrument; perUnitDistribution
+        effectiveTime; targetInstrument; newInstrument; perUnitDistribution
       asEvent = toInterface @Event.I this

--- a/src/main/daml/Daml/Finance/Lifecycle/Event/Replacement.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Event/Replacement.daml
@@ -3,7 +3,6 @@
 
 module Daml.Finance.Lifecycle.Event.Replacement where
 
-import DA.Time (time)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (K, Q)
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I, View(..))
 import Daml.Finance.Interface.Lifecycle.Event.Replacement qualified as Replacement (HasImplementation, I, View(..))
@@ -24,8 +23,8 @@ template Event
       -- ^ Event identifier.
     description : Text
       -- ^ Event description.
-    effectiveDate : Date
-      -- ^ Date on which the replacement is effectuated.
+    effectiveTime : Time
+      -- ^ Time on which the replacement is effectuated.
     targetInstrument : Instrument.K
       -- ^ Instrument the replacement event applies to.
     perUnitReplacement : [Instrument.Q]
@@ -37,8 +36,8 @@ template Event
     observer observers
 
     interface instance Event.I for Event where
-      view = Event.View with providers; id; description; eventTime = time effectiveDate 0 0 0
+      view = Event.View with providers; id; description; eventTime = effectiveTime
 
     interface instance Replacement.I for Event where
-      view = Replacement.View with effectiveDate; targetInstrument; perUnitReplacement
+      view = Replacement.View with effectiveTime; targetInstrument; perUnitReplacement
       asEvent = toInterface @Event.I this

--- a/src/main/daml/Daml/Finance/Lifecycle/Rule/Claim.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Rule/Claim.daml
@@ -5,7 +5,6 @@ module Daml.Finance.Lifecycle.Rule.Claim where
 
 import DA.Foldable (forA_)
 import DA.Set (member)
-import DA.Time (time)
 import Daml.Finance.Interface.Account.Util (getCustodian, getOwner)
 import Daml.Finance.Interface.Holding.Util (getInstrument)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (Calculate(..), CalculationResult(..), GetView(..))
@@ -90,6 +89,6 @@ template Rule
           description = effectView.description
           contextId = Some effectView.id
           routedSteps
-          settlementTime = Some $ time effectView.settlementDate 0 0 0
+          settlementTime = effectView.settlementTime
 
         pure Claim.ClaimResult with batchCid; instructionCids

--- a/src/main/daml/Daml/Finance/Lifecycle/Rule/Distribution.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Rule/Distribution.daml
@@ -46,6 +46,6 @@ template Rule
             producedInstrument = Some distribution.newInstrument
             otherConsumed = []
             otherProduced = distribution.perUnitDistribution
-            settlementDate = distribution.effectiveDate
+            settlementTime = Some distribution.effectiveTime
             observers
         pure (Some distribution.newInstrument, [effectCid])

--- a/src/main/daml/Daml/Finance/Lifecycle/Rule/Replacement.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Rule/Replacement.daml
@@ -46,6 +46,6 @@ template Rule
             producedInstrument = None
             otherConsumed = []
             otherProduced = replacement.perUnitReplacement
-            settlementDate = replacement.effectiveDate
+            settlementTime = Some replacement.effectiveTime
             observers
         pure (None, [effectCid])

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
@@ -3,7 +3,6 @@
 
 module Daml.Finance.Instrument.Equity.Test.Dividend where
 
-import DA.Date (toDateUTC)
 import DA.Map qualified as M (fromList)
 import DA.Set (fromList, singleton)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
@@ -68,7 +67,7 @@ run = script do
       Equity.DeclareDividend with
         id = Id $ "APPL - " <> show now
         description = "Cash Dividend"
-        effectiveDate = toDateUTC now
+        effectiveTime = now
         newInstrument = exEquityInstrument
         perUnitDistribution = [Instrument.qty 2.0 cashInstrument]
 

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Merger.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Merger.daml
@@ -3,7 +3,6 @@
 
 module Daml.Finance.Instrument.Equity.Test.Merger where
 
-import DA.Date (toDateUTC)
 import DA.Map qualified as M (fromList)
 import DA.Set (fromList, singleton)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
@@ -66,7 +65,7 @@ run = script do
       Equity.DeclareReplacement with
         id = Id $ "ABC merge - " <> show now
         description = "Merge"
-        effectiveDate = toDateUTC now
+        effectiveTime = now
         perUnitReplacement = [Instrument.qty 0.5 mergedInstrument]
 
   -- Lifecycle replacement event

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/StockSplit.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/StockSplit.daml
@@ -3,7 +3,6 @@
 
 module Daml.Finance.Instrument.Equity.Test.StockSplit where
 
-import DA.Date (toDateUTC)
 import DA.Map qualified as M (fromList)
 import DA.Set (fromList, singleton)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
@@ -64,7 +63,7 @@ run = script do
       Equity.DeclareStockSplit with
         id = Id $ "APPL - " <> show now
         description = "Stocksplit"
-        effectiveDate = toDateUTC now
+        effectiveTime = now
         newInstrument = postEquityInstrument
         adjustmentFactor = 0.5
 


### PR DESCRIPTION
This brings the effect in line with settlement by using `Optional Time` instead of `Date`.

It also removes a bunch of Date -> Time conversions.

All our lifecycle events are settled "immediately" (the `settlementTime` coincides with the time of the event). 