### PR TITLE
Decouple D.F.Claims from D.F.Data

### DIFF
--- a/package/main/daml/Daml.Finance.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Claims/daml.yaml
@@ -11,7 +11,6 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/0.1.2/contingent-claims-core-0.1.2.dar
   - .lib/daml-finance/ContingentClaims.Lifecycle/0.1.3/contingent-claims-lifecycle-0.1.3.dar
-  - .lib/daml-finance/Daml.Finance.Data/0.1.10/daml-finance-data-0.1.10.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.9/daml-finance-interface-claims-0.1.9.dar
   - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.9/daml-finance-interface-data-0.1.9.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.9/daml-finance-interface-instrument-base-0.1.9.dar

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -11,6 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/0.1.2/contingent-claims-core-0.1.2.dar
   - .lib/daml-finance/Daml.Finance.Claims/0.1.6/daml-finance-claims-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Data/0.1.10/daml-finance-data-0.1.10.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.9/daml-finance-interface-claims-0.1.9.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.9/daml-finance-interface-instrument-base-0.1.9.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/0.1.9/daml-finance-interface-instrument-bond-0.1.9.dar

--- a/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
@@ -11,6 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/0.1.2/contingent-claims-core-0.1.2.dar
   - .lib/daml-finance/Daml.Finance.Claims/0.1.6/daml-finance-claims-0.1.6.dar
+  - .lib/daml-finance/Daml.Finance.Data/0.1.10/daml-finance-data-0.1.10.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.9/daml-finance-interface-claims-0.1.9.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.9/daml-finance-interface-instrument-base-0.1.9.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.1.10/daml-finance-interface-instrument-swap-0.1.10.dar

--- a/src/main/daml/Daml/Finance/Claims/Util.daml
+++ b/src/main/daml/Daml/Finance/Claims/Util.daml
@@ -5,14 +5,12 @@ module Daml.Finance.Claims.Util
   ( isZero
   , isZero'
   , toTime
-  , toTime'
   ) where
 
 import ContingentClaims.Core.Claim (Claim, mapParams)
 import ContingentClaims.Lifecycle.Util qualified as CC (isZero)
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, GetClaims(..), getClaims)
 import Daml.Finance.Interface.Claims.Types (TaggedClaim)
-import Daml.Finance.Interface.Types.Date.Classes (HasUTCTimeConversion(..))
 
 -- | Checks if all input claims are zero.
 isZero : Party -> Claim.I -> Update Bool
@@ -24,18 +22,10 @@ isZero' = all $ CC.isZero . (.claim)
 
 -- | Maps the time parameter in a `Claim` to `Time`. As `Time` is generally understood to express
 -- UTC time, we recommend mapping to UTC time.
-toTime : HasUTCTimeConversion t => Claim t x a o -> Claim Time x a o
-toTime =
-  let contraMap _ = error "Inverse mapping from `Time` is not provided"
-    -- currently the contramap from `Time` back to `a` is not used, because `Observation`\s do not
-    -- depend on time explicitly
-  in mapParams contraMap toUTCTime identity identity identity
-
--- | Maps the time parameter in a `Claim` to `Time`. As `Time` is generally understood to express
--- UTC time, we recommend mapping to UTC time.
-toTime' : (t -> Time) -> Claim t x a o -> Claim Time x a o
-toTime' forwardMap c =
+toTime : (t -> Time) -> Claim t x a o -> Claim Time x a o
+toTime forwardMap c =
   let contraMap _ = error "Inverse mapping from `Time` is not provided"
     -- currently the contramap from `Time` back to `a` is not used, because `Observation`\s do not
     -- depend on time explicitly
   in mapParams contraMap forwardMap identity identity identity c
+

--- a/src/main/daml/Daml/Finance/Claims/Util/Builders.daml
+++ b/src/main/daml/Daml/Finance/Claims/Util/Builders.daml
@@ -12,7 +12,7 @@ import Daml.Finance.Interface.Claims.Types (C, Deliverable, Observable, TaggedCl
 import Daml.Finance.Interface.Types.Date.Calendar
 import Daml.Finance.Interface.Types.Date.Classes (toUTCTime)
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
-import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..), Schedule, SchedulePeriod)
+import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..), Schedule)
 import Daml.Finance.Util.Date.DayCount (calcPeriodDcf)
 import Daml.Finance.Util.Date.Schedule (createSchedule)
 import Prelude hiding (key)
@@ -42,7 +42,7 @@ prepareAndTagClaims cs tag =
   in TaggedClaim with tag; claim
 
 -- FIXED_RATE_BOND_COUPON_CLAIMS_BEGIN
-createFixRatePaymentClaimsList : [SchedulePeriod] -> PeriodicSchedule -> Bool -> Decimal -> Bool ->
+createFixRatePaymentClaimsList : Schedule -> PeriodicSchedule -> Bool -> Decimal -> Bool ->
   DayCountConventionEnum -> Decimal -> Deliverable -> [Claim Date Decimal Deliverable Observable]
 createFixRatePaymentClaimsList schedule periodicSchedule useAdjustedDatesForDcf couponRate
   ownerReceives dayCountConvention notional cashInstrumentCid =
@@ -63,7 +63,7 @@ createFixRatePaymentClaimsList schedule periodicSchedule useAdjustedDatesForDcf 
 -- FIXED_RATE_BOND_COUPON_CLAIMS_END
 
 -- | Calculate a fix rate amount for each payment date and create claims.
-createFixRatePaymentClaims : [SchedulePeriod] -> PeriodicSchedule -> Bool -> Decimal -> Bool ->
+createFixRatePaymentClaims : Schedule -> PeriodicSchedule -> Bool -> Decimal -> Bool ->
   DayCountConventionEnum -> Decimal -> Deliverable -> TaggedClaim
 createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf couponRate ownerReceives
   dayCountConvention notional cashInstrumentCid =
@@ -74,7 +74,7 @@ createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf coup
 
 -- | Calculate a fix rate amount (if a credit event has not yet happened) for each payment date and
 -- create claims.
-createConditionalCreditFixRatePaymentClaims : [SchedulePeriod] -> PeriodicSchedule -> Bool ->
+createConditionalCreditFixRatePaymentClaims : Schedule -> PeriodicSchedule -> Bool ->
   Decimal -> Bool -> DayCountConventionEnum -> Decimal -> Deliverable -> Observable -> TaggedClaim
 createConditionalCreditFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf
   couponRate ownerReceives dayCountConvention notional cashInstrumentCid defaultProbabilityReferenceId
@@ -111,7 +111,7 @@ createCreditEventPaymentClaims ownerReceives notional cashInstrumentCid defaultP
 -- corresponding payment on the last day of that payment period. This means that the calculation
 -- agent needs to provide such an Observable, irrespective of the kind of reference rate used (e.g.
 -- a forward looking LIBOR or a backward looking SOFR-COMPOUND).
-createFloatingRatePaymentClaims : [SchedulePeriod] -> PeriodicSchedule -> Bool -> Decimal -> Bool ->
+createFloatingRatePaymentClaims : Schedule -> PeriodicSchedule -> Bool -> Decimal -> Bool ->
   DayCountConventionEnum -> Decimal -> Deliverable -> Observable -> TaggedClaim
 createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf floatingRateSpread
   ownerReceives dayCountConvention notional cashInstrumentCid referenceRateId =
@@ -138,7 +138,7 @@ createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf
 -- fixings:
 --   - unadjusted fixings in case of a price return asset swap
 --   - adjusted fixings in case of a total return asset swap
-createAssetPerformancePaymentClaims : [SchedulePeriod] -> PeriodicSchedule -> Bool -> Bool ->
+createAssetPerformancePaymentClaims : Schedule -> PeriodicSchedule -> Bool -> Bool ->
   DayCountConventionEnum -> Decimal -> Deliverable -> Observable -> TaggedClaim
 createAssetPerformancePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf ownerReceives
   dayCountConvention notional cashInstrumentCid referenceAssetId =

--- a/src/main/daml/Daml/Finance/Claims/Util/Builders.daml
+++ b/src/main/daml/Daml/Finance/Claims/Util/Builders.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Claims.Util.Builders where
 
 import ContingentClaims.Core.Claim (Claim(..), Inequality(..), give, one, scale, upTo, when, until)
 import ContingentClaims.Core.Observation (Observation(..))
-import Daml.Finance.Claims.Util (toTime')
+import Daml.Finance.Claims.Util (toTime)
 import Daml.Finance.Data.Reference.HolidayCalendar (GetCalendar(..), HolidayCalendar, HolidayCalendarKey(..))
 import Daml.Finance.Data.Time.DateClock.Types (Unit(..))
 import Daml.Finance.Interface.Claims.Types (C, Deliverable, Observable, TaggedClaim(..))
@@ -38,7 +38,7 @@ rollPaymentSchedule periodicSchedule holidayCalendarIds actor calendarDataProvid
 -- | Convert the claims to UTCTime and tag them.
 prepareAndTagClaims : [Claim Date Decimal Deliverable Observable] -> Text -> TaggedClaim
 prepareAndTagClaims cs tag =
-  let claim = mapClaimToUTCTime $ mconcat cs
+  let claim = toTime dateToDateClockTime $ mconcat cs
   in TaggedClaim with tag; claim
 
 -- FIXED_RATE_BOND_COUPON_CLAIMS_BEGIN
@@ -188,4 +188,4 @@ dateToDateClockTime = toUTCTime . Unit
 mapClaimToUTCTime : Claim Date Decimal Deliverable Observable -> C
 mapClaimToUTCTime =
   let dateToTime = toUTCTime . Unit
-  in toTime' dateToTime
+  in toTime dateToTime

--- a/src/main/daml/Daml/Finance/Claims/Util/Builders.daml
+++ b/src/main/daml/Daml/Finance/Claims/Util/Builders.daml
@@ -6,18 +6,17 @@ module Daml.Finance.Claims.Util.Builders where
 import ContingentClaims.Core.Claim (Claim(..), Inequality(..), give, one, scale, upTo, when, until)
 import ContingentClaims.Core.Observation (Observation(..))
 import Daml.Finance.Claims.Util (toTime)
-import Daml.Finance.Data.Time.DateClock.Types (Unit(..))
-import Daml.Finance.Interface.Claims.Types (C, Deliverable, Observable, TaggedClaim(..))
-import Daml.Finance.Interface.Types.Date.Classes (toUTCTime)
+import Daml.Finance.Interface.Claims.Types (Deliverable, Observable, TaggedClaim(..))
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
 import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..), Schedule)
 import Daml.Finance.Util.Date.DayCount (calcPeriodDcf)
 import Prelude hiding (key)
 
 -- | Convert the claims to UTCTime and tag them.
-prepareAndTagClaims : [Claim Date Decimal Deliverable Observable] -> Text -> TaggedClaim
-prepareAndTagClaims cs tag =
-  let claim = toTime dateToDateClockTime $ mconcat cs
+prepareAndTagClaims : (Date -> Time) -> [Claim Date Decimal Deliverable Observable] ->
+  Text -> TaggedClaim
+prepareAndTagClaims dateToTime cs tag =
+  let claim = toTime dateToTime $ mconcat cs
   in TaggedClaim with tag; claim
 
 -- FIXED_RATE_BOND_COUPON_CLAIMS_BEGIN
@@ -42,47 +41,48 @@ createFixRatePaymentClaimsList schedule periodicSchedule useAdjustedDatesForDcf 
 -- FIXED_RATE_BOND_COUPON_CLAIMS_END
 
 -- | Calculate a fix rate amount for each payment date and create claims.
-createFixRatePaymentClaims : Schedule -> PeriodicSchedule -> Bool -> Decimal -> Bool ->
-  DayCountConventionEnum -> Decimal -> Deliverable -> TaggedClaim
-createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf couponRate ownerReceives
-  dayCountConvention notional cashInstrumentCid =
+createFixRatePaymentClaims : (Date -> Time) -> Schedule -> PeriodicSchedule -> Bool -> Decimal ->
+  Bool -> DayCountConventionEnum -> Decimal -> Deliverable -> TaggedClaim
+createFixRatePaymentClaims dateToTime schedule periodicSchedule useAdjustedDatesForDcf
+  couponRate ownerReceives dayCountConvention notional cashInstrumentCid =
     let
       couponClaims = createFixRatePaymentClaimsList schedule periodicSchedule useAdjustedDatesForDcf
         couponRate ownerReceives dayCountConvention notional cashInstrumentCid
-    in prepareAndTagClaims couponClaims "Fix rate payment"
+    in prepareAndTagClaims dateToTime couponClaims "Fix rate payment"
 
 -- | Calculate a fix rate amount (if a credit event has not yet happened) for each payment date and
 -- create claims.
-createConditionalCreditFixRatePaymentClaims : Schedule -> PeriodicSchedule -> Bool ->
-  Decimal -> Bool -> DayCountConventionEnum -> Decimal -> Deliverable -> Observable -> TaggedClaim
-createConditionalCreditFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf
-  couponRate ownerReceives dayCountConvention notional cashInstrumentCid defaultProbabilityReferenceId
+createConditionalCreditFixRatePaymentClaims : (Date -> Time) -> Schedule -> PeriodicSchedule ->
+  Bool -> Decimal -> Bool -> DayCountConventionEnum -> Decimal -> Deliverable -> Observable ->
+  TaggedClaim
+createConditionalCreditFixRatePaymentClaims dateToTime schedule periodicSchedule
+  useAdjustedDatesForDcf couponRate ownerReceives dayCountConvention notional
+  cashInstrumentCid defaultProbabilityReferenceId
   = let
       couponClaims = createFixRatePaymentClaimsList schedule periodicSchedule useAdjustedDatesForDcf
         couponRate ownerReceives dayCountConvention notional cashInstrumentCid
       creditEvent = Lte (Const 1.0, Observe defaultProbabilityReferenceId)
       couponClaimUntilCreditEvent = until creditEvent $ mconcat couponClaims
     in
-      prepareAndTagClaims [couponClaimUntilCreditEvent]
+      prepareAndTagClaims dateToTime [couponClaimUntilCreditEvent]
         "Fix rate payment (unless credit event has occurred)"
 
 -- | Calculate a (1-recoveryRate) payment if a credit event just happened and create claims.
-createCreditEventPaymentClaims : Bool -> Decimal -> Deliverable -> Observable -> Observable ->
-  PeriodicSchedule -> TaggedClaim
-createCreditEventPaymentClaims ownerReceives notional cashInstrumentCid defaultProbabilityReferenceId
-  recoveryRateReferenceId periodicSchedule =
+createCreditEventPaymentClaims : (Date -> Time) -> Bool -> Decimal -> Deliverable -> Observable ->
+  Observable -> PeriodicSchedule -> TaggedClaim
+createCreditEventPaymentClaims dateToTime ownerReceives notional cashInstrumentCid
+  defaultProbabilityReferenceId recoveryRateReferenceId periodicSchedule =
   let
     creditEvent = Lte (Const 1.0, Observe defaultProbabilityReferenceId)
     payoffAmount =
-      scale (Const 1.0 - Observe recoveryRateReferenceId)
-      $ scale (Const notional)
+      scale ((Const 1.0 - Observe recoveryRateReferenceId) * Const notional)
       $ one cashInstrumentCid
     payoff = if ownerReceives then payoffAmount else give payoffAmount
     creditEventClaim =
       when (TimeGte periodicSchedule.effectiveDate)
       $ when creditEvent
       $ when (upTo periodicSchedule.terminationDate) payoff
-  in prepareAndTagClaims [creditEventClaim] "Credit event payment"
+  in prepareAndTagClaims dateToTime [creditEventClaim] "Credit event payment"
 
 -- FLOATING_RATE_BOND_COUPON_CLAIMS_BEGIN
 -- | Calculate a floating rate amount for each payment date and create claims.
@@ -90,10 +90,10 @@ createCreditEventPaymentClaims ownerReceives notional cashInstrumentCid defaultP
 -- corresponding payment on the last day of that payment period. This means that the calculation
 -- agent needs to provide such an Observable, irrespective of the kind of reference rate used (e.g.
 -- a forward looking LIBOR or a backward looking SOFR-COMPOUND).
-createFloatingRatePaymentClaims : Schedule -> PeriodicSchedule -> Bool -> Decimal -> Bool ->
-  DayCountConventionEnum -> Decimal -> Deliverable -> Observable -> TaggedClaim
-createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf floatingRateSpread
-  ownerReceives dayCountConvention notional cashInstrumentCid referenceRateId =
+createFloatingRatePaymentClaims : (Date -> Time) -> Schedule -> PeriodicSchedule -> Bool ->
+  Decimal -> Bool -> DayCountConventionEnum -> Decimal -> Deliverable -> Observable -> TaggedClaim
+createFloatingRatePaymentClaims dateToTime schedule periodicSchedule useAdjustedDatesForDcf
+  floatingRateSpread ownerReceives dayCountConvention notional cashInstrumentCid referenceRateId =
   let
     couponClaimAmounts = mconcat $ map (\p ->
         when (TimeGte p.adjustedStartDate)
@@ -107,7 +107,7 @@ createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf
         $ one cashInstrumentCid
       ) schedule
     couponClaims = if ownerReceives then couponClaimAmounts else give couponClaimAmounts
-  in prepareAndTagClaims [couponClaims] "Floating rate payment"
+  in prepareAndTagClaims dateToTime [couponClaims] "Floating rate payment"
 -- FLOATING_RATE_BOND_COUPON_CLAIMS_END
 
 -- ASSET_PERFORMANCE_CLAIMS_BEGIN
@@ -117,10 +117,10 @@ createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf
 -- fixings:
 --   - unadjusted fixings in case of a price return asset swap
 --   - adjusted fixings in case of a total return asset swap
-createAssetPerformancePaymentClaims : Schedule -> PeriodicSchedule -> Bool -> Bool ->
+createAssetPerformancePaymentClaims : (Date -> Time) -> Schedule -> PeriodicSchedule -> Bool -> Bool ->
   DayCountConventionEnum -> Decimal -> Deliverable -> Observable -> TaggedClaim
-createAssetPerformancePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf ownerReceives
-  dayCountConvention notional cashInstrumentCid referenceAssetId =
+createAssetPerformancePaymentClaims dateToTime schedule periodicSchedule useAdjustedDatesForDcf
+  ownerReceives dayCountConvention notional cashInstrumentCid referenceAssetId =
   let
     assetClaimAmounts = mconcat $ map (\p ->
         when (TimeGte p.adjustedStartDate)
@@ -136,15 +136,17 @@ createAssetPerformancePaymentClaims schedule periodicSchedule useAdjustedDatesFo
     correctionAssetClaims =
       if ownerReceives then give correctionClaimAmounts else correctionClaimAmounts
   in
-    prepareAndTagClaims [assetClaims, correctionAssetClaims] "Asset performance payment"
+    prepareAndTagClaims dateToTime [assetClaims, correctionAssetClaims] "Asset performance payment"
 -- ASSET_PERFORMANCE_CLAIMS_END
 
 -- FIXED_RATE_BOND_REDEMPTION_CLAIM_BEGIN
 -- | Create an FX adjusted principal claim.
 -- This can be used for both FX swaps (using the appropriate FX rate) and single currency bonds
 -- (setting the FX rate to 1.0).
-createFxAdjustedPrincipalClaim : Bool -> Decimal -> Decimal -> Deliverable -> Date -> TaggedClaim
-createFxAdjustedPrincipalClaim ownerReceives fxRateMultiplier notional cashInstrumentCid valueDate =
+createFxAdjustedPrincipalClaim : (Date -> Time) -> Bool -> Decimal -> Decimal -> Deliverable ->
+  Date -> TaggedClaim
+createFxAdjustedPrincipalClaim dateToTime ownerReceives fxRateMultiplier notional
+  cashInstrumentCid valueDate =
   let
     fxLegClaimAmount = when (TimeGte valueDate)
                        $ scale (Const fxRateMultiplier)
@@ -152,19 +154,5 @@ createFxAdjustedPrincipalClaim ownerReceives fxRateMultiplier notional cashInstr
                        $ one cashInstrumentCid
     fxLegClaim = if ownerReceives then fxLegClaimAmount else give fxLegClaimAmount
   in
-    prepareAndTagClaims [fxLegClaim] "Principal payment"
+    prepareAndTagClaims dateToTime [fxLegClaim] "Principal payment"
 -- FIXED_RATE_BOND_REDEMPTION_CLAIM_END
-
--- | Maps a `Date` to `Time` using the rule in the `DateClock`.
--- From the Daml.Finance.Instrument.Generics.Test file, but could not import here (duplicated for
--- now). In the termsheet only date is mentioned, but lifecycle logic is based on time.
-dateToDateClockTime : Date -> Time
-dateToDateClockTime = toUTCTime . Unit
-
--- | Maps a `Date` claim to a `Time` claim using the rule in the `DateClock`.
--- From the Daml.Finance.Instrument.Generics.Test file, but could not import here (duplicated for
--- now). In the termsheet only date is mentioned, but lifecycle logic is based on time.
-mapClaimToUTCTime : Claim Date Decimal Deliverable Observable -> C
-mapClaimToUTCTime =
-  let dateToTime = toUTCTime . Unit
-  in toTime dateToTime

--- a/src/main/daml/Daml/Finance/Claims/Util/Builders.daml
+++ b/src/main/daml/Daml/Finance/Claims/Util/Builders.daml
@@ -6,34 +6,13 @@ module Daml.Finance.Claims.Util.Builders where
 import ContingentClaims.Core.Claim (Claim(..), Inequality(..), give, one, scale, upTo, when, until)
 import ContingentClaims.Core.Observation (Observation(..))
 import Daml.Finance.Claims.Util (toTime)
-import Daml.Finance.Data.Reference.HolidayCalendar (GetCalendar(..), HolidayCalendar, HolidayCalendarKey(..))
 import Daml.Finance.Data.Time.DateClock.Types (Unit(..))
 import Daml.Finance.Interface.Claims.Types (C, Deliverable, Observable, TaggedClaim(..))
-import Daml.Finance.Interface.Types.Date.Calendar
 import Daml.Finance.Interface.Types.Date.Classes (toUTCTime)
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
 import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..), Schedule)
 import Daml.Finance.Util.Date.DayCount (calcPeriodDcf)
-import Daml.Finance.Util.Date.Schedule (createSchedule)
 import Prelude hiding (key)
-
--- | Retrieve holiday calendar(s) from the ledger.
-getHolidayCalendars : [Text] -> Party -> Party -> Update [HolidayCalendarData]
-getHolidayCalendars holidayCalendarIds actor provider =
-  let
-    -- get a holiday calendar from the ledger
-    getCalendar id = do
-      exerciseByKey @HolidayCalendar holCalKey GetCalendar with viewer = actor where
-        holCalKey = HolidayCalendarKey with provider; id
-  in
-    -- get the holiday calendars
-    mapA getCalendar holidayCalendarIds
-
--- | Retrieve holiday calendar(s) from the ledger and roll out the payment schedule.
-rollPaymentSchedule : PeriodicSchedule -> [Text] -> Party -> Party -> Update Schedule
-rollPaymentSchedule periodicSchedule holidayCalendarIds actor calendarDataProvider = do
-  cals <- getHolidayCalendars holidayCalendarIds actor calendarDataProvider
-  pure $ createSchedule cals periodicSchedule
 
 -- | Convert the claims to UTCTime and tag them.
 prepareAndTagClaims : [Claim Date Decimal Deliverable Observable] -> Text -> TaggedClaim

--- a/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate/Instrument.daml
@@ -6,6 +6,7 @@ module Daml.Finance.Instrument.Bond.FixedRate.Instrument where
 import DA.Date (daysSinceEpochToDate)
 import DA.Set (singleton)
 import Daml.Finance.Claims.Util.Builders
+import Daml.Finance.Instrument.Bond.Util
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, GetClaims(..), View(..))
 import Daml.Finance.Interface.Claims.Dynamic.Instrument qualified as DynamicInstrument (I, CreateNewVersion(..), View(..))
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, K, View(..), createReference, disclosureUpdateReference)
@@ -69,8 +70,8 @@ template Instrument
       asBaseInstrument = toInterface @BaseInstrument.I this
       getClaims Claim.GetClaims{actor} = do
         -- get the initial claims tree (as of the bond's acquisition time)
-        schedule <- rollPaymentSchedule periodicSchedule holidayCalendarIds actor
-          calendarDataProvider
+        let getCalendars = getHolidayCalendars actor calendarDataProvider
+        schedule <- rollSchedule getCalendars periodicSchedule holidayCalendarIds
         let
           useAdjustedDatesForDcf = True
           notional = 1.0

--- a/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate/Instrument.daml
@@ -78,11 +78,11 @@ template Instrument
           ownerReceives = True
           fxAdjustment = 1.0
           couponClaims =
-            createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf couponRate
-              ownerReceives dayCountConvention notional currency
+            createFixRatePaymentClaims dateToDateClockTime schedule periodicSchedule
+              useAdjustedDatesForDcf couponRate ownerReceives dayCountConvention notional currency
           redemptionClaim =
-            createFxAdjustedPrincipalClaim ownerReceives fxAdjustment notional currency
-              periodicSchedule.terminationDate
+            createFxAdjustedPrincipalClaim dateToDateClockTime ownerReceives fxAdjustment notional
+              currency periodicSchedule.terminationDate
         pure $ [couponClaims, redemptionClaim]
     -- FIXED_RATE_BOND_CLAIMS_END
 

--- a/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate/Instrument.daml
@@ -82,11 +82,12 @@ template Instrument
           ownerReceives = True
           fxAdjustment = 1.0
           couponClaims =
-            createFloatingRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf
-              couponSpread ownerReceives dayCountConvention notional currency referenceRateId
+            createFloatingRatePaymentClaims dateToDateClockTime schedule periodicSchedule
+              useAdjustedDatesForDcf couponSpread ownerReceives dayCountConvention notional
+              currency referenceRateId
           redemptionClaim =
-            createFxAdjustedPrincipalClaim ownerReceives fxAdjustment notional currency
-              periodicSchedule.terminationDate
+            createFxAdjustedPrincipalClaim dateToDateClockTime ownerReceives fxAdjustment notional
+              currency periodicSchedule.terminationDate
         pure $ [couponClaims, redemptionClaim]
 
     interface instance BaseInstrument.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate/Instrument.daml
@@ -6,6 +6,7 @@ module Daml.Finance.Instrument.Bond.FloatingRate.Instrument where
 import DA.Date (daysSinceEpochToDate)
 import DA.Set (singleton)
 import Daml.Finance.Claims.Util.Builders
+import Daml.Finance.Instrument.Bond.Util
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, GetClaims(..), View(..))
 import Daml.Finance.Interface.Claims.Dynamic.Instrument qualified as DynamicInstrument (I, CreateNewVersion(..), View(..))
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, K, View(..), createReference, disclosureUpdateReference)
@@ -73,8 +74,8 @@ template Instrument
       asBaseInstrument = toInterface @BaseInstrument.I this
       getClaims Claim.GetClaims{actor} = do
         -- get the initial claims tree (as of the bond's acquisition time)
-        schedule <- rollPaymentSchedule
-          periodicSchedule holidayCalendarIds actor calendarDataProvider
+        let getCalendars = getHolidayCalendars actor calendarDataProvider
+        schedule <- rollSchedule getCalendars periodicSchedule holidayCalendarIds
         let
           useAdjustedDatesForDcf = True
           notional = 1.0

--- a/src/main/daml/Daml/Finance/Instrument/Bond/InflationLinked/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/InflationLinked/Instrument.daml
@@ -8,6 +8,7 @@ import ContingentClaims.Core.Observation (Observation(..))
 import DA.Date (daysSinceEpochToDate)
 import DA.Set (singleton)
 import Daml.Finance.Claims.Util.Builders
+import Daml.Finance.Instrument.Bond.Util
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, GetClaims(..), View(..))
 import Daml.Finance.Interface.Claims.Dynamic.Instrument qualified as DynamicInstrument (I, CreateNewVersion(..), View(..))
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, K, View(..), createReference, disclosureUpdateReference)
@@ -81,9 +82,8 @@ template Instrument
       asBaseInstrument = toInterface @BaseInstrument.I this
       getClaims Claim.GetClaims{actor} = do
         -- get the initial claims tree (as of the bond's acquisition time)
-        schedule <-
-          rollPaymentSchedule periodicSchedule holidayCalendarIds actor calendarDataProvider
-
+        let getCalendars = getHolidayCalendars actor calendarDataProvider
+        schedule <- rollSchedule getCalendars periodicSchedule holidayCalendarIds
         let
           -- calculate the current inflation factor (how inflation has developed from the first
           -- reference date until now)

--- a/src/main/daml/Daml/Finance/Instrument/Bond/InflationLinked/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/InflationLinked/Instrument.daml
@@ -116,8 +116,8 @@ template Instrument
           redemptionClaim = when (TimeGte $ periodicSchedule.terminationDate) $
             cond deflation deflationClaim inflationClaim
 
-          couponClaimsTagged = prepareAndTagClaims couponClaims "Coupon"
-          redemptionClaimTagged = prepareAndTagClaims [redemptionClaim] "Redemption"
+          couponClaimsTagged = prepareAndTagClaims dateToDateClockTime couponClaims "Coupon"
+          redemptionClaimTagged = prepareAndTagClaims dateToDateClockTime [redemptionClaim] "Redemption"
         pure $ [couponClaimsTagged, redemptionClaimTagged]
 
     interface instance BaseInstrument.I for Instrument where

--- a/src/main/daml/Daml/Finance/Instrument/Bond/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/Util.daml
@@ -1,9 +1,18 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module Daml.Finance.Instrument.Bond.Util where
 
 import Daml.Finance.Data.Reference.HolidayCalendar (GetCalendar(..), HolidayCalendar, HolidayCalendarKey(..))
+import Daml.Finance.Data.Time.DateClock.Types (Unit(..))
+import Daml.Finance.Interface.Types.Date.Classes (toUTCTime)
 import Daml.Finance.Interface.Types.Date.Calendar
 import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..), Schedule)
 import Daml.Finance.Util.Date.Schedule (createSchedule)
+
+-- | Maps a `Date` to `Time` using the rule in the `DateClock`.
+dateToDateClockTime : Date -> Time
+dateToDateClockTime = toUTCTime . Unit
 
 -- | Retrieve holiday calendar(s) from the ledger.
 getHolidayCalendars : Party -> Party -> [Text] -> Update [HolidayCalendarData]
@@ -22,3 +31,5 @@ rollSchedule : ([Text] -> Update [HolidayCalendarData]) -> PeriodicSchedule -> [
 rollSchedule getHolidayCalendars periodicSchedule holidayCalendarIds = do
   cals <- getHolidayCalendars holidayCalendarIds
   pure $ createSchedule cals periodicSchedule
+
+

--- a/src/main/daml/Daml/Finance/Instrument/Bond/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/Util.daml
@@ -1,0 +1,24 @@
+module Daml.Finance.Instrument.Bond.Util where
+
+import Daml.Finance.Data.Reference.HolidayCalendar (GetCalendar(..), HolidayCalendar, HolidayCalendarKey(..))
+import Daml.Finance.Interface.Types.Date.Calendar
+import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..), Schedule)
+import Daml.Finance.Util.Date.Schedule (createSchedule)
+
+-- | Retrieve holiday calendar(s) from the ledger.
+getHolidayCalendars : Party -> Party -> [Text] -> Update [HolidayCalendarData]
+getHolidayCalendars actor provider holidayCalendarIds =
+  let
+    -- get a holiday calendar from the ledger
+    getCalendar id = do
+      exerciseByKey @HolidayCalendar holCalKey GetCalendar with viewer = actor where
+        holCalKey = HolidayCalendarKey with provider; id
+  in
+    -- get the holiday calendars
+    mapA getCalendar holidayCalendarIds
+
+-- | Retrieve holiday calendar(s) from the ledger and roll out a schedule.
+rollSchedule : ([Text] -> Update [HolidayCalendarData]) -> PeriodicSchedule -> [Text] -> Update Schedule
+rollSchedule getHolidayCalendars periodicSchedule holidayCalendarIds = do
+  cals <- getHolidayCalendars holidayCalendarIds
+  pure $ createSchedule cals periodicSchedule

--- a/src/main/daml/Daml/Finance/Instrument/Bond/ZeroCoupon/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/ZeroCoupon/Instrument.daml
@@ -6,6 +6,7 @@ module Daml.Finance.Instrument.Bond.ZeroCoupon.Instrument where
 import DA.Date (daysSinceEpochToDate)
 import DA.Set (singleton)
 import Daml.Finance.Claims.Util.Builders
+import Daml.Finance.Instrument.Bond.Util
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, GetClaims(..), View(..))
 import Daml.Finance.Interface.Claims.Dynamic.Instrument qualified as DynamicInstrument (I, CreateNewVersion(..), View(..))
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, K, View(..), createReference, disclosureUpdateReference)
@@ -62,7 +63,7 @@ template Instrument
           ownerReceives = True
           fxAdjustment = 1.0
           redemptionClaim =
-            createFxAdjustedPrincipalClaim ownerReceives fxAdjustment notional currency maturityDate
+            createFxAdjustedPrincipalClaim dateToDateClockTime ownerReceives fxAdjustment notional currency maturityDate
         in
           pure $ [redemptionClaim]
 

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Asset/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Asset/Instrument.daml
@@ -86,9 +86,9 @@ template Instrument
           useAdjustedDatesForDcf = True
           notional = 1.0
           ownerReceivesAssetLeg = not ownerReceivesFix
-          fixClaims = createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf
+          fixClaims = createFixRatePaymentClaims dateToDateClockTime schedule periodicSchedule useAdjustedDatesForDcf
             fixRate ownerReceivesFix dayCountConvention notional currency
-          assetClaims = createAssetPerformancePaymentClaims schedule periodicSchedule
+          assetClaims = createAssetPerformancePaymentClaims dateToDateClockTime schedule periodicSchedule
             useAdjustedDatesForDcf ownerReceivesAssetLeg dayCountConvention notional currency
             referenceAssetId
         pure $ [fixClaims, assetClaims]

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Asset/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Asset/Instrument.daml
@@ -6,6 +6,7 @@ module Daml.Finance.Instrument.Swap.Asset.Instrument where
 import DA.Date (daysSinceEpochToDate)
 import DA.Set (singleton)
 import Daml.Finance.Claims.Util.Builders
+import Daml.Finance.Instrument.Swap.Util
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, GetClaims(..), View(..))
 import Daml.Finance.Interface.Claims.Dynamic.Instrument qualified as DynamicInstrument (I, CreateNewVersion(..), View(..))
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, K, View(..), createReference, disclosureUpdateReference)
@@ -79,8 +80,8 @@ template Instrument
       asBaseInstrument = toInterface @BaseInstrument.I this
       getClaims Claim.GetClaims{actor} = do
         -- get the initial claims tree (as of the swap's acquisition time)
-        schedule <-
-          rollPaymentSchedule periodicSchedule holidayCalendarIds actor calendarDataProvider
+        let getCalendars = getHolidayCalendars actor calendarDataProvider
+        schedule <- rollSchedule getCalendars periodicSchedule holidayCalendarIds
         let
           useAdjustedDatesForDcf = True
           notional = 1.0

--- a/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault/Instrument.daml
@@ -86,10 +86,10 @@ template Instrument
           useAdjustedDatesForDcf = True
           notional = 1.0
           ownerReceivesCreditLeg = not ownerReceivesFix
-          fixClaims = createConditionalCreditFixRatePaymentClaims schedule periodicSchedule
+          fixClaims = createConditionalCreditFixRatePaymentClaims dateToDateClockTime schedule periodicSchedule
             useAdjustedDatesForDcf fixRate ownerReceivesFix dayCountConvention notional currency
             defaultProbabilityReferenceId
-          creditDefaultClaims = createCreditEventPaymentClaims ownerReceivesCreditLeg notional
+          creditDefaultClaims = createCreditEventPaymentClaims dateToDateClockTime ownerReceivesCreditLeg notional
             currency defaultProbabilityReferenceId recoveryRateReferenceId periodicSchedule
         pure $ [fixClaims, creditDefaultClaims]
 

--- a/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault/Instrument.daml
@@ -6,6 +6,7 @@ module Daml.Finance.Instrument.Swap.CreditDefault.Instrument where
 import DA.Date (daysSinceEpochToDate)
 import DA.Set (singleton)
 import Daml.Finance.Claims.Util.Builders
+import Daml.Finance.Instrument.Swap.Util
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, GetClaims(..), View(..))
 import Daml.Finance.Interface.Claims.Dynamic.Instrument qualified as DynamicInstrument (I, CreateNewVersion(..), View(..))
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, K, View(..), createReference, disclosureUpdateReference)
@@ -79,8 +80,8 @@ template Instrument
       asBaseInstrument = toInterface @BaseInstrument.I this
       getClaims Claim.GetClaims{actor} = do
         -- get the initial claims tree (as of the swap's acquisition time)
-        schedule <-
-          rollPaymentSchedule periodicSchedule holidayCalendarIds actor calendarDataProvider
+        let getCalendars = getHolidayCalendars actor calendarDataProvider
+        schedule <- rollSchedule getCalendars periodicSchedule holidayCalendarIds
         let
           useAdjustedDatesForDcf = True
           notional = 1.0

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Currency/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Currency/Instrument.daml
@@ -6,6 +6,7 @@ module Daml.Finance.Instrument.Swap.Currency.Instrument where
 import DA.Date (daysSinceEpochToDate)
 import DA.Set (singleton)
 import Daml.Finance.Claims.Util.Builders
+import Daml.Finance.Instrument.Swap.Util
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, GetClaims(..), View(..))
 import Daml.Finance.Interface.Claims.Dynamic.Instrument qualified as DynamicInstrument (I, CreateNewVersion(..), View(..))
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, K, View(..), createReference, disclosureUpdateReference)
@@ -83,7 +84,8 @@ template Instrument
       asBaseInstrument = toInterface @BaseInstrument.I this
       getClaims Claim.GetClaims{actor} = do
         -- get the initial claims tree (as of the swap's acquisition time)
-        schedule <- rollPaymentSchedule periodicSchedule holidayCalendarIds actor calendarDataProvider
+        let getCalendars = getHolidayCalendars actor calendarDataProvider
+        schedule <- rollSchedule getCalendars periodicSchedule holidayCalendarIds
         let
           useAdjustedDatesForDcf = True
           notional = 1.0

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Currency/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Currency/Instrument.daml
@@ -91,9 +91,9 @@ template Instrument
           notional = 1.0
           issuerPaysForeignLeg = not ownerReceivesBase
           foreignRateInclFxPrincipalAdjustmentFactor = foreignRate * fxRate
-          baseLegClaims = createFixRatePaymentClaims schedule periodicSchedule
+          baseLegClaims = createFixRatePaymentClaims dateToDateClockTime schedule periodicSchedule
             useAdjustedDatesForDcf baseRate ownerReceivesBase dayCountConvention notional baseCurrency
-          foreignLegClaims = createFixRatePaymentClaims schedule periodicSchedule
+          foreignLegClaims = createFixRatePaymentClaims dateToDateClockTime schedule periodicSchedule
             useAdjustedDatesForDcf foreignRateInclFxPrincipalAdjustmentFactor issuerPaysForeignLeg
             dayCountConvention notional foreignCurrency
         pure $ [baseLegClaims, foreignLegClaims]

--- a/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange/Instrument.daml
@@ -6,6 +6,7 @@ module Daml.Finance.Instrument.Swap.ForeignExchange.Instrument where
 import DA.Date (daysSinceEpochToDate)
 import DA.Set (singleton)
 import Daml.Finance.Claims.Util.Builders
+import Daml.Finance.Instrument.Swap.Util
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, View(..))
 import Daml.Finance.Interface.Claims.Dynamic.Instrument qualified as DynamicInstrument (I, CreateNewVersion(..), View(..))
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, K, View(..), createReference, disclosureUpdateReference)
@@ -74,13 +75,13 @@ template Instrument
         -- get the initial claims tree (as of the swap's acquisition time)
         let
           notional = 1.0
-          baseCurrencyFirstPayment = createFxAdjustedPrincipalClaim False 1.0 notional baseCurrency
+          baseCurrencyFirstPayment = createFxAdjustedPrincipalClaim dateToDateClockTime False 1.0 notional baseCurrency
             firstPaymentDate
-          foreignCurrencyFirstPayment = createFxAdjustedPrincipalClaim True firstFxRate notional
+          foreignCurrencyFirstPayment = createFxAdjustedPrincipalClaim dateToDateClockTime True firstFxRate notional
             foreignCurrency firstPaymentDate
-          baseCurrencyFinalPayment = createFxAdjustedPrincipalClaim True 1.0 notional baseCurrency
+          baseCurrencyFinalPayment = createFxAdjustedPrincipalClaim dateToDateClockTime True 1.0 notional baseCurrency
             maturityDate
-          foreignCurrencyFinalPayment = createFxAdjustedPrincipalClaim False finalFxRate notional
+          foreignCurrencyFinalPayment = createFxAdjustedPrincipalClaim dateToDateClockTime False finalFxRate notional
             foreignCurrency maturityDate
         pure $ [baseCurrencyFirstPayment, foreignCurrencyFirstPayment, baseCurrencyFinalPayment,
           foreignCurrencyFinalPayment]

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
@@ -8,6 +8,7 @@ import DA.List (head, last)
 import DA.Set (singleton)
 import Daml.Finance.Claims.Util.Builders
 import Daml.Finance.Instrument.Swap.Fpml.Util
+import Daml.Finance.Instrument.Swap.Util
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, GetClaims(..), View(..))
 import Daml.Finance.Interface.Claims.Dynamic.Instrument qualified as DynamicInstrument (I, CreateNewVersion(..), View(..))
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, K, View(..), createReference, disclosureUpdateReference)
@@ -82,16 +83,16 @@ template Instrument
               s.paymentDates.calculationPeriodDatesReference == s.calculationPeriodDates.id
             assertMsg "Only payment schedules relative to CalculationPeriodEndDate supported" $
               s.paymentDates.payRelativeTo == CalculationPeriodEndDate
-            calculationSchedule <- rollPaymentSchedule
+            let getCalendars = getHolidayCalendars issuer calendarDataProvider
+
+            calculationSchedule <- rollSchedule
+              getCalendars
               calculationPeriodicSchedule
               s.calculationPeriodDates.calculationPeriodDatesAdjustments.businessCenters
-              issuer
-              calendarDataProvider
-            paymentSchedule <- rollPaymentSchedule
+            paymentSchedule <- rollSchedule
+              getCalendars
               paymentPeriodicSchedule
               s.paymentDates.paymentDatesAdjustments.businessCenters
-              issuer
-              calendarDataProvider
 
             -- Verify the effectiveDate and the terminationDate
             effectiveDateAdjusted <- adjustDateAccordingToBusinessDayAdjustments

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
@@ -6,7 +6,6 @@ module Daml.Finance.Instrument.Swap.Fpml.Instrument where
 import DA.Date (daysSinceEpochToDate)
 import DA.List (head, last)
 import DA.Set (singleton)
-import Daml.Finance.Claims.Util.Builders
 import Daml.Finance.Instrument.Swap.Fpml.Util
 import Daml.Finance.Instrument.Swap.Util
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, GetClaims(..), View(..))

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -9,7 +9,8 @@ import DA.Date
 import DA.Foldable (foldMap)
 import DA.List (head, init, last, tail)
 import DA.Optional (fromOptional, fromSome, isNone, isSome)
-import Daml.Finance.Claims.Util.Builders (getHolidayCalendars, prepareAndTagClaims)
+import Daml.Finance.Claims.Util.Builders (prepareAndTagClaims)
+import Daml.Finance.Instrument.Swap.Util
 import Daml.Finance.Interface.Claims.Types (Deliverable, Observable, TaggedClaim(..))
 import Daml.Finance.Interface.Instrument.Swap.Fpml.FpmlTypes
 import Daml.Finance.Interface.Types.Common.Types (Id(..))
@@ -65,7 +66,7 @@ createPaymentPeriodicSchedule s =
 -- element
 getCalendarsAndAdjust : Date -> BusinessDayAdjustments -> Party -> Party -> Update Date
 getCalendarsAndAdjust unadjustedDate businessDayAdjustments issuer calendarDataAgency = do
-  cals <- getHolidayCalendars businessDayAdjustments.businessCenters issuer calendarDataAgency
+  cals <- getHolidayCalendars issuer calendarDataAgency businessDayAdjustments.businessCenters
   pure $ adjustDate (merge cals) businessDayAdjustments.businessDayConvention unadjustedDate
 
 -- | Adjust a date as specified in a BusinessDayAdjustments FpML element
@@ -177,7 +178,7 @@ verifyFxScheduleAndGetId : [SchedulePeriod] -> SwapStream -> Party -> Party ->
   FxLinkedNotionalSchedule -> Update (Optional Text, Optional Decimal, Optional [Date])
 verifyFxScheduleAndGetId calculationSchedule s issuer calendarDataAgency fx = do
   fxFixingCalendars <-
-    getHolidayCalendars fx.varyingNotionalFixingDates.businessCenters issuer calendarDataAgency
+    getHolidayCalendars issuer calendarDataAgency fx.varyingNotionalFixingDates.businessCenters
   let
     fxFixingDates = map (\p ->
       addBusinessDays
@@ -219,7 +220,7 @@ getRateFixingsAndCalendars s r calculationSchedule issuer calendarDataAgency = d
     r.resetRelativeTo == CalculationPeriodStartDate
   assertMsg "No adjustements (besides business day type) supported" $
     r.fixingDates.businessDayConvention == NoAdjustment
-  rateFixingCalendars <- getHolidayCalendars r.fixingDates.businessCenters issuer calendarDataAgency
+  rateFixingCalendars <- getHolidayCalendars issuer calendarDataAgency r.fixingDates.businessCenters
   let
     rateFixingCalendar = merge rateFixingCalendars
     rateFixingDates = map (\p ->

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -262,7 +262,7 @@ calculateFixPaymentClaimsFromSwapStream fixedRateSchedule s periodicSchedule cal
       claimAmounts =
         mconcat $ zipWith createClaim (zip calculationSchedule notionals) paymentScheduleAligned
       claims = if issuerPaysLeg then claimAmounts else give claimAmounts
-      claimsTagged = prepareAndTagClaims [claims] "Fix rate payment"
+      claimsTagged = prepareAndTagClaims dateToDateClockTime [claims] "Fix rate payment"
       allTaggedClaims = [claimsTagged]
     pure allTaggedClaims
 
@@ -312,7 +312,7 @@ calculatePrincipalExchangePaymentClaims paymentScheduleAligned issuerPaysLeg cur
       principalClaims = initialClaims ++ intermediateUndoClaims ++ intermediateNewClaims ++
         principalFinalClaims
     in
-      prepareAndTagClaims principalClaims "Principal exchange payment"
+      prepareAndTagClaims dateToDateClockTime principalClaims "Principal exchange payment"
 
 -- | Create claims from swapStream that describes a fixed or floating coupon stream.
 calculateFloatingPaymentClaimsFromSwapStream : FloatingRateCalculation -> SwapStream ->
@@ -362,7 +362,7 @@ calculateFloatingPaymentClaimsFromSwapStream floatingRateCalculation s periodicS
       claimAmounts = mconcat $ zipWith3 createClaim (zip calculationSchedule notionals)
         paymentScheduleAligned rateFixingDates
       claims = if issuerPaysLeg then claimAmounts else give claimAmounts
-      claimsTagged = prepareAndTagClaims [claims] "Floating rate payment"
+      claimsTagged = prepareAndTagClaims dateToDateClockTime [claims] "Floating rate payment"
       allTaggedClaims = case s.principalExchanges of
         None -> [claimsTagged]
         Some principalExchanges -> [claimsTagged, principalClaimsTagged]

--- a/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate/Instrument.daml
@@ -6,6 +6,7 @@ module Daml.Finance.Instrument.Swap.InterestRate.Instrument where
 import DA.Date (daysSinceEpochToDate)
 import DA.Set (singleton)
 import Daml.Finance.Claims.Util.Builders
+import Daml.Finance.Instrument.Swap.Util
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, GetClaims(..), View(..))
 import Daml.Finance.Interface.Claims.Dynamic.Instrument qualified as DynamicInstrument (I, CreateNewVersion(..), View(..))
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, K, View(..), createReference, disclosureUpdateReference)
@@ -74,8 +75,8 @@ template Instrument
       asBaseInstrument = toInterface @BaseInstrument.I this
       getClaims Claim.GetClaims{actor} = do
         -- get the initial claims tree (as of the swap's acquisition time)
-        schedule <-
-          rollPaymentSchedule periodicSchedule holidayCalendarIds actor calendarDataProvider
+        let getCalendars = getHolidayCalendars actor calendarDataProvider
+        schedule <- rollSchedule getCalendars periodicSchedule holidayCalendarIds
         let
           useAdjustedDatesForDcf = True
           notional = 1.0

--- a/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate/Instrument.daml
@@ -81,9 +81,9 @@ template Instrument
           useAdjustedDatesForDcf = True
           notional = 1.0
           ownerReceivesFloatingLeg = not ownerReceivesFix
-          fixClaims = createFixRatePaymentClaims schedule periodicSchedule useAdjustedDatesForDcf
+          fixClaims = createFixRatePaymentClaims dateToDateClockTime schedule periodicSchedule useAdjustedDatesForDcf
             fixRate ownerReceivesFix dayCountConvention notional currency
-          floatingClaims = createFloatingRatePaymentClaims schedule periodicSchedule
+          floatingClaims = createFloatingRatePaymentClaims dateToDateClockTime schedule periodicSchedule
             useAdjustedDatesForDcf 0.0 ownerReceivesFloatingLeg dayCountConvention notional currency
             referenceRateId
         pure $ [fixClaims, floatingClaims]

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Util.daml
@@ -1,9 +1,18 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module Daml.Finance.Instrument.Swap.Util where
 
 import Daml.Finance.Data.Reference.HolidayCalendar (GetCalendar(..), HolidayCalendar, HolidayCalendarKey(..))
+import Daml.Finance.Data.Time.DateClock.Types (Unit(..))
+import Daml.Finance.Interface.Types.Date.Classes (toUTCTime)
 import Daml.Finance.Interface.Types.Date.Calendar
 import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..), Schedule)
 import Daml.Finance.Util.Date.Schedule (createSchedule)
+
+-- | Maps a `Date` to `Time` using the rule in the `DateClock`.
+dateToDateClockTime : Date -> Time
+dateToDateClockTime = toUTCTime . Unit
 
 -- | Retrieve holiday calendar(s) from the ledger.
 getHolidayCalendars : Party -> Party -> [Text] -> Update [HolidayCalendarData]

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Util.daml
@@ -1,0 +1,24 @@
+module Daml.Finance.Instrument.Swap.Util where
+
+import Daml.Finance.Data.Reference.HolidayCalendar (GetCalendar(..), HolidayCalendar, HolidayCalendarKey(..))
+import Daml.Finance.Interface.Types.Date.Calendar
+import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..), Schedule)
+import Daml.Finance.Util.Date.Schedule (createSchedule)
+
+-- | Retrieve holiday calendar(s) from the ledger.
+getHolidayCalendars : Party -> Party -> [Text] -> Update [HolidayCalendarData]
+getHolidayCalendars actor provider holidayCalendarIds =
+  let
+    -- get a holiday calendar from the ledger
+    getCalendar id = do
+      exerciseByKey @HolidayCalendar holCalKey GetCalendar with viewer = actor where
+        holCalKey = HolidayCalendarKey with provider; id
+  in
+    -- get the holiday calendars
+    mapA getCalendar holidayCalendarIds
+
+-- | Retrieve holiday calendar(s) from the ledger and roll out a schedule.
+rollSchedule : ([Text] -> Update [HolidayCalendarData]) -> PeriodicSchedule -> [Text] -> Update Schedule
+rollSchedule getHolidayCalendars periodicSchedule holidayCalendarIds = do
+  cals <- getHolidayCalendars holidayCalendarIds
+  pure $ createSchedule cals periodicSchedule

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/FloatingRate.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/FloatingRate.daml
@@ -6,7 +6,6 @@ module Daml.Finance.Instrument.Bond.Test.FloatingRate where
 import DA.Date
 import DA.Map qualified as M (empty, fromList)
 import DA.Set (singleton)
-import Daml.Finance.Claims.Util.Builders
 import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Reference.HolidayCalendar
 import Daml.Finance.Instrument.Bond.Test.Util
@@ -17,6 +16,7 @@ import Daml.Finance.Interface.Types.Date.DayCount
 import Daml.Finance.Interface.Types.Date.RollConvention
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
+import Daml.Finance.Test.Util.Time (dateToDateClockTime)
 import Daml.Script
 
 -- Penultimate coupon payment on a bond showing creation of new instrument version

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/InflationLinked.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/InflationLinked.daml
@@ -6,7 +6,6 @@ module Daml.Finance.Instrument.Bond.Test.InflationLinked where
 import DA.Date
 import DA.Map qualified as M (empty, fromList)
 import DA.Set (singleton)
-import Daml.Finance.Claims.Util.Builders
 import Daml.Finance.Data.Numeric.Observation(Observation(..))
 import Daml.Finance.Data.Reference.HolidayCalendar
 import Daml.Finance.Instrument.Bond.Test.Util
@@ -17,6 +16,7 @@ import Daml.Finance.Interface.Types.Date.DayCount
 import Daml.Finance.Interface.Types.Date.RollConvention
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
+import Daml.Finance.Test.Util.Time (dateToDateClockTime)
 import Daml.Script
 
 -- Penultimate coupon payment on a bond showing creation of new instrument version

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/Util.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Instrument.Generic.Test.Util where
 
 import ContingentClaims.Core.Claim (Claim)
 import DA.Map qualified as M
-import Daml.Finance.Claims.Util (toTime')
+import Daml.Finance.Claims.Util (toTime)
 import Daml.Finance.Data.Time.DateClock.Types (Unit(..))
 import Daml.Finance.Instrument.Generic.Instrument (Instrument(..))
 import Daml.Finance.Interface.Claims.Types (C, Deliverable, Observable)
@@ -17,11 +17,11 @@ import Daml.Script
 
 -- | Maps a `Date` to `Time` using the mapping defined in the `DateClock`.
 dateToDateClockTime : Date -> Time
-dateToDateClockTime d = (toUTCTime . Unit) d
+dateToDateClockTime = toUTCTime . Unit
 
 -- | Maps a `Date` claim to a `Time` claim using the rule in the `DateClock`.
 mapClaimToUTCTime : Claim Date Decimal Deliverable Observable -> C
-mapClaimToUTCTime c = let dateToTime = toUTCTime . Unit in toTime' dateToTime c
+mapClaimToUTCTime = toTime dateToDateClockTime
 
 -- | Originate generic instrument
 originateGeneric : Party -> Party -> Text -> Text -> Time -> C -> [(Text, Parties)] -> Time ->

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Asset.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Asset.daml
@@ -6,7 +6,6 @@ module Daml.Finance.Instrument.Swap.Test.Asset where
 import DA.Date
 import DA.Map qualified as M (empty, fromList)
 import DA.Set (singleton)
-import Daml.Finance.Claims.Util.Builders
 import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Reference.HolidayCalendar
 import Daml.Finance.Instrument.Swap.Test.Util
@@ -17,6 +16,7 @@ import Daml.Finance.Interface.Types.Date.DayCount
 import Daml.Finance.Interface.Types.Date.RollConvention
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
+import Daml.Finance.Test.Util.Time (dateToDateClockTime)
 import Daml.Script
 
 -- Calculate payments on an asset swap, including lifecycling and creation of new instrument

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/CreditDefault.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/CreditDefault.daml
@@ -6,7 +6,6 @@ module Daml.Finance.Instrument.Swap.Test.CreditDefault where
 import DA.Date
 import DA.Map qualified as M (empty, fromList)
 import DA.Set (singleton)
-import Daml.Finance.Claims.Util.Builders
 import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Reference.HolidayCalendar
 import Daml.Finance.Instrument.Swap.Test.Util
@@ -17,6 +16,7 @@ import Daml.Finance.Interface.Types.Date.DayCount
 import Daml.Finance.Interface.Types.Date.RollConvention
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
+import Daml.Finance.Test.Util.Time (dateToDateClockTime)
 import Daml.Script
 
 -- | Parties involved in the test script.

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -6,7 +6,6 @@ module Daml.Finance.Instrument.Swap.Test.Fpml where
 import DA.Date
 import DA.Map qualified as M (empty, fromList)
 import DA.Set (singleton)
-import Daml.Finance.Claims.Util.Builders
 import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Reference.HolidayCalendar
 import Daml.Finance.Instrument.Swap.Test.Util
@@ -18,6 +17,7 @@ import Daml.Finance.Interface.Types.Date.DayCount
 import Daml.Finance.Interface.Types.Date.RollConvention
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
+import Daml.Finance.Test.Util.Time (dateToDateClockTime)
 import Daml.Script
 
 -- Calculate interest rate payment on an interest rate swap (represented using FpML swapStreams),

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/InterestRate.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/InterestRate.daml
@@ -6,7 +6,6 @@ module Daml.Finance.Instrument.Swap.Test.InterestRate where
 import DA.Date
 import DA.Map qualified as M (empty, fromList)
 import DA.Set (singleton)
-import Daml.Finance.Claims.Util.Builders
 import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Reference.HolidayCalendar
 import Daml.Finance.Instrument.Swap.Test.Util
@@ -17,6 +16,7 @@ import Daml.Finance.Interface.Types.Date.DayCount
 import Daml.Finance.Interface.Types.Date.RollConvention
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
+import Daml.Finance.Test.Util.Time (dateToDateClockTime)
 import Daml.Script
 
 -- Calculate interest rate payment on an interest rate swap, including lifecycling and creation of

--- a/src/test/daml/Daml/Finance/Test/Util/Time.daml
+++ b/src/test/daml/Daml/Finance/Test/Util/Time.daml
@@ -25,3 +25,7 @@ createClockUpdateEvent providers today observers = do
     createCmd DateClockUpdateEvent with
       providers; id; description; date = today; observers; eventTime = toUTCTime date
   pure eventCid
+
+-- | Maps a `Date` to `Time` using the rule in the `DateClock`.
+dateToDateClockTime : Date -> Time
+dateToDateClockTime = toUTCTime . Unit


### PR DESCRIPTION
Fixes https://github.com/digital-asset/daml-finance/issues/386

This PR removes the dependency of Daml.Finance.Claims on Daml.Finance.Data.

By so doing, it makes Daml.Finance.Claims agnostic to the specific
- calendar implementation
- logic to convert `Date` to `Time`

where we have made a specific choice, but a user could want to make a different one.

As a next step, I would like to take `prepareAndTagClaims` out of the builder functions, to simplify their signature and make them return pure `Claim` objects.  However, I won't feel to bad if I don't manage before the release.

