### PR TITLE
Cancel of settlement

### DIFF
--- a/src/main/daml/Daml/Finance/Holding/Util.daml
+++ b/src/main/daml/Daml/Finance/Holding/Util.daml
@@ -33,10 +33,10 @@ transferImpl this self Transferable.Transfer{actors; newOwnerAccount} = do
   vNewAccount <- view <$> fetchInterfaceByKey @Account.R @Account.I newOwnerAccount
   -- Verify
   assertMsg "actors must contain all transfer outgoing of the sender account" $
-    S.isSubsetOf vAccount.controllers.outgoing actors
+    vAccount.controllers.outgoing `S.isSubsetOf` actors
   assertMsg "actors must contain all transfer incoming of the receiving account" $
-    S.isSubsetOf vNewAccount.controllers.incoming actors
-  assertMsg "actors must contain all lockers" $ S.isSubsetOf lockers actors
+    vNewAccount.controllers.incoming `S.isSubsetOf` actors
+  assertMsg "actors must contain all lockers" $ lockers `S.isSubsetOf` actors
   assertMsg "custodians must be the same" $ vBase.account.custodian == vAccount.custodian
   -- Release all locks
   let

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Batch.daml
@@ -52,19 +52,19 @@ interface Batch where
       pure $ view this
 
   choice Settle : [ContractId Holding.I]
-    -- ^ Execute settlement.
+    -- ^ Settles the batch.
     with
       actors : Parties
-        -- ^ The parties that executes the settlement.
+        -- ^ The parties settling the batch.
     controller actors
     do
       settle this arg
 
   choice Cancel : ()
-    -- ^ Cancel this batch.
+    -- ^ Cancels the batch.
     with
       actors : Parties
-        -- ^ The parties executing the cancellation.
+        -- ^ The parties canceling the batch.
     controller actors
     do
       cancel this arg

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Batch.daml
@@ -39,6 +39,8 @@ interface Batch where
 
   settle : Settle -> Update [ContractId Holding.I]
     -- ^ Implementation of the `Settle` choice.
+  cancel : Cancel -> Update ()
+    -- ^ Implementation of the `Cancel` choice.
 
   nonconsuming choice GetView : View
     -- ^ Retrieves the interface view.
@@ -57,6 +59,15 @@ interface Batch where
     controller actors
     do
       settle this arg
+
+  choice Cancel : ()
+    -- ^ Execute settlement.
+    with
+      actors : Parties
+        -- ^ The parties that executes the cancel.
+    controller actors
+    do
+      cancel this arg
 
 -- | Type constraint for requiring templates to implement `Batch`.
 type Implementation t = HasToInterface t I

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Batch.daml
@@ -39,7 +39,7 @@ interface Batch where
 
   settle : Settle -> Update [ContractId Holding.I]
     -- ^ Implementation of the `Settle` choice.
-  cancel : Cancel -> Update ()
+  cancel : Cancel -> Update [ContractId Holding.I]
     -- ^ Implementation of the `Cancel` choice.
 
   nonconsuming choice GetView : View
@@ -60,7 +60,7 @@ interface Batch where
     do
       settle this arg
 
-  choice Cancel : ()
+  choice Cancel : [ContractId Holding.I]
     -- ^ Cancels the batch.
     with
       actors : Parties

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Batch.daml
@@ -64,7 +64,7 @@ interface Batch where
     -- ^ Execute settlement.
     with
       actors : Parties
-        -- ^ The parties that executes the cancel.
+        -- ^ The parties that execute the cancel.
     controller actors
     do
       cancel this arg

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Batch.daml
@@ -64,7 +64,7 @@ interface Batch where
     -- ^ Execute settlement.
     with
       actors : Parties
-        -- ^ The parties that execute the cancel.
+        -- ^ The parties that execute the cancellation.
     controller actors
     do
       cancel this arg

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Batch.daml
@@ -61,10 +61,10 @@ interface Batch where
       settle this arg
 
   choice Cancel : ()
-    -- ^ Execute settlement.
+    -- ^ Cancel this batch.
     with
       actors : Parties
-        -- ^ The parties that execute the cancellation.
+        -- ^ The parties executing the cancellation.
     controller actors
     do
       cancel this arg

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Instruction.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Instruction.daml
@@ -67,7 +67,7 @@ interface Instruction where
     -- ^ Allocates this instruction and optionally returns a previously allocated (mutated) asset.
     with
       actors : Parties
-        -- ^ Actors allocating the instruction.
+        -- ^ The parties allocating the instruction.
       allocation : Allocation
         -- ^ Allocation of an instruction.
     controller actors
@@ -78,7 +78,7 @@ interface Instruction where
     -- ^ Approves this instruction.
     with
       actors : Parties
-        -- ^ Actors approving the instruction.
+        -- ^ The parties approving the instruction.
       approval : Approval
         -- ^ Approval of an instruction.
     controller actors
@@ -95,10 +95,10 @@ interface Instruction where
       execute this arg
 
   choice Cancel : Optional (ContractId Holding.I)
-    -- ^ Cancel this instruction.
+    -- ^ Cancels this instruction.
     with
       actors : Parties
-        -- ^ The parties executing the cancellation.
+        -- ^ The parties canceling the instruction.
     controller actors
     do
       cancel this arg

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Instruction.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Instruction.daml
@@ -51,6 +51,8 @@ interface Instruction where
     -- ^ Implementation of the `Approve` choice.
   execute : Execute -> Update (Optional (ContractId Holding.I))
     -- ^ Implementation of the `Execute` choice.
+  cancel : Cancel -> Update (Optional (ContractId Holding.I))
+    -- ^ Implementation of the `Cancel` choice.
 
   nonconsuming choice GetView : View
     -- ^ Retrieves the interface view.
@@ -91,6 +93,15 @@ interface Instruction where
     controller actors
     do
       execute this arg
+
+  choice Cancel : Optional (ContractId Holding.I)
+    -- ^ Cancel this instruction.
+    with
+      actors : Parties
+        -- ^ The parties executing the instruction.
+    controller actors
+    do
+      cancel this arg
 
 -- | Type constraint for requiring templates to implement `Instruction` along with `Disclosure`.
 type Implementation t = (HasToInterface t I, Disclosure.Implementation t)

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Instruction.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Instruction.daml
@@ -98,7 +98,7 @@ interface Instruction where
     -- ^ Cancel this instruction.
     with
       actors : Parties
-        -- ^ The parties executing the instruction.
+        -- ^ The parties executing the cancellation.
     controller actors
     do
       cancel this arg

--- a/src/main/daml/Daml/Finance/Interface/Util/Disclosure.daml
+++ b/src/main/daml/Daml/Finance/Interface/Util/Disclosure.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Interface.Util.Disclosure where
 
 import DA.Map qualified as M (delete, insert, lookup, values)
 import DA.Optional (fromOptional)
-import DA.Set qualified as S (difference, empty, isSubsetOf, null)
+import DA.Set qualified as S (difference, empty, intersection, isSubsetOf, null)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap, Parties)
 import Prelude hiding (null)
 
@@ -79,27 +79,27 @@ interface Disclosure where
     -- Any party can undisclose itself. None is returned if no update is needed.
     with
       disclosers : Parties
-        -- ^ Party calling this choice.
+        -- ^ Parties calling this choice.
       observersToRemove : (Text, Parties)
         -- ^ Observer context to remove.
     controller disclosers
     do
       assertMsg "controller must be authorized to RemoveObservers when removing other parties" $
-        disclosers == snd observersToRemove ||
+        not (S.null $ S.intersection disclosers (snd observersToRemove)) ||
         disclosers `S.isSubsetOf` (view this).disclosureControllers
       let
         key = fst observersToRemove
         curObservers = (view this).observers
       case M.lookup key curObservers of
-        Some parties -> do
-          let updatedParties = parties `S.difference` snd observersToRemove
-          if updatedParties == parties then
+        Some observers -> do
+          let updatedObservers = observers `S.difference` snd observersToRemove
+          if updatedObservers == observers then
             pure None
           else do
             let
-              newObservers = if S.null updatedParties
+              newObservers = if S.null updatedObservers
                 then M.delete key curObservers
-                else M.insert key updatedParties curObservers
+                else M.insert key updatedObservers curObservers
             archive' this $ toInterfaceContractId @I self
             Some <$> setObservers this SetObservers with disclosers; newObservers
         None -> pure None

--- a/src/main/daml/Daml/Finance/Interface/Util/Disclosure.daml
+++ b/src/main/daml/Daml/Finance/Interface/Util/Disclosure.daml
@@ -85,7 +85,7 @@ interface Disclosure where
     controller disclosers
     do
       assertMsg "controller must be authorized to RemoveObservers when removing other parties" $
-        not (S.null $ S.intersection disclosers (snd observersToRemove)) ||
+        not (S.null $ disclosers `S.intersection` snd observersToRemove) ||
         disclosers `S.isSubsetOf` (view this).disclosureControllers
       let
         key = fst observersToRemove

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -7,7 +7,7 @@ import DA.Action (foldlA)
 import DA.Foldable (forA_)
 import DA.List (groupOn)
 import DA.Optional (catOptionals, fromOptional)
-import DA.Set (Set, empty, member, fromList, insert, size)
+import DA.Set (Set, empty, member, fromList, insert, size, union)
 import DA.Traversable qualified as T
 import Daml.Finance.Interface.Holding.Base qualified as Holding (I)
 import Daml.Finance.Interface.Holding.Util (undisclose)
@@ -68,7 +68,6 @@ template Batch
           orderPassThroughChains . fmap (fmap buildKey) $ routedStepsWithInstructionId
         assertMsg "ordering must be complete" $
           length orderedInstructions == length routedStepsWithInstructionId
-
         -- settle
         let
           settleInstruction instruction = do
@@ -77,7 +76,7 @@ template Batch
               Pledge cid -> Some <$> fetch cid
               _ -> pure None
             oSettledHoldingCid <- exercise (toInterfaceContractId @Instruction.I instructionCid)
-              Instruction.Execute with actors
+              Instruction.Execute with actors = actors `union` requestors
             oSettledHolding <- T.mapA fetch oSettledHoldingCid
             let
               usedTypeRepOpts = fmap
@@ -86,15 +85,12 @@ template Batch
             oHoldingCid <-
               T.mapA (\tCid -> fromOptional tCid <$> undiscloseT actors tCid) oSettledHoldingCid
             pure (oHoldingCid, usedTypeRepOpts)
-
         -- execute instructions
         (oHoldingCids, oUsedTypeReps) <- unzip <$> mapA settleInstruction orderedInstructions
-
         -- consistency check
         forA_ (groupOn fst . catOptionals . concat $ oUsedTypeReps) \ts ->
           assertMsg "Allocated holdings of the same instrument must have the same template type rep"
             $ size (fromList ts) == 1
-
         pure $ catOptionals oHoldingCids
 
 -- | HIDE

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -64,7 +64,7 @@ template Batch
         requestors; settlers; id; description; contextId; routedSteps; settlementTime
       settle Batch.Settle{actors} = do
         assertMsg "actors must intersect with settlers" $
-          not $ S.null $ S.intersection actors settlers
+          not $ S.null $ actors `S.intersection` settlers
         -- order instructions (such that they can be executed with passthroughs)
         orderedInstructions <-
           orderPassThroughChains . fmap (fmap buildKey) $ routedStepsWithInstructionId

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -8,7 +8,7 @@ import DA.Foldable (forA_)
 import DA.List (groupOn)
 import DA.Optional (catOptionals, fromOptional)
 import DA.Set (Set)
-import DA.Set qualified as S (empty, member, fromList, insert, intersection, null, size, union)
+import DA.Set qualified as S (empty, member, fromList, insert, intersection, isSubsetOf, null, size, union)
 import DA.Traversable qualified as T
 import Daml.Finance.Interface.Holding.Base qualified as Holding (I)
 import Daml.Finance.Interface.Holding.Util (undisclose)
@@ -94,16 +94,16 @@ template Batch
           assertMsg "Allocated holdings of the same instrument must have the same template type rep"
             $ S.size (S.fromList ts) == 1
         pure $ catOptionals oHoldingCids
-      cancel Batch.Cancel{actors} =
+      cancel Batch.Cancel{actors} = do
+        assertMsg "actors must contain reqeustors" $ S.isSubsetOf requestors actors
         let
           cancelInstruction instruction = do
             instructionCid <- fst <$> (fetchByKey @Instruction instruction)
             exercise (toInterfaceContractId @Instruction.I instructionCid) Instruction.Cancel with
               actors
             pure ()
-        in
-          -- cancel instructions
-          forA_ (map (buildKey . snd) routedStepsWithInstructionId) cancelInstruction
+        -- cancel instructions
+        forA_ (map (buildKey . snd) routedStepsWithInstructionId) cancelInstruction
 
 -- | HIDE
 -- Partially order instructions, so that pass-through chains can be executed in order.

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -101,9 +101,8 @@ template Batch
             instructionCid <- fst <$> (fetchByKey @Instruction instruction)
             exercise (toInterfaceContractId @Instruction.I instructionCid) Instruction.Cancel with
               actors
-            pure ()
         -- cancel instructions
-        forA_ routedStepsWithInstructionId $ cancelInstruction . buildKey . snd
+        catOptionals <$> mapA (cancelInstruction . buildKey . snd) routedStepsWithInstructionId
 
 -- | HIDE
 -- Partially order instructions, so that pass-through chains can be executed in order.

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -7,12 +7,13 @@ import DA.Action (foldlA)
 import DA.Foldable (forA_)
 import DA.List (groupOn)
 import DA.Optional (catOptionals, fromOptional)
-import DA.Set (Set, empty, member, fromList, insert, size, union)
+import DA.Set (Set)
+import DA.Set qualified as S (empty, member, fromList, insert, intersection, null, size, union)
 import DA.Traversable qualified as T
 import Daml.Finance.Interface.Holding.Base qualified as Holding (I)
 import Daml.Finance.Interface.Holding.Util (undisclose)
-import Daml.Finance.Interface.Settlement.Batch qualified as Batch (HasImplementation, I, Settle(..), View(..))
-import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Execute(..), I)
+import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Cancel(..), HasImplementation, I, Settle(..), View(..))
+import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Cancel(..), Execute(..), I)
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), InstructionKey(..), RoutedStep(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..), Parties)
 import Daml.Finance.Settlement.Instruction (Instruction(..))
@@ -55,15 +56,16 @@ template Batch
 
     let
       (routedSteps, instructionIds) = unzip routedStepsWithInstructionId
-      undiscloseT actors = undisclose @Holding.I (show id, actors) actors
+      undiscloseT actors = undisclose @Holding.I (show id, settlers) actors
+      buildKey instructionId = InstructionKey with requestors; batchId = id; id = instructionId
 
     interface instance Batch.I for Batch where
       view = Batch.View with
         requestors; settlers; id; description; contextId; routedSteps; settlementTime
       settle Batch.Settle{actors} = do
+        assertMsg "actors must intersect with settlers" $
+          not $ S.null $ S.intersection actors settlers
         -- order instructions (such that they can be executed with passthroughs)
-        let
-          buildKey instructionId = InstructionKey with requestors; batchId = id; id = instructionId
         orderedInstructions <-
           orderPassThroughChains . fmap (fmap buildKey) $ routedStepsWithInstructionId
         assertMsg "ordering must be complete" $
@@ -76,7 +78,7 @@ template Batch
               Pledge cid -> Some <$> fetch cid
               _ -> pure None
             oSettledHoldingCid <- exercise (toInterfaceContractId @Instruction.I instructionCid)
-              Instruction.Execute with actors = actors `union` requestors
+              Instruction.Execute with actors = actors `S.union` requestors
             oSettledHolding <- T.mapA fetch oSettledHoldingCid
             let
               usedTypeRepOpts = fmap
@@ -90,8 +92,18 @@ template Batch
         -- consistency check
         forA_ (groupOn fst . catOptionals . concat $ oUsedTypeReps) \ts ->
           assertMsg "Allocated holdings of the same instrument must have the same template type rep"
-            $ size (fromList ts) == 1
+            $ S.size (S.fromList ts) == 1
         pure $ catOptionals oHoldingCids
+      cancel Batch.Cancel{actors} =
+        let
+          cancelInstruction instruction = do
+            instructionCid <- fst <$> (fetchByKey @Instruction instruction)
+            exercise (toInterfaceContractId @Instruction.I instructionCid) Instruction.Cancel with
+              actors
+            pure ()
+        in
+          -- cancel instructions
+          forA_ (map (buildKey . snd) routedStepsWithInstructionId) cancelInstruction
 
 -- | HIDE
 -- Partially order instructions, so that pass-through chains can be executed in order.
@@ -99,7 +111,7 @@ orderPassThroughChains : [(RoutedStep, InstructionKey)] -> Update [Instruction]
 orderPassThroughChains routedStepsWithInstructionKeys =
   reverse . fst <$> foldlA
     (\(orderedInstructions, usedInstructionIds) (routedStep, instructionKey) ->
-      if member instructionKey.id usedInstructionIds
+      if S.member instructionKey.id usedInstructionIds
       then
         -- instruction has already been visited, do not re-insert in list
         pure (orderedInstructions, usedInstructionIds)
@@ -108,7 +120,7 @@ orderPassThroughChains routedStepsWithInstructionKeys =
         assertMsg "routed step must match" $ routedStep == instruction.routedStep
         let
           orderedInstructions' = instruction :: orderedInstructions
-          usedInstructionIds' = insert instruction.id usedInstructionIds
+          usedInstructionIds' = S.insert instruction.id usedInstructionIds
         case instruction.allocation of
           Pledge _ ->
             -- a Pledge might be the start of a pass-through chain, try to follow the chain
@@ -118,7 +130,7 @@ orderPassThroughChains routedStepsWithInstructionKeys =
             pure (orderedInstructions, usedInstructionIds)
           _ ->
             pure (orderedInstructions', usedInstructionIds')
-    ) ([], empty) routedStepsWithInstructionKeys
+    ) ([], S.empty) routedStepsWithInstructionKeys
 
 -- | HIDE
 -- Follows the pass-through chain and collects the corresponding instructions in an ordered list.
@@ -131,9 +143,9 @@ collectPassThroughChain
       PassthroughTo (passthroughAccount, toInstructionKey) -> do
         toInstruction <- snd <$> fetchByKey @Instruction toInstructionKey
         assertMsg "toInstruction must not have been used before" $
-          not $ member toInstruction.id usedInstructionIds
+          not $ S.member toInstruction.id usedInstructionIds
         collectPassThroughChain
           (toInstruction :: orderedInstructions)
-          (insert toInstruction.id usedInstructionIds)
+          (S.insert toInstruction.id usedInstructionIds)
           toInstruction
       _ -> pure (orderedInstructions, usedInstructionIds)

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -95,7 +95,7 @@ template Batch
             $ S.size (S.fromList ts) == 1
         pure $ catOptionals oHoldingCids
       cancel Batch.Cancel{actors} = do
-        assertMsg "actors must contain reqeustors" $ S.isSubsetOf requestors actors
+        assertMsg "actors must contain requestors" $ S.isSubsetOf requestors actors
         let
           cancelInstruction instruction = do
             instructionCid <- fst <$> (fetchByKey @Instruction instruction)

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -95,7 +95,7 @@ template Batch
             $ S.size (S.fromList ts) == 1
         pure $ catOptionals oHoldingCids
       cancel Batch.Cancel{actors} = do
-        assertMsg "actors must contain requestors" $ S.isSubsetOf requestors actors
+        assertMsg "actors must contain requestors" $ requestors `S.isSubsetOf` actors
         let
           cancelInstruction instruction = do
             instructionCid <- fst <$> (fetchByKey @Instruction instruction)

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -103,7 +103,7 @@ template Batch
               actors
             pure ()
         -- cancel instructions
-        forA_ (map (buildKey . snd) routedStepsWithInstructionId) cancelInstruction
+        forA_ routedStepsWithInstructionId $ cancelInstruction . buildKey . snd
 
 -- | HIDE
 -- Partially order instructions, so that pass-through chains can be executed in order.

--- a/src/main/daml/Daml/Finance/Settlement/Instruction.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Instruction.daml
@@ -182,6 +182,7 @@ template Instruction
       execute Instruction.Execute{actors} = do
         assertMsg "actors must intersect with settlers" $
           not $ S.null $ S.intersection actors settlers
+        mustContainActors actors requestors
         let
           abortUnapproved = abort $ "instruction must be approved" <> messageSuffix
           abortOnOffLedgerMix =

--- a/src/main/daml/Daml/Finance/Settlement/Instruction.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Instruction.daml
@@ -59,12 +59,12 @@ template Instruction
     let
       messageSuffix = " / instruction id = " <> show id
       context = show batchId <> "(" <> show id <> ")"
-      mustContainActors : Parties -> Parties -> Update ()
-      mustContainActors actors others =
-        assertMsg ("actors must contain " <> show others) $ others `S.isSubsetOf` actors
-      mustBeCustodian : Party -> Update ()
-      mustBeCustodian other =
-        assertMsg ("custodian must match " <> show other) $ routedStep.custodian == other
+      assertIsSubsetOfActors : Parties -> Parties -> Update ()
+      assertIsSubsetOfActors actors others =
+        assertMsg (show others <> " must be a subset of actors") $ others `S.isSubsetOf` actors
+      assertIsCustodian : Party -> Update ()
+      assertIsCustodian other =
+        assertMsg ("custodian must be " <> show other) $ routedStep.custodian == other
       -- utilitise for disclose / undisclose
       discloseA = discloseAccountHelper Account.disclose (context, settlers)
       undiscloseA = discloseAccountHelper Account.undisclose (context, settlers)
@@ -115,7 +115,7 @@ template Instruction
         allocation
         approval
       allocate Instruction.Allocate{actors; allocation} = do
-        let mustAuthorize = mustContainActors actors
+        let mustAuthorize = assertIsSubsetOfActors actors
         assertMsg ("allocation must be new" <> messageSuffix) $ allocation /= this.allocation
         -- undisclose previous allocation
         obCid <- undisclosePreviousAllocation
@@ -129,7 +129,7 @@ template Instruction
             baseCid <- discloseB vSenderAccount.controllers.outgoing settlers baseCid
             mustAuthorize vSenderAccount.controllers.outgoing
             mustAuthorize $ Base.getLockers base
-            mustBeCustodian senderAccount.custodian
+            assertIsCustodian senderAccount.custodian
             getAmount base === routedStep.quantity.amount
             getInstrument base === routedStep.quantity.unit
             pure $ Pledge baseCid
@@ -137,7 +137,7 @@ template Instruction
             discloseA passthroughAccount True
             vSenderAccount <- view <$> fetchInterfaceByKey @Account.R @Account.I passthroughAccount
             mustAuthorize vSenderAccount.controllers.outgoing
-            mustBeCustodian passthroughAccount.custodian
+            assertIsCustodian passthroughAccount.custodian
             pure $ PassthroughFrom (passthroughAccount, fromInstruction)
           CreditReceiver -> do
             mustAuthorize $ S.singleton routedStep.custodian
@@ -154,7 +154,7 @@ template Instruction
           signedSenders = if allocationDisclosed == Unallocated then S.empty else actors
         pure (cid, obCid)
       approve Instruction.Approve{actors; approval} = do
-        let mustAuthorize = mustContainActors actors
+        let mustAuthorize = assertIsSubsetOfActors actors
         assertMsg ("approval must be new" <> messageSuffix) $ approval /= this.approval
         -- undisclose previous approval
         undiclosePreviousApproval
@@ -164,18 +164,18 @@ template Instruction
             discloseA receiverAccount False
             vReceiverAccount <- view <$> fetchInterfaceByKey @Account.R @Account.I receiverAccount
             mustAuthorize vReceiverAccount.controllers.incoming
-            mustBeCustodian receiverAccount.custodian
+            assertIsCustodian receiverAccount.custodian
           PassthroughTo (passthroughAccount, toInstruction) -> do
             discloseA passthroughAccount False
             vReceiverAccount <- view <$>
               fetchInterfaceByKey @Account.R @Account.I passthroughAccount
             mustAuthorize vReceiverAccount.controllers.incoming
             mustAuthorize vReceiverAccount.controllers.outgoing
-            mustBeCustodian passthroughAccount.custodian
+            assertIsCustodian passthroughAccount.custodian
             (_, toInstruction) <- fetchByKey @Instruction toInstruction
-            mustBeCustodian toInstruction.routedStep.custodian
+            assertIsCustodian toInstruction.routedStep.custodian
           DebitSender -> do
-            mustBeCustodian routedStep.receiver
+            assertIsCustodian routedStep.receiver
             mustAuthorize $ S.singleton routedStep.custodian
           SettleOffLedgerAcknowledge -> do
             mustAuthorize $ S.singleton routedStep.custodian
@@ -188,7 +188,7 @@ template Instruction
       execute Instruction.Execute{actors} = do
         assertMsg "actors must intersect with settlers" $
           not $ S.null $ actors `S.intersection` settlers
-        mustContainActors actors requestors
+        assertIsSubsetOfActors actors requestors
         let
           abortUnapproved = abort $ "instruction must be approved" <> messageSuffix
           abortOnOffLedgerMix =
@@ -249,7 +249,7 @@ template Instruction
           (CreditReceiver, a) ->
             case a of
               TakeDelivery receiverAccount -> do
-                mustBeCustodian routedStep.sender
+                assertIsCustodian routedStep.sender
                 baseCid <- Account.exerciseInterfaceByKey @Account.I receiverAccount
                   routedStep.custodian Account.Credit with quantity = routedStep.quantity
                 viewA <- view <$> fetchInterfaceByKey @Account.R @Account.I receiverAccount
@@ -270,7 +270,7 @@ template Instruction
               SettleOffLedgerAcknowledge -> pure None
               _ -> abortOnOffLedgerMix
       cancel Instruction.Cancel{actors} = do
-        mustContainActors actors requestors
+        assertIsSubsetOfActors actors requestors
         undiclosePreviousApproval
         undisclosePreviousAllocation
 

--- a/src/main/daml/Daml/Finance/Settlement/Instruction.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Instruction.daml
@@ -73,7 +73,7 @@ template Instruction
         disclose @Base.I (show batchId, settlers) viewer disclosers cid
       undiscloseB disclosers settlers cid =
         undisclose @Base.I (show batchId, settlers) disclosers cid
-      undiclosePreviousAllocation = do
+      undisclosePreviousAllocation = do
         case allocation of
           Pledge previousBaseCid -> do
             previousBase <- fetch previousBaseCid
@@ -118,7 +118,7 @@ template Instruction
         let mustAuthorize = mustContainActors actors
         assertMsg ("allocation must be new" <> messageSuffix) $ allocation /= this.allocation
         -- undisclose previous allocation
-        obCid <- undiclosePreviousAllocation
+        obCid <- undisclosePreviousAllocation
         -- allocate
         allocationDisclosed <- case allocation of
           Pledge baseCid -> do
@@ -272,7 +272,7 @@ template Instruction
       cancel Instruction.Cancel{actors} = do
         mustContainActors actors requestors
         undiclosePreviousApproval
-        undiclosePreviousAllocation
+        undisclosePreviousAllocation
 
 -- | HIDE
 discloseAccountHelper : forall a. ((Text, Parties) -> Party -> Parties -> AccountKey -> Update a) ->

--- a/src/main/daml/Daml/Finance/Settlement/Instruction.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Instruction.daml
@@ -61,7 +61,7 @@ template Instruction
       context = show batchId <> "(" <> show id <> ")"
       mustContainActors : Parties -> Parties -> Update ()
       mustContainActors actors others =
-        assertMsg ("actors must contain " <> show others) $ S.isSubsetOf others actors
+        assertMsg ("actors must contain " <> show others) $ others `S.isSubsetOf` actors
       mustBeCustodian : Party -> Update ()
       mustBeCustodian other =
         assertMsg ("custodian must match " <> show other) $ routedStep.custodian == other
@@ -187,7 +187,7 @@ template Instruction
           signedReceivers = if approval == Unapproved then S.empty else actors
       execute Instruction.Execute{actors} = do
         assertMsg "actors must intersect with settlers" $
-          not $ S.null $ S.intersection actors settlers
+          not $ S.null $ actors `S.intersection` settlers
         mustContainActors actors requestors
         let
           abortUnapproved = abort $ "instruction must be approved" <> messageSuffix

--- a/src/main/daml/Daml/Finance/Settlement/Instruction.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Instruction.daml
@@ -11,7 +11,7 @@ import Daml.Finance.Interface.Account.Util (getAccount)
 import Daml.Finance.Interface.Holding.Base qualified as Base (I, getLockers)
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I, Transfer(..))
 import Daml.Finance.Interface.Holding.Util (disclose, getAmount, getInstrument, undisclose)
-import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..), Execute(..), HasImplementation, I, View(..))
+import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..), Cancel(..), Execute(..), HasImplementation, I, View(..))
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), InstructionKey(..), RoutedStep)
 import Daml.Finance.Interface.Types.Common.Types (AccountKey, Id(..), Parties, PartiesMap)
 import Daml.Finance.Interface.Util.Common (fetchInterfaceByKey)
@@ -59,6 +59,13 @@ template Instruction
     let
       messageSuffix = " / instruction id = " <> show id
       context = show batchId <> "(" <> show id <> ")"
+      mustContainActors : Parties -> Parties -> Update ()
+      mustContainActors actors others =
+        assertMsg ("actors must contain " <> show others) $ S.isSubsetOf others actors
+      mustBeCustodian : Party -> Update ()
+      mustBeCustodian other =
+        assertMsg ("custodian must match " <> show other) $ routedStep.custodian == other
+      -- utilitise for disclose / undisclose
       discloseA = discloseAccountHelper Account.disclose (context, settlers)
       undiscloseA = discloseAccountHelper Account.undisclose (context, settlers)
       discloseB disclosers settlers cid = do
@@ -66,12 +73,26 @@ template Instruction
         disclose @Base.I (show batchId, settlers) viewer disclosers cid
       undiscloseB disclosers settlers cid =
         undisclose @Base.I (show batchId, settlers) disclosers cid
-      mustContainActors : Parties -> Parties -> Update ()
-      mustContainActors actors others =
-        assertMsg ("actors must contain " <> show others) $ S.isSubsetOf others actors
-      mustBeCustodian : Party -> Update ()
-      mustBeCustodian other =
-        assertMsg ("custodian must match " <> show other) $ routedStep.custodian == other
+      undiclosePreviousAllocation = do
+        case allocation of
+          Pledge previousBaseCid -> do
+            previousBase <- fetch previousBaseCid
+            let previousSenderAccount = getAccount previousBase
+            undiscloseA previousSenderAccount True
+            viewA <- view <$> fetchInterfaceByKey @Account.R @Account.I previousSenderAccount
+            undiscloseB viewA.controllers.outgoing settlers previousBaseCid
+          PassthroughFrom (previousPassthroughAccount, _) -> do
+            undiscloseA previousPassthroughAccount True
+            pure None
+          _ ->
+            pure None
+      undiclosePreviousApproval =
+        case approval of
+          TakeDelivery previousReceiverAccount ->
+            undiscloseA previousReceiverAccount False
+          PassthroughTo (previousPassthroughAccount, _) ->
+            undiscloseA previousPassthroughAccount False
+          _ -> pure None
 
     interface instance Disclosure.I for Instruction where
       view = Disclosure.View with
@@ -97,17 +118,7 @@ template Instruction
         let mustAuthorize = mustContainActors actors
         assertMsg ("allocation must be new" <> messageSuffix) $ allocation /= this.allocation
         -- undisclose previous allocation
-        otCid <- case this.allocation of
-          Pledge previousBaseCid -> do
-            previousBase <- fetch previousBaseCid
-            let previousSenderAccount = getAccount previousBase
-            undiscloseA previousSenderAccount True
-            viewA <- view <$> fetchInterfaceByKey @Account.R @Account.I previousSenderAccount
-            undiscloseB viewA.controllers.outgoing settlers previousBaseCid
-          PassthroughFrom (previousPassthroughAccount, _) -> do
-            undiscloseA previousPassthroughAccount True
-            pure None
-          _ -> pure None
+        obCid <- undiclosePreviousAllocation
         -- allocate
         allocationDisclosed <- case allocation of
           Pledge baseCid -> do
@@ -141,17 +152,12 @@ template Instruction
         cid <- toInterfaceContractId <$> create this with
           allocation = allocationDisclosed
           signedSenders = if allocationDisclosed == Unallocated then S.empty else actors
-        pure (cid, otCid)
+        pure (cid, obCid)
       approve Instruction.Approve{actors; approval} = do
         let mustAuthorize = mustContainActors actors
         assertMsg ("approval must be new" <> messageSuffix) $ approval /= this.approval
         -- undisclose previous approval
-        case this.approval of
-          TakeDelivery previousReceiverAccount ->
-            undiscloseA previousReceiverAccount False
-          PassthroughTo (previousPassthroughAccount, _) ->
-            undiscloseA previousPassthroughAccount False
-          _ -> pure None
+        undiclosePreviousApproval
         -- approve
         case approval of
           TakeDelivery receiverAccount -> do
@@ -210,8 +216,8 @@ template Instruction
                 -- undiclose accounts
                 undiscloseA senderAccount True
                 undiscloseA receiverAccount False
-                -- disclose to actors (such that they can get the TemplateTypeRep in the Batch)
-                Some <$> discloseB viewA.controllers.incoming actors baseCid
+                -- disclose to settlers (such that they can get the TemplateTypeRep in the Batch)
+                Some <$> discloseB viewA.controllers.incoming settlers baseCid
               DebitSender -> do
                 base <- fetch baseCid
                 let senderAccount = getAccount base
@@ -263,6 +269,10 @@ template Instruction
             case a of
               SettleOffLedgerAcknowledge -> pure None
               _ -> abortOnOffLedgerMix
+      cancel Instruction.Cancel{actors} = do
+        mustContainActors actors requestors
+        undiclosePreviousApproval
+        undiclosePreviousAllocation
 
 -- | HIDE
 discloseAccountHelper : forall a. ((Text, Parties) -> Party -> Parties -> AccountKey -> Update a) ->

--- a/src/test/daml/Daml/Finance/Settlement/Test/Batch.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Batch.daml
@@ -3,15 +3,13 @@
 
 module Daml.Finance.Settlement.Test.Batch where
 
-import DA.Date (addDays, toDateUTC)
-import DA.Map qualified as M (empty)
-import DA.Set (empty, fromList, singleton)
-import DA.Time (time)
+import DA.Map qualified as M (fromList)
+import DA.Set (fromList, singleton, toList)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
-import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
+import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Cancel(..), Settle(..))
 import Daml.Finance.Interface.Settlement.Factory qualified as Factory (I, Instruct(..))
-import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
+import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..), Execute(..))
 import Daml.Finance.Interface.Settlement.RouteProvider qualified as RouteProvider (I, Discover(..))
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), Step(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..))
@@ -38,6 +36,8 @@ data TestParties = TestParties
       -- ^ Buyer of the equity instrument.
     seller : Party
       -- ^ Seller of the equity instrument.
+    publicParty : Party
+      -- ^ The public party. Every party can readAs the public party.
 
 -- DvP via settlement chain and instructions.
 -- Seller transfers equity to buyer in exchange for cash.
@@ -52,14 +52,15 @@ data TestParties = TestParties
 -- |     \  /       | securities            |
 -- |     Bank       |                       |
 -- +----------------+-----------------------+
-run: Bool -> Script ()
-run settleCashOnLedger = script do
+run: Bool -> Bool -> Script ()
+run settleCashOnLedger bankIsRequesting = script do
   TestParties{..} <- setupParties
 
   -- Account and holding factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank []
   holdingFactoryCid <- toInterfaceContractId <$> submit bank do
-    createCmd Fungible.Factory with provider = bank; observers = M.empty
+    createCmd Fungible.Factory with
+      provider = bank; observers = M.fromList [("PublicParty", singleton publicParty)]
 
   -- Originate instruments
   now <- getTime
@@ -86,24 +87,39 @@ run settleCashOnLedger = script do
       , Step with
           sender = buyer; receiver = seller; quantity = Instrument.qty 200_000.0 cashInstrument
       ]
-    settlementTime = time (addDays (toDateUTC now) 1) 0 0 0
 
   -- Discover settlement routes
   routeProviderCid <- toInterfaceContractId @RouteProvider.I <$> submit bank do
     createCmd SingleCustodian with
-      provider = bank; observers = empty; custodian = bank
+      provider = bank; custodian = bank; observers = singleton publicParty
   routedSteps <- submit bank do
     exerciseCmd routeProviderCid RouteProvider.Discover with
       discoverors = singleton bank; contextId = None; steps
 
-  -- Instruct settlement
-  settlementFactoryCid <- toInterfaceContractId @Factory.I <$> submit bank do
-    createCmd Factory with provider = bank; observers = empty
-  (batchCid, [equityInstructionCid, cashInstructionCid]) <-
+  -- Setup settlement factory
+  settlementFactoryCid <- toInterfaceContractId @Factory.I <$>
     submit bank do
+      createCmd Factory with provider = bank; observers = singleton publicParty
+
+  -- Instruct settlement
+  let
+    requestors = fromList $ if bankIsRequesting then [bank] else [buyer, seller]
+    settlers = fromList [buyer, seller]
+    instructCmd = submitMulti (toList requestors) [publicParty] do
       exerciseCmd settlementFactoryCid Factory.Instruct with
-        instructors = singleton bank; settlers = singleton bank; id = Id "APPL 1000@200.0USD"
-        description = "DVP"; contextId = None; routedSteps; settlementTime = Some settlementTime
+        instructors = requestors; settlers; id = Id "APPL 1000@200.0USD"; description = "DVP"
+        contextId = None; routedSteps; settlementTime = None
+
+  -- Create batch and instructions, and then cancel
+  (batchCid, _) <- instructCmd
+  -- seller can't cancel batch
+  submitMustFail seller do exerciseCmd batchCid Batch.Cancel with actors = singleton seller
+  -- requestors can cancel batch
+  submitMulti (toList requestors) [] do
+    exerciseCmd batchCid Batch.Cancel with actors = requestors
+
+  -- Create batch and instructions
+  (batchCid, [equityInstructionCid, cashInstructionCid]) <- instructCmd
 
   -- Allocate and approve equity instruction
   (equityInstructionCid, _) <- submit seller do
@@ -127,7 +143,7 @@ run settleCashOnLedger = script do
             actors = singleton seller; approval = TakeDelivery sellerCashAccount
     else
       do
-        -- Settle by off ledger trasnfer
+        -- Settle by off ledger transfer
         (cashInstructionCid, _) <- submitMulti [buyer, bank] [] do
           exerciseCmd cashInstructionCid Instruction.Allocate with
             actors = fromList [buyer, bank]; allocation = SettleOffLedger
@@ -135,11 +151,23 @@ run settleCashOnLedger = script do
           exerciseCmd cashInstructionCid Instruction.Approve with
             actors = fromList [seller, bank]; approval = SettleOffLedgerAcknowledge
 
-  -- Set time
-  setTime settlementTime
-
   -- Settle batch
-  cids <- submit bank do exerciseCmd batchCid Batch.Settle with actors = singleton bank
+  -- neither the bank, nor seller, nor buyer can execute an instruction
+  submitMustFail bank do
+    exerciseCmd cashInstructionCid Instruction.Execute with actors = singleton bank
+  submitMustFail seller do
+    exerciseCmd cashInstructionCid Instruction.Execute with actors = singleton seller
+  submitMustFail buyer do
+    exerciseCmd cashInstructionCid Instruction.Execute with actors = singleton buyer
+  -- the bank can't settle the batch
+  if bankIsRequesting then
+    submitMultiMustFail [bank] [] do
+      exerciseCmd batchCid Batch.Settle with actors = singleton bank
+  else
+    pure ()
+  -- any of the settlers can settle the batch (i.e., buyer or seller)
+  cids <- submitMulti [buyer] [publicParty] do
+    exerciseCmd batchCid Batch.Settle with actors = singleton buyer
 
   -- Assert state
   let ts = zip [buyer, seller] cids
@@ -148,17 +176,25 @@ run settleCashOnLedger = script do
 
   pure ()
 
--- Settles cash by off-ledger means.
+-- Settle cash on-ledger
+-- with bank as requestor
 run1 : Script ()
-run1 = run True
-
--- Settles cash on-ledger.
+run1 = run True True
+-- with buyer and seller as requestors
 run2 : Script ()
-run2 = run False
+run2 = run True False
+
+-- Settle cash off-ledger
+-- with bank as requestor
+run3 : Script ()
+run3 = run False True
+-- with buyer and seller as requestors
+run4 : Script ()
+run4 = run False False
 
 -- | Settup parties for the scripts
 setupParties : Script TestParties
 setupParties = do
-  [cb, csd, bank, issuer, buyer, seller] <- createParties
-    ["CentralBank", "CentralSecurityDepository", "Bank", "Issuer", "Buyer", "Seller"]
-  pure TestParties with cb, csd, bank, issuer, buyer, seller
+  [cb, csd, bank, issuer, buyer, seller, publicParty] <- createParties
+    ["CentralBank", "CentralSecurityDepository", "Bank", "Issuer", "Buyer", "Seller", "PublicParty"]
+  pure TestParties with cb, csd, bank, issuer, buyer, seller, publicParty


### PR DESCRIPTION
1. **Restriction for settling individual `Instruction`** 
To avoid instructions being settled individually, i.e., not as part of the batch, we require the `requestors` and at least on of the `settlers` to settle `Instruction`s. Any of the `settlers` can still trigger a settlement of the `Batch` (and as a consequence its `Instruction`s).
2. **`requestors` can now cancel a `Batch` (and its `Instruction`s)** 
3. **Changed the authorization for `RemoveObservers`**
For disclosure purposes, I had to change the authorization for `RemoveObservers`. Now any of the parties of a context can remove the whole context (and clean up for the others). 

These changes do not affect the quickstarter 

**follow up:** I think we should factor out the actual choice bodies of the `Disclosure.I` (as we have done for most of our interfaces) https://github.com/digital-asset/daml-finance/issues/462