### PR TITLE
Calendar improvements

### DIFF
--- a/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
@@ -10,6 +10,8 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/0.1.8/daml-finance-interface-types-common-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/0.1.8/daml-finance-interface-types-date-0.1.8.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.8/daml-finance-interface-util-0.1.8.dar
 build-options:
   - --target=1.15
 

--- a/package/test/daml/Daml.Finance.Data.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Data.Test/daml.yaml
@@ -11,6 +11,7 @@ dependencies:
   - daml-script
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Data/0.1.9/daml-finance-data-0.1.9.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.8/daml-finance-interface-data-0.1.8.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/0.1.8/daml-finance-interface-types-date-0.1.8.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/0.1.11/daml-finance-test-util-0.1.11.dar
 build-options:

--- a/src/main/daml/Daml/Finance/Claims/Util/Builders.daml
+++ b/src/main/daml/Daml/Finance/Claims/Util/Builders.daml
@@ -19,16 +19,14 @@ import Prelude hiding (key)
 
 -- | Retrieve holiday calendar(s) from the ledger.
 getHolidayCalendars : [Text] -> Party -> Party -> Update [HolidayCalendarData]
-getHolidayCalendars holidayCalendarIds actor calendarDataAgency =
+getHolidayCalendars holidayCalendarIds actor provider =
   let
     -- get a holiday calendar from the ledger
-    getCalendar holidayCalendarId = do
+    getCalendar id = do
       exerciseByKey @HolidayCalendar holCalKey GetCalendar with viewer = actor where
-        holCalKey = HolidayCalendarKey with
-          agency = calendarDataAgency
-          entity = holidayCalendarId
+        holCalKey = HolidayCalendarKey with provider; id
   in
-    -- Get the holiday calendars
+    -- get the holiday calendars
     mapA getCalendar holidayCalendarIds
 
 -- | Retrieve holiday calendar(s) from the ledger and roll out the payment schedule.

--- a/src/main/daml/Daml/Finance/Claims/Util/Builders.daml
+++ b/src/main/daml/Daml/Finance/Claims/Util/Builders.daml
@@ -31,8 +31,8 @@ getHolidayCalendars holidayCalendarIds actor provider =
 
 -- | Retrieve holiday calendar(s) from the ledger and roll out the payment schedule.
 rollPaymentSchedule : PeriodicSchedule -> [Text] -> Party -> Party -> Update Schedule
-rollPaymentSchedule periodicSchedule holidayCalendarIds actor calendarDataAgency = do
-  cals <- getHolidayCalendars holidayCalendarIds actor calendarDataAgency
+rollPaymentSchedule periodicSchedule holidayCalendarIds actor calendarDataProvider = do
+  cals <- getHolidayCalendars holidayCalendarIds actor calendarDataProvider
   pure $ createSchedule cals periodicSchedule
 
 -- | Convert the claims to UTCTime and tag them.

--- a/src/main/daml/Daml/Finance/Data/Reference/HolidayCalendar.daml
+++ b/src/main/daml/Daml/Finance/Data/Reference/HolidayCalendar.daml
@@ -2,15 +2,17 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 module Daml.Finance.Data.Reference.HolidayCalendar
-  ( GetCalendar(..)
+  ( Factory(..)
+  , GetCalendar(..)
   , HolidayCalendar(..)
   , HolidayCalendarKey(..)
-  , UpdateCalendar(..)
   ) where
 
 import DA.Set (singleton)
+import Daml.Finance.Interface.Data.Reference.HolidayCalendar qualified as HolidayCalendar (I, View(..))
+import Daml.Finance.Interface.Data.Reference.HolidayCalendar.Factory qualified as HolidayCalendarFactory
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
-import Daml.Finance.Interface.Types.Date.Calendar
+import Daml.Finance.Interface.Types.Date.Calendar (HolidayCalendarData)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, SetObservers(..), View(..), flattenObservers)
 
 -- | Key used to look up the holiday calendar of an entity, as defined by a reference data provider.
@@ -27,12 +29,12 @@ data HolidayCalendarKey = HolidayCalendarKey
 -- It is maintained by a reference data provider.
 template HolidayCalendar
   with
-    provider : Party
-      -- ^ The party maintaining the `HolidayCalendar`.
     calendar : HolidayCalendarData
       -- ^ Holiday Calendar Data used to define holidays.
     observers : PartiesMap
       -- ^ Observers.
+    provider : Party
+      -- ^ The party maintaining the `HolidayCalendar`.
   where
     signatory provider
     observer Disclosure.flattenObservers observers
@@ -46,6 +48,12 @@ template HolidayCalendar
         toInterfaceContractId <$> create this with observers = newObservers
       archive' = archive . fromInterfaceContractId @HolidayCalendar
 
+    interface instance HolidayCalendar.I for HolidayCalendar where
+      asDisclosure = toInterface @Disclosure.I this
+      view = HolidayCalendar.View with calendar; provider
+      updateCalendar arg =
+        toInterfaceContractId <$> create this with calendar = arg.newCalendar
+
     nonconsuming choice GetCalendar : HolidayCalendarData
       -- ^ Returns the calendar's `HolidayCalendarData`.
       with
@@ -55,11 +63,29 @@ template HolidayCalendar
       do
         pure calendar
 
-    choice UpdateCalendar : ContractId HolidayCalendar
-      -- ^ Updates the holiday calendar.
-      with
-        newCalendar : HolidayCalendarData
-          -- ^ The new `HolidayCalendarData`.
-      controller provider
-      do
-        create this with calendar = newCalendar
+-- | Implementation of the corresponding HolidayCalendar Factory.
+template Factory
+  with
+    provider : Party
+      -- ^ The factory's provider.
+    observers : PartiesMap
+      -- ^ The factory's observers.
+  where
+    signatory provider
+    observer Disclosure.flattenObservers observers
+
+    interface instance HolidayCalendarFactory.F for Factory
+      where
+        asDisclosure = toInterface @Disclosure.I this
+        view = HolidayCalendarFactory.View with provider
+        create' HolidayCalendarFactory.Create{calendar; observers; provider} =
+          toInterfaceContractId <$>
+            create HolidayCalendar with calendar; observers; provider
+        remove HolidayCalendarFactory.Remove{cid} =
+          archive $ fromInterfaceContractId @HolidayCalendar cid
+
+    interface instance Disclosure.I for Factory where
+      view = Disclosure.View with disclosureControllers = singleton provider; observers
+      setObservers Disclosure.SetObservers{newObservers} =
+        toInterfaceContractId <$> create this with observers = newObservers
+      archive' = archive . fromInterfaceContractId @Factory

--- a/src/main/daml/Daml/Finance/Data/Reference/HolidayCalendar.daml
+++ b/src/main/daml/Daml/Finance/Data/Reference/HolidayCalendar.daml
@@ -13,38 +13,35 @@ import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Types.Date.Calendar
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, SetObservers(..), View(..), flattenObservers)
 
--- | Key used to look up the holiday calendar of an entity, as defined by a reference data agency.
+-- | Key used to look up the holiday calendar of an entity, as defined by a reference data provider.
 data HolidayCalendarKey = HolidayCalendarKey
   with
-    agency : Party
+    provider : Party
       -- ^ The party maintaining the `HolidayCalendar`.
-    entity : Text
+    id : Text
       -- ^ A textual label identifying the calendar (e.g. "NYSE" for the New York Stock Exchange
       --   holiday calendar).
   deriving (Eq, Show)
 
 -- | Holiday calendar of an entity (typically an exchange or a currency).
--- It is maintained by a reference data agency.
+-- It is maintained by a reference data provider.
 template HolidayCalendar
   with
-    agency : Party
+    provider : Party
       -- ^ The party maintaining the `HolidayCalendar`.
-    entity : Text
-      -- ^ A textual label identifying the calendar (e.g. "NYSE" for the New York Stock Exchange
-      --   holiday calendar).
     calendar : HolidayCalendarData
       -- ^ Holiday Calendar Data used to define holidays.
     observers : PartiesMap
       -- ^ Observers.
   where
-    signatory agency
+    signatory provider
     observer Disclosure.flattenObservers observers
 
-    key HolidayCalendarKey with agency, entity : HolidayCalendarKey
-    maintainer key.agency
+    key (HolidayCalendarKey with provider; id = calendar.id) : HolidayCalendarKey
+    maintainer key.provider
 
     interface instance Disclosure.I for HolidayCalendar where
-      view = Disclosure.View with disclosureControllers = singleton agency; observers
+      view = Disclosure.View with disclosureControllers = singleton provider; observers
       setObservers Disclosure.SetObservers{newObservers} =
         toInterfaceContractId <$> create this with observers = newObservers
       archive' = archive . fromInterfaceContractId @HolidayCalendar
@@ -63,6 +60,6 @@ template HolidayCalendar
       with
         newCalendar : HolidayCalendarData
           -- ^ The new `HolidayCalendarData`.
-      controller agency
+      controller provider
       do
         create this with calendar = newCalendar

--- a/src/main/daml/Daml/Finance/Interface/Data/Reference/HolidayCalendar.daml
+++ b/src/main/daml/Daml/Finance/Interface/Data/Reference/HolidayCalendar.daml
@@ -1,0 +1,40 @@
+module Daml.Finance.Interface.Data.Reference.HolidayCalendar where
+
+-- import Daml.Finance.Interface.Types.Common.Types (Parties, PartiesMap)
+-- import Daml.Finance.Interface.Types.Date.Calendar
+-- import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
+-- import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, SetObservers(..), View(..), flattenObservers)
+
+-- | Type synonym for `HolidayCalendar`.
+-- type I = HolidayCalendar
+
+-- -- | Type synonym for `View`.
+-- type V = View
+
+-- -- | View for `HolidayCalendar`.
+-- data View = View
+--   with
+--     agency : Parties
+--       -- ^ The parties maintaining the `HolidayCalendar`.
+--     entity : Text
+--       -- ^ A textual label identifying the calendar (e.g. "NYSE" for the New York Stock Exchange
+--       --   holiday calendar).
+--     calendar : HolidayCalendarData
+--       -- ^ Holiday Calendar Data used to define holidays.
+--     observers : PartiesMap
+--       -- ^ Observers.
+
+-- interface HolidayCalendar where
+--   viewtype V
+
+--   asDisclosure : Disclosure.I
+--     -- ^ Conversion to `Disclosure` interface.
+
+--   nonconsuming choice GetView : View
+--     -- ^ Retrieves the interface view.
+--     with
+--       viewer : Party
+--         -- ^ The party fetching the view.
+--     controller viewer
+--     do
+--       pure $ view this

--- a/src/main/daml/Daml/Finance/Interface/Data/Reference/HolidayCalendar.daml
+++ b/src/main/daml/Daml/Finance/Interface/Data/Reference/HolidayCalendar.daml
@@ -1,40 +1,53 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module Daml.Finance.Interface.Data.Reference.HolidayCalendar where
 
--- import Daml.Finance.Interface.Types.Common.Types (Parties, PartiesMap)
--- import Daml.Finance.Interface.Types.Date.Calendar
--- import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
--- import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, SetObservers(..), View(..), flattenObservers)
+import Daml.Finance.Interface.Types.Date.Calendar
+import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, Implementation)
 
 -- | Type synonym for `HolidayCalendar`.
--- type I = HolidayCalendar
+type I = HolidayCalendar
 
--- -- | Type synonym for `View`.
--- type V = View
+-- | Type synonym for `View`.
+type V = View
 
--- -- | View for `HolidayCalendar`.
--- data View = View
---   with
---     agency : Parties
---       -- ^ The parties maintaining the `HolidayCalendar`.
---     entity : Text
---       -- ^ A textual label identifying the calendar (e.g. "NYSE" for the New York Stock Exchange
---       --   holiday calendar).
---     calendar : HolidayCalendarData
---       -- ^ Holiday Calendar Data used to define holidays.
---     observers : PartiesMap
---       -- ^ Observers.
+-- | View for `HolidayCalendar`.
+data View = View
+  with
+    provider : Party
+      -- ^ The parties providing the `HolidayCalendar`.
+    calendar : HolidayCalendarData
+      -- ^ Holiday Calendar Data used to define holidays.
 
--- interface HolidayCalendar where
---   viewtype V
+interface HolidayCalendar where
+  viewtype V
 
---   asDisclosure : Disclosure.I
---     -- ^ Conversion to `Disclosure` interface.
+  asDisclosure : Disclosure.I
+    -- ^ Conversion to `Disclosure` interface.
+  updateCalendar : UpdateCalendar -> Update (ContractId HolidayCalendar)
+      -- ^ Updates the holiday calendar.
 
---   nonconsuming choice GetView : View
---     -- ^ Retrieves the interface view.
---     with
---       viewer : Party
---         -- ^ The party fetching the view.
---     controller viewer
---     do
---       pure $ view this
+  nonconsuming choice GetView : View
+    -- ^ Retrieves the interface view.
+    with
+      viewer : Party
+        -- ^ The party fetching the view.
+    controller viewer
+    do
+      pure $ view this
+
+  choice UpdateCalendar : ContractId HolidayCalendar
+    -- ^ Updates the holiday calendar.
+    with
+      newCalendar : HolidayCalendarData
+        -- ^ The new `HolidayCalendarData`.
+    controller (view this).provider
+    do
+      updateCalendar this arg
+
+-- | Type constraint for requiring templates to implement `HolidayCalendar` along with `Disclosure`.
+type Implementation t = (HasToInterface t I, Disclosure.Implementation t)
+instance HasToInterface I Disclosure.I where _toInterface = asDisclosure
+class (Implementation t) => HasImplementation t
+instance HasImplementation I

--- a/src/main/daml/Daml/Finance/Interface/Data/Reference/HolidayCalendar/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Data/Reference/HolidayCalendar/Factory.daml
@@ -1,0 +1,61 @@
+module Daml.Finance.Interface.Data.Reference.HolidayCalendar.Factory where
+
+import Daml.Finance.Interface.Data.Reference.HolidayCalendar qualified as HolidayCalendar (I)
+import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
+import Daml.Finance.Interface.Types.Date.Calendar (HolidayCalendarData)
+import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, Implementation)
+
+-- | Type synonym for `Factory`.
+type F = Factory
+
+-- | Type synonym for `View`.
+type V = View
+
+-- View of `Factory`.
+data View = View
+  with
+    provider : Party
+      -- ^ The provider of the `Factory`.
+  deriving (Eq, Show)
+
+-- | Interface that allows implementing templates to create holiday calendars.
+interface Factory where
+  viewtype V
+
+  asDisclosure : Disclosure.I
+    -- ^ Conversion to `Disclosure` interface.
+  create' : Create -> Update (ContractId HolidayCalendar.I)
+    -- ^ Implementation of `Create` choice.
+  remove : Remove -> Update ()
+    -- ^ Implementation of `Remove` choice.
+
+  nonconsuming choice Create : ContractId HolidayCalendar.I
+    -- ^ Create a new Holiday Calendar.
+    with
+      calendar : HolidayCalendarData
+        -- ^ Holiday Calendar Data used to define holidays.
+      observers : PartiesMap
+        -- ^ Observers.
+      provider : Party
+        -- ^ The calendar's provider.
+    controller provider
+    do
+      create' this arg
+
+  nonconsuming choice Remove : ()
+    -- ^ Archive an Holiday Calendar.
+    with
+      cid : ContractId HolidayCalendar.I
+        -- ^ The calendar's contractid.
+      provider : Party
+        -- ^ The calendar's provider.
+    controller provider
+      do
+        remove this arg
+
+-- | Type constraint for requiring templates to implement `Factory` along with `Disclosure`.
+type Implementation t = (HasToInterface t F, Disclosure.Implementation t)
+instance HasToInterface F Disclosure.I where _toInterface = asDisclosure
+class (Implementation t) => HasImplementation t
+instance HasImplementation F
+

--- a/src/main/daml/Daml/Finance/Interface/Data/Reference/HolidayCalendar/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Data/Reference/HolidayCalendar/Factory.daml
@@ -1,3 +1,6 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module Daml.Finance.Interface.Data.Reference.HolidayCalendar.Factory where
 
 import Daml.Finance.Interface.Data.Reference.HolidayCalendar qualified as HolidayCalendar (I)
@@ -58,4 +61,5 @@ type Implementation t = (HasToInterface t F, Disclosure.Implementation t)
 instance HasToInterface F Disclosure.I where _toInterface = asDisclosure
 class (Implementation t) => HasImplementation t
 instance HasImplementation F
+
 

--- a/src/main/daml/Daml/Finance/Interface/Data/TimeObservable.daml
+++ b/src/main/daml/Daml/Finance/Interface/Data/TimeObservable.daml
@@ -43,7 +43,7 @@ interface TimeObservable where
     -- ^ Retrieves the current time.
     with
       actors : Parties
-        -- ^ The party retrieving the view.
+        -- ^ The party retrieving the current time.
     controller actors
     do
       getTime this

--- a/src/main/daml/Daml/Finance/Interface/Holding/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Holding/Factory.daml
@@ -58,7 +58,7 @@ interface Factory where
       do
         remove this arg
 
--- | Type constraint for requiring templates to implement `Holding` along with `Disclosure`.
+-- | Type constraint for requiring templates to implement `Factory` along with `Disclosure`.
 type Implementation t = (HasToInterface t F, Disclosure.Implementation t)
 instance HasToInterface F Disclosure.I where _toInterface = asDisclosure
 class (Implementation t) => HasImplementation t

--- a/src/test/daml/Daml/Finance/Data/Test/HolidayCalendar.daml
+++ b/src/test/daml/Daml/Finance/Data/Test/HolidayCalendar.daml
@@ -4,16 +4,18 @@
 module Daml.Finance.Data.Test.HolidayCalendar where
 
 import DA.Date
-import DA.Map qualified as M (fromList)
+import DA.Map qualified as M (empty, fromList)
 import DA.Set (singleton)
 import Daml.Finance.Data.Reference.HolidayCalendar
+import Daml.Finance.Interface.Data.Reference.HolidayCalendar (GetView(..), UpdateCalendar(..))
+import Daml.Finance.Interface.Data.Reference.HolidayCalendar.Factory qualified as Factory (Create(..), F, Remove(..))
 import Daml.Finance.Interface.Types.Date.Calendar
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Script
 
--- | Test holiday calendars by a reference data agency
-test_reference_data_agency : Script ()
-test_reference_data_agency = script do
+-- | Test holiday calendars by a reference data provider.
+test_reference_data_provider : Script ()
+test_reference_data_provider = script do
   [reuters, publicParty] <- createParties ["Reuters", "PublicParty"]
 
   let
@@ -24,14 +26,18 @@ test_reference_data_agency = script do
     observers = [("PublicParty", singleton publicParty)]
 
   -- Reuters defines the USNY holiday calendar
+  -- Create calendar via factory
+  calendarFactoryCid <- toInterfaceContractId @Factory.F <$> submit reuters do
+    createCmd Factory with provider = reuters; observers = M.empty
+
   usnyCalendarCid <- submit reuters do
-    createCmd HolidayCalendar with
+    exerciseCmd calendarFactoryCid Factory.Create with
       provider = reuters
       calendar = cal
       observers = M.fromList observers
 
-  -- Retrieve the calendar from the ledger
-  Some usnyCalendar <- queryContractId publicParty usnyCalendarCid
+  -- Retrieve the calendar view from the ledger
+  usnyCalendarView <- submit reuters do exerciseCmd usnyCalendarCid GetView with viewer = reuters
 
   -- Define a new calendar locally
   let
@@ -51,10 +57,16 @@ test_reference_data_agency = script do
       newCalendar = cal2
 
   -- Retrieve the updated calendar from the ledger
-  Some usnyCalendar2 <- queryContractId publicParty usnyCalendarCid2
+  usnyCalendarView2 <- submit reuters do exerciseCmd usnyCalendarCid2 GetView with viewer = reuters
 
   -- Verify that the updated calendar now has different holidays
   assertMsg "The calendars should now have different holidays"
-    (usnyCalendar.calendar.holidays /= usnyCalendar2.calendar.holidays)
+    $ usnyCalendarView.calendar.holidays /= usnyCalendarView2.calendar.holidays
+
+  -- Archive calendar (via factory)
+  submit reuters do
+    exerciseCmd calendarFactoryCid Factory.Remove with
+      cid = usnyCalendarCid2
+      provider = reuters
 
   pure ()

--- a/src/test/daml/Daml/Finance/Data/Test/HolidayCalendar.daml
+++ b/src/test/daml/Daml/Finance/Data/Test/HolidayCalendar.daml
@@ -26,8 +26,7 @@ test_reference_data_agency = script do
   -- Reuters defines the USNY holiday calendar
   usnyCalendarCid <- submit reuters do
     createCmd HolidayCalendar with
-      agency = reuters
-      entity = cal.id
+      provider = reuters
       calendar = cal
       observers = M.fromList observers
 

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/FixedRate.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/FixedRate.daml
@@ -60,15 +60,13 @@ run = script do
   -- A reference data provider publishes the holiday calendar on the ledger
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
-      agency = calendarDataProvider
-      entity = cal.id
+      provider = calendarDataProvider
       calendar = cal
       observers = M.fromList pp
 
   calendarCid2 <- submit calendarDataProvider do
     createCmd HolidayCalendar with
-      agency = calendarDataProvider
-      entity = cal2.id
+      provider = calendarDataProvider
       calendar = cal2
       observers = M.fromList pp
 

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/FloatingRate.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/FloatingRate.daml
@@ -58,8 +58,7 @@ run = script do
   -- A reference data provider publishes the holiday calendar on the ledger
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
-      agency = calendarDataProvider
-      entity = cal.id
+      provider = calendarDataProvider
       calendar = cal
       observers = M.fromList pp
 

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/InflationLinked.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/InflationLinked.daml
@@ -59,8 +59,7 @@ run = script do
   -- A reference data provider publishes the holiday calendar on the ledger
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
-      agency = calendarDataProvider
-      entity = cal.id
+      provider = calendarDataProvider
       calendar = cal
       observers = M.fromList pp
 

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Asset.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Asset.daml
@@ -61,8 +61,7 @@ run = script do
   -- A reference data provider publishes the holiday calendar on the ledger
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
-      agency = calendarDataProvider
-      entity = cal.id
+      provider = calendarDataProvider
       calendar = cal
       observers = M.fromList observers
 

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/CreditDefault.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/CreditDefault.daml
@@ -318,8 +318,7 @@ setupCalendar TestParties{..} = do
   let pp = [("PublicParty", singleton publicParty)]
   submit calendarDataProvider do
     createCmd HolidayCalendar with
-      agency = calendarDataProvider
-      entity = holidayCalendarData.id
+      provider = calendarDataProvider
       calendar = holidayCalendarData
       observers = M.fromList pp
 

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Currency.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Currency.daml
@@ -57,8 +57,7 @@ run = script do
   -- A reference data provider publishes the holiday calendar on the ledger
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
-      agency = calendarDataProvider
-      entity = cal.id
+      provider = calendarDataProvider
       calendar = cal
       observers = M.fromList observers
 

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -189,11 +189,11 @@ run = script do
   -- A reference data provider publishes the holiday calendars on the ledger
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
-      agency = calendarDataProvider; entity = cal.id; calendar = cal
+      provider = calendarDataProvider; calendar = cal
       observers = M.fromList observers
   fixingCalendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
-      agency = calendarDataProvider; entity = fixingCal.id; calendar = fixingCal
+      provider = calendarDataProvider; calendar = fixingCal
       observers = M.fromList observers
 
   observableCid <- toInterfaceContractId <$> submit issuer do
@@ -369,11 +369,11 @@ runStubRateInterpolation = script do
   -- A reference data provider publishes the holiday calendars on the ledger
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
-      agency = calendarDataProvider; entity = cal.id; calendar = cal
+      provider = calendarDataProvider; calendar = cal
       observers = M.fromList observers
   fixingCalendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
-      agency = calendarDataProvider; entity = fixingCal.id; calendar = fixingCal
+      provider = calendarDataProvider; calendar = fixingCal
       observers = M.fromList observers
 
   observableLibor3MCid <- toInterfaceContractId <$> submit issuer do
@@ -593,11 +593,11 @@ runDualStubSampleTrade = script do
   -- A reference data provider publishes the holiday calendars on the ledger
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
-      agency = calendarDataProvider; entity = cal.id; calendar = cal
+      provider = calendarDataProvider; calendar = cal
       observers = M.fromList observers
   fixingCalendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
-      agency = calendarDataProvider; entity = fixingCal.id; calendar = fixingCal
+      provider = calendarDataProvider; calendar = fixingCal
       observers = M.fromList observers
 
   observableLibor3MCid <- toInterfaceContractId <$> submit issuer do
@@ -841,11 +841,11 @@ runSeparatePaymentFrequencySampleTrade = script do
   -- A reference data provider publishes the holiday calendars on the ledger
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
-      agency = calendarDataProvider; entity = cal.id; calendar = cal
+      provider = calendarDataProvider; calendar = cal
       observers = M.fromList observers
   fixingCalendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
-      agency = calendarDataProvider; entity = fixingCal.id; calendar = fixingCal
+      provider = calendarDataProvider; calendar = fixingCal
       observers = M.fromList observers
 
   observableLibor6MCid <- toInterfaceContractId <$> submit issuer do
@@ -1135,11 +1135,11 @@ runCurrencySwapSampleTrade = script do
   -- A reference data provider publishes the holiday calendars on the ledger
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
-      agency = calendarDataProvider; entity = cal.id; calendar = cal
+      provider = calendarDataProvider; calendar = cal
       observers = M.fromList observers
   fixingCalendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
-      agency = calendarDataProvider; entity = fixingCal.id; calendar = fixingCal
+      provider = calendarDataProvider; calendar = fixingCal
       observers = M.fromList observers
 
   observableLibor3MCid <- toInterfaceContractId <$> submit issuer do
@@ -1439,11 +1439,11 @@ runAmortizingNotionalSampleTrade = script do
   -- A reference data provider publishes the holiday calendars on the ledger
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
-      agency = calendarDataProvider; entity = cal.id; calendar = cal
+      provider = calendarDataProvider; calendar = cal
       observers = M.fromList observers
   fixingCalendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
-      agency = calendarDataProvider; entity = fixingCal.id; calendar = fixingCal
+      provider = calendarDataProvider; calendar = fixingCal
       observers = M.fromList observers
 
   observableLibor3MCid <- toInterfaceContractId <$> submit issuer do

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/InterestRate.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/InterestRate.daml
@@ -60,8 +60,7 @@ run = script do
   -- A reference data provider publishes the holiday calendar on the ledger
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
-      agency = calendarDataProvider
-      entity = cal.id
+      provider = calendarDataProvider
       calendar = cal
       observers = M.fromList observers
 


### PR DESCRIPTION
- align terminology (agency -> provider)
- remove redundant identifier
- add interface and factory

The interface and factory feel a bit boiler-platy, given that most business logic already uses the common data type `HolidayCalendarData`. However it is required if we want to stick to the "Factory" pattern  