### PR TITLE
elections: ensure that electionTime >= current business time

### DIFF
--- a/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
@@ -11,6 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Claims/0.1.6/daml-finance-claims-0.1.6.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.10/daml-finance-interface-claims-0.1.10.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.9/daml-finance-interface-data-0.1.9.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.10/daml-finance-interface-holding-0.1.10.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.10/daml-finance-interface-instrument-base-0.1.10.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.11/daml-finance-interface-instrument-generic-0.1.11.dar

--- a/package/test/daml/Daml.Finance.Test.Util/daml.yaml
+++ b/package/test/daml/Daml.Finance.Test.Util/daml.yaml
@@ -14,6 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Data/0.1.10/daml-finance-data-0.1.10.dar
   - .lib/daml-finance/Daml.Finance.Instrument.Token/0.1.10/daml-finance-instrument-token-0.1.10.dar
   - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.5/daml-finance-interface-account-0.1.5.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.9/daml-finance-interface-data-0.1.9.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.10/daml-finance-interface-holding-0.1.10.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.10/daml-finance-interface-instrument-base-0.1.10.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.11/daml-finance-interface-lifecycle-0.1.11.dar

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Lifecycle/Rule.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Lifecycle/Rule.daml
@@ -7,12 +7,13 @@ module Daml.Finance.Instrument.Generic.Lifecycle.Rule
 
 import DA.Foldable (forA_)
 import DA.Optional (fromSome)
-import DA.Set (fromList)
+import DA.Set (fromList, singleton)
 import DA.Text (sha256)
 import Daml.Finance.Claims.Util (isZero')
 import Daml.Finance.Claims.Util.Lifecycle (electionEvent, lifecycle, splitPending, timeEvent)
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, GetClaims(..), getClaims)
 import Daml.Finance.Interface.Claims.Types (C)
+import Daml.Finance.Interface.Data.TimeObservable (GetTime(..))
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (K, R, createReference, getKey)
 import Daml.Finance.Interface.Instrument.Generic.Election qualified as Election (ApplyElection(..), Exercisable(..), ExercisableView(..), getElectionTime)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Evolve(..), View(..))
@@ -22,7 +23,7 @@ import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, SetObs
 import Daml.Finance.Instrument.Generic.Instrument (Instrument(..))
 import Daml.Finance.Lifecycle.Effect (Effect(..))
 import Daml.Finance.Lifecycle.ElectionEffect (ElectionEffect(..))
-import Prelude hiding (exercise, key)
+import Prelude
 
 -- | Rule to process a time update event.
 template Rule
@@ -84,7 +85,7 @@ template Rule
 
     interface instance Election.Exercisable for Rule where
       view = Election.ExercisableView with lifecycler
-      applyElection Election.ApplyElection{electionCid; observableCids} = do
+      applyElection Election.ApplyElection{electionCid; observableCids; timeCid} = do
 
         -- fetch election
         election <- fetch electionCid
@@ -92,6 +93,12 @@ template Rule
           v = view election
           electionTime = Election.getElectionTime election
           election = electionEvent electionTime v.electorIsOwner v.claim
+
+        -- verify that the election has not been made "retroactively"
+        currentTime <- Prelude.exercise timeCid GetTime with actors = singleton lifecycler
+        assertMsg ("Election time " <> show electionTime
+          <> " must be greater or equal than current time " <> show currentTime)
+          $ electionTime >= currentTime
 
         -- fetch claim tree
         claimInstrument <- fetchInterfaceByKey @BaseInstrument.R v.instrument

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Generic/Election.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Generic/Election.daml
@@ -5,6 +5,7 @@ module Daml.Finance.Interface.Instrument.Generic.Election where
 
 import Daml.Finance.Interface.Claims.Types (C)
 import Daml.Finance.Interface.Data.NumericObservable qualified as NumericObservable (I)
+import Daml.Finance.Interface.Data.TimeObservable qualified as TimeObservable (I)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (K)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (I)
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I, Implementation, getEventTime)
@@ -65,15 +66,17 @@ interface Election where
     -- ^ Applies the election to the instrument, returning the new instrument as well as the
     --   corresponding effects. The election is archived as part of this choice.
     with
-      observableCids : [ContractId NumericObservable.I]
-        -- ^ Set of observables.
       exercisableCid : ContractId Exercisable
         -- ^ The contract that is used to apply an election to the instrument.
+      observableCids : [ContractId NumericObservable.I]
+        -- ^ Set of observables.
+      timeCid : ContractId TimeObservable.I
+        -- ^ Current business time.
     controller (view this).provider
     do
       let v = view this
       (newInstrumentCid, effects) <- exercise exercisableCid ApplyElection with
-        observableCids
+        observableCids; timeCid
         electionCid = toInterfaceContractId self
       archive' this self -- this is needed as we can't write postconsuming choices on interfaces
       pure (newInstrumentCid, effects)
@@ -118,6 +121,8 @@ interface Exercisable where
         -- ^ The election.
       observableCids : [ContractId NumericObservable.I]
         -- ^ Set of observables.
+      timeCid : ContractId TimeObservable.I
+        -- ^ Current business time.
     controller (view this).lifecycler
     do
       applyElection this arg

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
@@ -6,7 +6,7 @@ module Daml.Finance.Instrument.Generic.Test.CallableBond where
 import ContingentClaims.Core.Claim (and, at, give, one, or, scale, when)
 import ContingentClaims.Core.Observation (Observation(..))
 import DA.Assert ((===))
-import DA.Date as D (Month(..), date)
+import DA.Date as D (Month(..), addDays, date)
 import DA.Map qualified as M (empty, fromList)
 import DA.Set (empty, fromList, singleton, toList)
 import DA.Time (time)
@@ -29,6 +29,7 @@ import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
+import Daml.Finance.Test.Util.Time (createDateClock)
 import Daml.Script
 import Prelude hiding (and, or)
 
@@ -139,10 +140,23 @@ run = script do
       id = Id "LifecycleRule"
       description = "Rule to lifecycle a generic instrument"
 
+  -- Election fails when current time is after election time
+  clockCid <- createDateClock (singleton issuer) (addDays intermediateDate 1) empty
+
+  submitMustFail issuer do
+    exerciseCmd callBondCid Election.Apply with
+      observableCids = []
+      exercisableCid = lifecycleRuleCid
+      timeCid = clockCid
+
+  -- Election succeeds when current time is at (or before) election time
+  clockCid <- createDateClock (singleton issuer) intermediateDate empty
+
   (_, [effectCid]) <- submit issuer do
     exerciseCmd callBondCid Election.Apply with
       observableCids = []
       exercisableCid = lifecycleRuleCid
+      timeCid = clockCid
 
   -- Create route provider
   routeProviderCid <- toInterfaceContractId <$> submit bank do

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/EuropeanOption.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/EuropeanOption.daml
@@ -33,6 +33,7 @@ import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
+import Daml.Finance.Test.Util.Time (createDateClock)
 import Daml.Script
 import Prelude hiding (or)
 
@@ -160,10 +161,13 @@ run = script do
       id = Id "LifecycleRule"
       description = "Rule to lifecycle a generic instrument"
 
+  clockCid <- createDateClock (singleton broker) maturity empty
+
   (_, [effectCid]) <- submit broker do
     exerciseCmd exerciseOptionCid Election.Apply with
       observableCids = [observableCid]
       exercisableCid = lifecycleRuleCid
+      timeCid = clockCid
 
   -- Create route provider
   routeProviderCid <- toInterfaceContractId <$> submit investor1 do
@@ -250,6 +254,7 @@ run = script do
     exerciseCmd expireOptionCid Election.Apply with
       observableCids = [observableCid]
       exercisableCid = lifecycleRuleCid
+      timeCid = clockCid
 
   -- Create route provider
   routeProviderCid <- toInterfaceContractId <$> submit investor2 do

--- a/src/test/daml/Daml/Finance/Test/Util/Time.daml
+++ b/src/test/daml/Daml/Finance/Test/Util/Time.daml
@@ -1,11 +1,15 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Daml.Finance.Test.Util.Time where
+module Daml.Finance.Test.Util.Time
+  ( createClockUpdateEvent
+  , createDateClock
+  ) where
 
 import DA.Set (toList)
 import Daml.Finance.Data.Time.DateClock (DateClock(..))
 import Daml.Finance.Data.Time.DateClock.Types (Unit(..))
+import Daml.Finance.Interface.Data.TimeObservable qualified as TimeObservable (I)
 import Daml.Finance.Interface.Types.Common.Types (Id(..), Parties)
 import Daml.Finance.Interface.Types.Date.Classes (HasUTCTimeConversion(..))
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I)
@@ -25,3 +29,15 @@ createClockUpdateEvent providers today observers = do
     createCmd DateClockUpdateEvent with
       providers; id; description; date = today; observers; eventTime = toUTCTime date
   pure eventCid
+
+-- | Given a `Date`, it creates a `DateClock` and returns it as a `TimeObservable`.
+createDateClock : Parties -> Date -> Parties
+  -> Script (ContractId TimeObservable.I)
+createDateClock providers today observers = do
+  let
+    description = show today
+    id = Id description
+    date = Unit today
+  toInterfaceContractId <$> submitMulti (toList providers) [] do
+    createCmd DateClock with
+      providers; date; id; description; observers


### PR DESCRIPTION
@georg-da this is the change we discussed to bring back the time sanity check on elections.

The potential risk I see with this PR is when
- ledger time is used as business time
- election cannot be put forward / processed for some reason (e.g. outage)
- because of the check electionTime >= currentTime we have effectively locked the instrument

This might not be obvious to customers. Moreover, we do not solve the issue where two elections can be put forward for an american option (using the same holding)

I am considering a different approach, where the sanity checks are performed in the workflow to create an `Election` (what we currently call the `ElectionFactory`). We should not expose this workflow via interfaces and make it clear that customers should think carefully about what sanity checks they want to implement. Let me know what you think 