### PR TITLE
Update Release Script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,28 +84,40 @@ commands:
               --run bash \<<'EOF'
                   set -euo pipefail
 
-                  PACKAGES=(`ls package/main/daml/*/daml.yaml`)
-                  for package in ${PACKAGES[@]}; do
-                    PACKAGE=`echo ${package} | cut -f4 -d "/"`
-                    VERSION=`yq e '.version' ${package}`
-                    TAG="${PACKAGE}/${VERSION}"
-                    echo "Processing package '${PACKAGE}' with tag '${TAG}'..."
+                  while read PACKAGE_NAME PACKAGE_PATH
+                  do
+                    CONFIG="package/${PACKAGE_PATH}/daml.yaml"
+                    VERSION=`yq e '.version' ${CONFIG}`
+                    TAG="${PACKAGE_NAME}/${VERSION}"
+                    echo "Processing package '${PACKAGE_NAME}' with tag '${TAG}'..."
 
                     if [[ `git tag -l ${TAG} | wc -l` -eq 0 ]]; then
-                      DAR_PREFIX=`yq e '.name' ${package}`
+                      DAR_PREFIX=`yq e '.name' ${CONFIG}`
                       DAR="${DAR_PREFIX}-${VERSION}.dar"
                       gpg --armor --detach-sign .dars/${DAR}
 
                       if [[ `echo $VERSION | grep ".99." | wc -l` -eq 0 ]] ; then
-                        gh release create ${TAG} .dars/${DAR}* --target ${CIRCLE_BRANCH} --title ${TAG} --notes "See release notes (insert link here) for further details."
+                        gh release create ${TAG} .dars/${DAR}* \
+                          --target ${CIRCLE_BRANCH} \
+                          --title ${TAG} \
+                          --notes "See Daml-Finance [documentation](https://docs.daml.com/daml-finance/index.html) for further details."
                       else
-                        gh release create ${TAG} .dars/${DAR}* --target ${CIRCLE_BRANCH} --prerelease --title ${TAG} --notes "Development snapshot of package '${PACKAGE}'. Use at your own risk."
+                        gh release create ${TAG} .dars/${DAR}* \
+                          --prerelease \
+                          --target ${CIRCLE_BRANCH} \
+                          --title ${TAG} \
+                          --notes "Development snapshot of package '${PACKAGE_NAME}'. Use at your own risk."
                       fi
-                      echo -e "Successfully released package '${PACKAGE}' with tag '${TAG}'.\n"
+                      echo -e "Successfully released package '${PACKAGE_NAME}' with tag '${TAG}'.\n"
                     else
-                      echo -e "Tag '${TAG}' already exists for package '${PACKAGE}'; Ignoring.\n"
+                      echo -e "Tag '${TAG}' already exists for package '${PACKAGE_NAME}'; Ignoring.\n"
                     fi
-                  done
+                  done < <(yq e '.local.packages
+                    | to_entries
+                    | map(.value.package)
+                    | .[]
+                    | select(.path == "main*")
+                    | .name + " " + .path' package/packages.yaml)
             EOF
   run_assembly:
     description: "Build Assembly for docs.daml.com"
@@ -136,7 +148,12 @@ commands:
 
                   # Push assembly to Artifactory
                   URL="https://digitalasset.jfrog.io/artifactory/assembly/daml-finance/${ASSEMBLY_VERSION}/${DOC_SOURCES_TAR}"
-                  curl -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" -sSf -X PUT -T "${DOC_SOURCES_TAR}" "${URL}"
+                  curl \
+                    -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" \
+                    -sSf \
+                    -X PUT \
+                    -T "${DOC_SOURCES_TAR}" \
+                    "${URL}"
 
                   # Tag assembly in GitHub
                   TAG="assembly/${ASSEMBLY_VERSION}"
@@ -169,6 +186,10 @@ jobs:
           command:
             make ci-build
       - run:
+          name: Validate packages
+          command:
+            make ci-validate
+      - run:
           name: Build java codegen
           command:
             make ci-build-java
@@ -180,10 +201,6 @@ jobs:
           name: Execute tests
           command:
             make ci-test
-      - run:
-          name: Validate packages
-          command:
-            make ci-validate
       - run:
           name: Build docs
           command: |
@@ -202,7 +219,7 @@ jobs:
     steps:
       - checkout
       - setup_nix
-      - import_gpg_key
+      # - import_gpg_key
       - run_release
   assembly:
     executor: daml-finance-executor

--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,5 @@
 use nix
 
 source_env_if_exists .envrc.private
+
+watch_file daml.yaml

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ ci-data-dependencies:
 		--run 'export LANG=C.UTF-8; packell data-dependencies validate'
 
 .PHONY: ci-local
-ci-local: clean-all ci-headers-check ci-data-dependencies ci-build ci-build-java ci-build-js ci-test ci-validate ci-docs
+ci-local: clean-all ci-headers-check ci-data-dependencies ci-build ci-validate ci-build-java ci-build-js ci-test ci-docs
 
 #########
 # Cache #

--- a/shell.nix
+++ b/shell.nix
@@ -17,9 +17,9 @@ in
 pkgs.mkShell {
   SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
   buildInputs = [
-    # (daml { stdenv = pkgs.stdenv;
-    #         jdk = pkgs.openjdk11_headless;
-    #         version = damlYaml.sdk-version; })
+    (daml { stdenv = pkgs.stdenv;
+            jdk = pkgs.openjdk11_headless;
+            version = damlYaml.sdk-version; })
     pkgs.bash
     pkgs.binutils # cp, grep, etc.
     pkgs.cacert

--- a/shell.nix
+++ b/shell.nix
@@ -17,9 +17,9 @@ in
 pkgs.mkShell {
   SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
   buildInputs = [
-    (daml { stdenv = pkgs.stdenv;
-            jdk = pkgs.openjdk11_headless;
-            version = damlYaml.sdk-version; })
+    # (daml { stdenv = pkgs.stdenv;
+    #         jdk = pkgs.openjdk11_headless;
+    #         version = damlYaml.sdk-version; })
     pkgs.bash
     pkgs.binutils # cp, grep, etc.
     pkgs.cacert


### PR DESCRIPTION
Update release script to read from `package/packages.yaml` instead of reading and processing our release via the folder structure.

- Also added `daml.yaml` file to `Direnv` so changes will trigger nix to process the change;
- Moved `ci-validate` to run before the codegen as the exception message is clearer for packaging exceptions.