### PR TITLE
Move quantity stuff

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -33,6 +33,14 @@ within this repository.
   import Daml.Finance.Interface.Asset.Holding qualified as Holding (view, I, V)
   ```
 
+### Exports
+
+- Only use explicit export lists when not all types or functions in a given module are exported
+- Use the `-- | HIDE` annotation for anything that is not exported
+- Do add comments for types and functions that are not exported
+- If you want an internal function to be tested individually, add it to the export list but
+  annotate it with the `-- | HIDE` comment.
+
 ### Module structure
 
 - Modules use the following newlines:

--- a/package/main/daml/Daml.Finance.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Holding/daml.yaml
@@ -11,7 +11,6 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.5/daml-finance-interface-account-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.10/daml-finance-interface-holding-0.1.10.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.10/daml-finance-interface-instrument-base-0.1.10.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/0.1.9/daml-finance-interface-types-common-0.1.9.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.9/daml-finance-interface-util-0.1.9.dar
 build-options:

--- a/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
@@ -11,6 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/0.1.3/contingent-claims-core-0.1.3.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.10/daml-finance-interface-instrument-base-0.1.10.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/0.1.9/daml-finance-interface-types-common-0.1.9.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.9/daml-finance-interface-util-0.1.9.dar
 build-options:
   - --target=1.15

--- a/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
@@ -11,7 +11,6 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.9/daml-finance-interface-data-0.1.9.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.10/daml-finance-interface-holding-0.1.10.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.10/daml-finance-interface-instrument-base-0.1.10.dar
   - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.11/daml-finance-interface-settlement-0.1.11.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/0.1.9/daml-finance-interface-types-common-0.1.9.dar
 build-options:

--- a/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
@@ -10,7 +10,6 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.10/daml-finance-interface-holding-0.1.10.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.10/daml-finance-interface-instrument-base-0.1.10.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/0.1.9/daml-finance-interface-types-common-0.1.9.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.9/daml-finance-interface-util-0.1.9.dar
 build-options:

--- a/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
@@ -11,7 +11,6 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.5/daml-finance-interface-account-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.10/daml-finance-interface-holding-0.1.10.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.10/daml-finance-interface-instrument-base-0.1.10.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.11/daml-finance-interface-lifecycle-0.1.11.dar
   - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.11/daml-finance-interface-settlement-0.1.11.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/0.1.9/daml-finance-interface-types-common-0.1.9.dar

--- a/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
@@ -15,10 +15,10 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Instrument.Bond/0.1.11/daml-finance-instrument-bond-0.1.11.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.10/daml-finance-interface-claims-0.1.10.dar
   - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.9/daml-finance-interface-data-0.1.9.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.10/daml-finance-interface-instrument-base-0.1.10.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.11/daml-finance-interface-lifecycle-0.1.11.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/0.1.9/daml-finance-interface-types-common-0.1.9.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/0.1.9/daml-finance-interface-types-date-0.1.9.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.9/daml-finance-interface-util-0.1.9.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/0.1.12/daml-finance-test-util-0.1.12.dar
 build-options:
   - --target=1.15

--- a/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
@@ -12,11 +12,11 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Holding/0.1.10/daml-finance-holding-0.1.10.dar
   - .lib/daml-finance/Daml.Finance.Instrument.Equity/0.1.12/daml-finance-instrument-equity-0.1.12.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.10/daml-finance-interface-instrument-base-0.1.10.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.1.11/daml-finance-interface-instrument-equity-0.1.11.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.11/daml-finance-interface-lifecycle-0.1.11.dar
   - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.11/daml-finance-interface-settlement-0.1.11.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/0.1.9/daml-finance-interface-types-common-0.1.9.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.9/daml-finance-interface-util-0.1.9.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/0.1.12/daml-finance-lifecycle-0.1.12.dar
   - .lib/daml-finance/Daml.Finance.Settlement/0.1.11/daml-finance-settlement-0.1.11.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/0.1.12/daml-finance-test-util-0.1.12.dar

--- a/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
@@ -18,7 +18,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Account/0.1.5/daml-finance-interface-account-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/0.1.10/daml-finance-interface-claims-0.1.10.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.10/daml-finance-interface-holding-0.1.10.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.10/daml-finance-interface-instrument-base-0.1.10.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/0.1.11/daml-finance-interface-instrument-generic-0.1.11.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.11/daml-finance-interface-lifecycle-0.1.11.dar
   - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.11/daml-finance-interface-settlement-0.1.11.dar

--- a/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
@@ -14,11 +14,11 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Data/0.1.10/daml-finance-data-0.1.10.dar
   - .lib/daml-finance/Daml.Finance.Instrument.Swap/0.1.11/daml-finance-instrument-swap-0.1.11.dar
   - .lib/daml-finance/Daml.Finance.Interface.Data/0.1.9/daml-finance-interface-data-0.1.9.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.10/daml-finance-interface-instrument-base-0.1.10.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.1.11/daml-finance-interface-instrument-swap-0.1.11.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/0.1.11/daml-finance-interface-lifecycle-0.1.11.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/0.1.9/daml-finance-interface-types-common-0.1.9.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/0.1.9/daml-finance-interface-types-date-0.1.9.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.9/daml-finance-interface-util-0.1.9.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/0.1.12/daml-finance-test-util-0.1.12.dar
 build-options:
   - --target=1.15

--- a/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
@@ -13,7 +13,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Account/0.1.5/daml-finance-account-0.1.5.dar
   - .lib/daml-finance/Daml.Finance.Holding/0.1.10/daml-finance-holding-0.1.10.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/0.1.10/daml-finance-interface-holding-0.1.10.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/0.1.10/daml-finance-interface-instrument-base-0.1.10.dar
   - .lib/daml-finance/Daml.Finance.Interface.Settlement/0.1.11/daml-finance-interface-settlement-0.1.11.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/0.1.9/daml-finance-interface-types-common-0.1.9.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/0.1.9/daml-finance-interface-util-0.1.9.dar

--- a/src/main/daml/Daml/Finance/Claims/Lifecycle/Rule.daml
+++ b/src/main/daml/Daml/Finance/Claims/Lifecycle/Rule.daml
@@ -1,9 +1,7 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Daml.Finance.Claims.Lifecycle.Rule
-  ( Rule(..)
-  ) where
+module Daml.Finance.Claims.Lifecycle.Rule where
 
 import DA.Set (fromList)
 import DA.Text (sha256)

--- a/src/main/daml/Daml/Finance/Claims/Util.daml
+++ b/src/main/daml/Daml/Finance/Claims/Util.daml
@@ -1,11 +1,7 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Daml.Finance.Claims.Util
-  ( isZero
-  , isZero'
-  , toTime
-  ) where
+module Daml.Finance.Claims.Util where
 
 import ContingentClaims.Core.Claim (Claim, mapParams)
 import ContingentClaims.Lifecycle.Util qualified as CC (isZero)

--- a/src/main/daml/Daml/Finance/Claims/Util/Lifecycle.daml
+++ b/src/main/daml/Daml/Finance/Claims/Util/Lifecycle.daml
@@ -18,7 +18,8 @@ import DA.Map as M (fromList, lookup)
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, GetClaims(..), getAcquisitionTime, getClaims)
 import Daml.Finance.Interface.Claims.Types (C, Observable, Pending(..), TaggedClaim(..))
 import Daml.Finance.Interface.Data.NumericObservable qualified as NumericObservable (I, observe)
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (Q, qty)
+import Daml.Finance.Interface.Types.Common.Types (InstrumentQuantity)
+import Daml.Finance.Interface.Util.Common (qty)
 import Daml.Finance.Util.Common (sortAndGroupOn)
 import Prelude hiding (exercise)
 
@@ -129,10 +130,10 @@ collectObservables observableCids = do
 
 -- | Map pending settlements into corresponding instrument quantities and split them into consumed
 -- and produced. Pending items with an amount of `0.0` are discarded.
-splitPending : [Pending] -> ([Instrument.Q],[Instrument.Q])
+splitPending : [Pending] -> ([InstrumentQuantity],[InstrumentQuantity])
 splitPending =
   partitionEithers . foldr f []
     where
-      f p acc | p.amount < 0.0 = Left (Instrument.qty (- 1.0 * p.amount) p.instrument) :: acc
-      f p acc | p.amount > 0.0 = Right (Instrument.qty p.amount p.instrument) :: acc
+      f p acc | p.amount < 0.0 = Left (qty (- 1.0 * p.amount) p.instrument) :: acc
+      f p acc | p.amount > 0.0 = Right (qty p.amount p.instrument) :: acc
       f _ acc = acc

--- a/src/main/daml/Daml/Finance/Data/Reference/HolidayCalendar.daml
+++ b/src/main/daml/Daml/Finance/Data/Reference/HolidayCalendar.daml
@@ -1,12 +1,7 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Daml.Finance.Data.Reference.HolidayCalendar
-  ( Factory(..)
-  , GetCalendar(..)
-  , HolidayCalendar(..)
-  , HolidayCalendarKey(..)
-  ) where
+module Daml.Finance.Data.Reference.HolidayCalendar where
 
 import DA.Set (singleton)
 import Daml.Finance.Interface.Data.Reference.HolidayCalendar qualified as HolidayCalendar (I, View(..))

--- a/src/main/daml/Daml/Finance/Holding/Util.daml
+++ b/src/main/daml/Daml/Finance/Holding/Util.daml
@@ -14,8 +14,7 @@ import Daml.Finance.Interface.Account.Util (fetchAccount)
 import Daml.Finance.Interface.Holding.Base (getLockers)
 import Daml.Finance.Interface.Holding.Base qualified as Base (Acquire(..), I, Lock(..), LockType(..), Release(..))
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I, Transfer(..))
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
-import Daml.Finance.Interface.Util.Common (fetchInterfaceByKey)
+import Daml.Finance.Interface.Util.Common (fetchInterfaceByKey, qty)
 import Prelude hiding (null)
 
 -- | Default implementation of transfer for the Transferable interface.
@@ -49,7 +48,7 @@ transferImpl this self Transferable.Transfer{actors; newOwnerAccount} = do
     Account.Debit with holdingCid = baseCid
   -- Credit
   newBaseCid <- Account.exerciseInterfaceByKey @Account.I newOwnerAccount newOwnerAccount.custodian
-    Account.Credit with quantity = Instrument.qty vBase.amount vBase.instrument
+    Account.Credit with quantity = qty vBase.amount vBase.instrument
   -- Consistency check
   newBase <- fetch newBaseCid
   assertMsg "credited and debited holding types must match" $

--- a/src/main/daml/Daml/Finance/Holding/Util.daml
+++ b/src/main/daml/Daml/Finance/Holding/Util.daml
@@ -1,11 +1,7 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Daml.Finance.Holding.Util
-  ( acquireImpl
-  , releaseImpl
-  , transferImpl
-  ) where
+module Daml.Finance.Holding.Util where
 
 import DA.Action (foldlA)
 import DA.Set qualified as S (delete, insert, isSubsetOf, null, singleton, toList)

--- a/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate/Instrument.daml
@@ -9,7 +9,7 @@ import Daml.Finance.Claims.Util.Builders
 import Daml.Finance.Instrument.Bond.Util
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, GetClaims(..), View(..))
 import Daml.Finance.Interface.Claims.Dynamic.Instrument qualified as DynamicInstrument (I, CreateNewVersion(..), View(..))
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, K, View(..), createReference, disclosureUpdateReference)
+import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, View(..), createReference, disclosureUpdateReference)
 import Daml.Finance.Interface.Instrument.Bond.FixedRate.Instrument qualified as FixedRate (HasImplementation, I, View(..))
 import Daml.Finance.Interface.Instrument.Bond.FixedRate.Types (FixedRate(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..), InstrumentKey(..), PartiesMap)
@@ -49,7 +49,7 @@ template Instrument
       -- ^ The reference data provider to use for the holiday calendar.
     dayCountConvention : DayCountConventionEnum
       -- ^ The day count convention used to calculate day count fractions. For example: Act360.
-    currency : BaseInstrument.K
+    currency : InstrumentKey
       -- ^ The currency of the bond. For example, if the bond pays in USD this should be a USD cash
       --   instrument.
     observers : PartiesMap

--- a/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate/Instrument.daml
@@ -9,7 +9,7 @@ import Daml.Finance.Claims.Util.Builders
 import Daml.Finance.Instrument.Bond.Util
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, GetClaims(..), View(..))
 import Daml.Finance.Interface.Claims.Dynamic.Instrument qualified as DynamicInstrument (I, CreateNewVersion(..), View(..))
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, K, View(..), createReference, disclosureUpdateReference)
+import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, View(..), createReference, disclosureUpdateReference)
 import Daml.Finance.Interface.Instrument.Bond.FloatingRate.Instrument qualified as FloatingRate (HasImplementation, I, View(..))
 import Daml.Finance.Interface.Instrument.Bond.FloatingRate.Types (FloatingRate(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..), InstrumentKey(..), PartiesMap)
@@ -55,7 +55,7 @@ template Instrument
       -- ^ The reference data provider to use for the holiday calendar.
     dayCountConvention : DayCountConventionEnum
       -- ^ The day count convention used to calculate day count fractions. For example: Act360.
-    currency : BaseInstrument.K
+    currency : InstrumentKey
       -- ^ The currency of the bond. For example, if the bond pays in USD this should be a USD cash
       --   instrument.
     observers : PartiesMap

--- a/src/main/daml/Daml/Finance/Instrument/Bond/InflationLinked/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/InflationLinked/Instrument.daml
@@ -11,7 +11,7 @@ import Daml.Finance.Claims.Util.Builders
 import Daml.Finance.Instrument.Bond.Util
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, GetClaims(..), View(..))
 import Daml.Finance.Interface.Claims.Dynamic.Instrument qualified as DynamicInstrument (I, CreateNewVersion(..), View(..))
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, K, View(..), createReference, disclosureUpdateReference)
+import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, View(..), createReference, disclosureUpdateReference)
 import Daml.Finance.Interface.Instrument.Bond.InflationLinked.Instrument qualified as InflationLinked (HasImplementation, I, View(..))
 import Daml.Finance.Interface.Instrument.Bond.InflationLinked.Types (InflationLinked(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..), InstrumentKey(..), PartiesMap)
@@ -63,7 +63,7 @@ template Instrument
       -- ^ The reference data provider to use for the holiday calendar.
     dayCountConvention : DayCountConventionEnum
       -- ^ The day count convention used to calculate day count fractions. For example: Act360.
-    currency : BaseInstrument.K
+    currency : InstrumentKey
       -- ^ The currency of the bond. For example, if the bond pays in USD this should be a USD cash
       --   instrument.
     observers : PartiesMap

--- a/src/main/daml/Daml/Finance/Instrument/Bond/ZeroCoupon/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/ZeroCoupon/Instrument.daml
@@ -9,7 +9,7 @@ import Daml.Finance.Claims.Util.Builders
 import Daml.Finance.Instrument.Bond.Util
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, GetClaims(..), View(..))
 import Daml.Finance.Interface.Claims.Dynamic.Instrument qualified as DynamicInstrument (I, CreateNewVersion(..), View(..))
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, K, View(..), createReference, disclosureUpdateReference)
+import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, View(..), createReference, disclosureUpdateReference)
 import Daml.Finance.Interface.Instrument.Bond.ZeroCoupon.Instrument qualified as ZeroCoupon (HasImplementation, I, View(..))
 import Daml.Finance.Interface.Instrument.Bond.ZeroCoupon.Types (ZeroCoupon(..))
 import Daml.Finance.Interface.Types.Common.Types (Id, InstrumentKey(..), PartiesMap)
@@ -39,7 +39,7 @@ template Instrument
       -- ^ The date when the bond was issued.
     maturityDate : Date
       -- ^ The redemption date of the bond.
-    currency : BaseInstrument.K
+    currency : InstrumentKey
       -- ^ The currency of the bond. For example, if the bond pays in USD this should be a USD cash
       -- instrument.
     observers : PartiesMap

--- a/src/main/daml/Daml/Finance/Instrument/Equity/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Equity/Instrument.daml
@@ -4,9 +4,10 @@
 module Daml.Finance.Instrument.Equity.Instrument where
 
 import DA.Set (fromList, singleton)
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, View(..), disclosureUpdateReference, qty)
+import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, View(..), disclosureUpdateReference)
 import Daml.Finance.Interface.Instrument.Equity.Instrument qualified as Equity (DeclareDividend(..), DeclareReplacement(..), DeclareStockSplit(..), HasImplementation, I, View(..))
 import Daml.Finance.Interface.Types.Common.Types (Id, InstrumentKey(..), PartiesMap)
+import Daml.Finance.Interface.Util.Common (qty)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, SetObservers(..), View(..), flattenObservers)
 import Daml.Finance.Lifecycle.Event.Distribution qualified as Distribution (Event(..))
 import Daml.Finance.Lifecycle.Event.Replacement qualified as Replacement (Event(..))
@@ -70,7 +71,7 @@ template Instrument
               description
               effectiveTime
               targetInstrument = instrumentKey
-              perUnitReplacement = [BaseInstrument.qty (1.0 / adjustmentFactor) newInstrument]
+              perUnitReplacement = [qty (1.0 / adjustmentFactor) newInstrument]
               observers = Disclosure.flattenObservers observers
       declareReplacement
         Equity.DeclareReplacement{id; description; effectiveTime; perUnitReplacement} =

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Election.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Election.daml
@@ -8,10 +8,9 @@ import DA.Set qualified as S (fromList, singleton)
 import DA.Text (sha256)
 import Daml.Finance.Interface.Claims.Types (C)
 import Daml.Finance.Interface.Holding.Base qualified as Base (I)
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (K)
 import Daml.Finance.Interface.Instrument.Generic.Election qualified as Election (HasImplementation, I, View(..))
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I, View(..))
-import Daml.Finance.Interface.Types.Common.Types (Id(..), Parties, PartiesMap)
+import Daml.Finance.Interface.Types.Common.Types (Id(..), InstrumentKey, Parties, PartiesMap)
 import Daml.Finance.Interface.Util.Common (verify)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, SetObservers(..), View(..), flattenObservers)
 
@@ -33,7 +32,7 @@ template Election
       -- ^ Election identifier.
     description : Text
       -- ^ A human readable description of the election.
-    instrument : Instrument.K
+    instrument : InstrumentKey
       -- ^ The instrument to which the election applies.
     amount : Decimal
       -- ^ Number of units of instrument to which the election applies.
@@ -86,7 +85,7 @@ template ElectionFactory
       -- ^ the elected sub-tree
     observers : Parties
       -- ^ observers of the contract
-    instrument : Instrument.K
+    instrument : InstrumentKey
       -- ^ key of the instrument to which the election applies
   where
     signatory provider

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Lifecycle/Rule.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Lifecycle/Rule.daml
@@ -13,10 +13,10 @@ import Daml.Finance.Claims.Util (isZero')
 import Daml.Finance.Claims.Util.Lifecycle (electionEvent, lifecycle, splitPending, timeEvent)
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, GetClaims(..), getClaims)
 import Daml.Finance.Interface.Claims.Types (C)
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (K, R, createReference, getKey)
+import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (R, createReference, getKey)
 import Daml.Finance.Interface.Instrument.Generic.Election qualified as Election (ApplyElection(..), Exercisable(..), ExercisableView(..), getElectionTime)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Evolve(..), View(..))
-import Daml.Finance.Interface.Types.Common.Types (Id(..), Parties, PartiesMap)
+import Daml.Finance.Interface.Types.Common.Types (Id(..), InstrumentKey, Parties, PartiesMap)
 import Daml.Finance.Interface.Util.Common (fetchInterfaceByKey)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, SetObservers(..), View(..), flattenObservers)
 import Daml.Finance.Instrument.Generic.Instrument (Instrument(..))
@@ -137,7 +137,7 @@ template Rule
 
 -- | HIDE
 -- Check if an instrument for the new key already exists, otherwise create it.
-tryCreateNewInstrument : Party -> C -> Time -> Instrument -> BaseInstrument.K -> Update ()
+tryCreateNewInstrument : Party -> C -> Time -> Instrument -> InstrumentKey -> Update ()
 tryCreateNewInstrument actor newClaim eventTime oldInstrument newKey = do
   existingRefCidOpt <- lookupByKey @BaseInstrument.R newKey
   case existingRefCidOpt of

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Asset/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Asset/Instrument.daml
@@ -9,7 +9,7 @@ import Daml.Finance.Claims.Util.Builders
 import Daml.Finance.Instrument.Swap.Util
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, GetClaims(..), View(..))
 import Daml.Finance.Interface.Claims.Dynamic.Instrument qualified as DynamicInstrument (I, CreateNewVersion(..), View(..))
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, K, View(..), createReference, disclosureUpdateReference)
+import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, View(..), createReference, disclosureUpdateReference)
 import Daml.Finance.Interface.Instrument.Swap.Asset.Instrument qualified as Asset (HasImplementation, I, View(..))
 import Daml.Finance.Interface.Instrument.Swap.Asset.Types (Asset(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..), InstrumentKey(..), PartiesMap)
@@ -61,7 +61,7 @@ template Instrument
       -- ^ The reference data provider to use for the holiday calendar.
     dayCountConvention : DayCountConventionEnum
       -- ^ The day count convention used to calculate day count fractions. For example: Act360.
-    currency : BaseInstrument.K
+    currency : InstrumentKey
       -- ^ The currency of the swap. For example, if the swap pays in USD this should be a USD cash
       --   instrument.
     observers : PartiesMap

--- a/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault/Instrument.daml
@@ -9,7 +9,7 @@ import Daml.Finance.Claims.Util.Builders
 import Daml.Finance.Instrument.Swap.Util
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, GetClaims(..), View(..))
 import Daml.Finance.Interface.Claims.Dynamic.Instrument qualified as DynamicInstrument (I, CreateNewVersion(..), View(..))
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, K, View(..), createReference, disclosureUpdateReference)
+import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, View(..), createReference, disclosureUpdateReference)
 import Daml.Finance.Interface.Instrument.Swap.CreditDefault.Instrument qualified as CreditDefaultSwap (HasImplementation, I, View(..))
 import Daml.Finance.Interface.Instrument.Swap.CreditDefault.Types (CreditDefault(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..), InstrumentKey(..), PartiesMap)
@@ -61,7 +61,7 @@ template Instrument
       -- ^ The reference data provider to use for the holiday calendar.
     dayCountConvention : DayCountConventionEnum
       -- ^ The day count convention used to calculate day count fractions. For example: Act360.
-    currency : BaseInstrument.K
+    currency : InstrumentKey
       -- ^ The currency of the swap. For example, if the swap pays in USD this should be a USD cash
       --   instrument.
     observers : PartiesMap

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Currency/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Currency/Instrument.daml
@@ -9,7 +9,7 @@ import Daml.Finance.Claims.Util.Builders
 import Daml.Finance.Instrument.Swap.Util
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, GetClaims(..), View(..))
 import Daml.Finance.Interface.Claims.Dynamic.Instrument qualified as DynamicInstrument (I, CreateNewVersion(..), View(..))
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, K, View(..), createReference, disclosureUpdateReference)
+import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, View(..), createReference, disclosureUpdateReference)
 import Daml.Finance.Interface.Instrument.Swap.Currency.Instrument qualified as CurrencySwap (HasImplementation, I, View(..))
 import Daml.Finance.Interface.Instrument.Swap.Currency.Types (CurrencySwap(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..), InstrumentKey(..), PartiesMap)
@@ -59,10 +59,10 @@ template Instrument
       -- ^ The reference data provider to use for the holiday calendar.
     dayCountConvention : DayCountConventionEnum
       -- ^ The day count convention used to calculate day count fractions. For example: Act360.
-    baseCurrency : BaseInstrument.K
+    baseCurrency : InstrumentKey
       -- ^ The base currency of the swap. For example, in the case of USD this should be a USD cash
       --   instrument.
-    foreignCurrency : BaseInstrument.K
+    foreignCurrency : InstrumentKey
       -- ^ The foreign currency of the swap. For example, in case of EUR this should be a EUR cash
       --   instrument.
     fxRate : Decimal

--- a/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange/Instrument.daml
@@ -9,7 +9,7 @@ import Daml.Finance.Claims.Util.Builders
 import Daml.Finance.Instrument.Swap.Util
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, View(..))
 import Daml.Finance.Interface.Claims.Dynamic.Instrument qualified as DynamicInstrument (I, CreateNewVersion(..), View(..))
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, K, View(..), createReference, disclosureUpdateReference)
+import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, View(..), createReference, disclosureUpdateReference)
 import Daml.Finance.Interface.Instrument.Swap.ForeignExchange.Instrument qualified as ForeignExchange (HasImplementation, I, View(..))
 import Daml.Finance.Interface.Instrument.Swap.ForeignExchange.Types (ForeignExchange(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..), InstrumentKey(..), PartiesMap)
@@ -51,10 +51,10 @@ template Instrument
       -- ^ The first payment date of the swap.
     maturityDate : Date
       -- ^ The final payment date of the swap.
-    baseCurrency : BaseInstrument.K
+    baseCurrency : InstrumentKey
       -- ^ The base currency of the swap, which will be exchanged to another (foreign) currency on
       --   the first payment date. For example, in case of USD this should be a USD cash instrument.
-    foreignCurrency : BaseInstrument.K
+    foreignCurrency : InstrumentKey
       -- ^ The foreign currency of the swap. For example, in case of EUR this should be a EUR cash
       --   instrument.
     observers : PartiesMap

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
@@ -10,7 +10,7 @@ import Daml.Finance.Instrument.Swap.Fpml.Util
 import Daml.Finance.Instrument.Swap.Util
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, GetClaims(..), View(..))
 import Daml.Finance.Interface.Claims.Dynamic.Instrument qualified as DynamicInstrument (I, CreateNewVersion(..), View(..))
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, K, View(..), createReference, disclosureUpdateReference)
+import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, View(..), createReference, disclosureUpdateReference)
 import Daml.Finance.Interface.Instrument.Swap.Fpml.FpmlTypes
 import Daml.Finance.Interface.Instrument.Swap.Fpml.Instrument qualified as Fpml (HasImplementation, I, View(..))
 import Daml.Finance.Interface.Instrument.Swap.Fpml.Types (Fpml(..))
@@ -44,7 +44,7 @@ template Instrument
       -- ^ Used to the identify which counterparty is the issuer in the swapStream.
     calendarDataProvider : Party
       -- ^ The reference data provider to use for the holiday calendar.
-    currencies : [BaseInstrument.K]
+    currencies : [InstrumentKey]
       -- ^ The currencies of the different swap legs, one for each swapStream. For example, if one
       --   leg pays in USD this should be a USD cash instrument.
     observers : PartiesMap

--- a/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate/Instrument.daml
@@ -9,7 +9,7 @@ import Daml.Finance.Claims.Util.Builders
 import Daml.Finance.Instrument.Swap.Util
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (I, GetClaims(..), View(..))
 import Daml.Finance.Interface.Claims.Dynamic.Instrument qualified as DynamicInstrument (I, CreateNewVersion(..), View(..))
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, K, View(..), createReference, disclosureUpdateReference)
+import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, View(..), createReference, disclosureUpdateReference)
 import Daml.Finance.Interface.Instrument.Swap.InterestRate.Instrument qualified as InterestRate (HasImplementation, I, View(..))
 import Daml.Finance.Interface.Instrument.Swap.InterestRate.Types (InterestRate(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..), InstrumentKey(..), PartiesMap)
@@ -56,7 +56,7 @@ template Instrument
       -- ^ The reference data provider to use for the holiday calendar.
     dayCountConvention : DayCountConventionEnum
       -- ^ The day count convention used to calculate day count fractions. For example: Act360.
-    currency : BaseInstrument.K
+    currency : InstrumentKey
       -- ^ The currency of the swap. For example, if the swap pays in USD this should be a USD cash
       --   instrument.
     observers : PartiesMap

--- a/src/main/daml/Daml/Finance/Interface/Account/Account.daml
+++ b/src/main/daml/Daml/Finance/Interface/Account/Account.daml
@@ -15,9 +15,6 @@ import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (AddObserv
 -- | Type synonym for `Account`.
 type I = Account
 
--- | Type synonym for `AccountKey`.
-type K = AccountKey
-
 -- | Type synonym for `Reference`. This type is currently used as a work-around given the lack of
 -- interface keys.
 type R = Reference
@@ -153,7 +150,7 @@ template Reference
 -- exerciseInterfaceByKey @Account.I accountKey actor Account.Debit with holdingCid
 -- ```
 exerciseInterfaceByKey : forall i d r. (HasInterfaceTypeRep i, HasExercise i d r)
-  => K          -- ^ The account key.
+  => AccountKey -- ^ The account key.
   -> Party      -- ^ The actor fetching the account.
   -> d          -- ^ The choice arguments.
   -> Update r
@@ -161,7 +158,7 @@ exerciseInterfaceByKey k viewer arg =
   exerciseInterfaceByKeyHelper @R @I @i k (GetCid with viewer) arg
 
 -- | Disclose account.
-disclose : (Text, Parties) -> Party -> Parties -> K -> Update (ContractId I)
+disclose : (Text, Parties) -> Party -> Parties -> AccountKey -> Update (ContractId I)
 disclose observersToAdd actor disclosers account =
   coerceInterfaceContractId <$>
     exerciseInterfaceByKey
@@ -171,7 +168,7 @@ disclose observersToAdd actor disclosers account =
       Disclosure.AddObservers with disclosers; observersToAdd
 
 -- | Undisclose account.
-undisclose : (Text, Parties) -> Party -> Parties -> K -> Update (Optional (ContractId I))
+undisclose : (Text, Parties) -> Party -> Parties -> AccountKey -> Update (Optional (ContractId I))
 undisclose observersToRemove actor disclosers account =
   fmap coerceInterfaceContractId <$>
     exerciseInterfaceByKey
@@ -192,7 +189,7 @@ createReference actor cid = do
 
 -- | HIDE
 -- Helper function to update the account reference once observers are added to the account.
-disclosureUpdateReference : PartiesMap -> K -> ContractId I -> Update (ContractId Disclosure.I)
+disclosureUpdateReference : PartiesMap -> AccountKey -> ContractId I -> Update (ContractId Disclosure.I)
 disclosureUpdateReference newObservers key iCid = do
   exerciseByKey @Reference key SetCid with newCid = iCid
   exerciseByKey @Reference key SetObservers with newObservers

--- a/src/main/daml/Daml/Finance/Interface/Account/Util.daml
+++ b/src/main/daml/Daml/Finance/Interface/Account/Util.daml
@@ -1,12 +1,7 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Daml.Finance.Interface.Account.Util
-  ( fetchAccount
-  , getAccount
-  , getCustodian
-  , getOwner
-  ) where
+module Daml.Finance.Interface.Account.Util where
 
 import Daml.Finance.Interface.Account.Account qualified as Account (I, R)
 import Daml.Finance.Interface.Holding.Base qualified as Base (I)

--- a/src/main/daml/Daml/Finance/Interface/Claims/Types.daml
+++ b/src/main/daml/Daml/Finance/Interface/Claims/Types.daml
@@ -1,13 +1,7 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Daml.Finance.Interface.Claims.Types
-  ( C
-  , Deliverable
-  , Observable
-  , Pending(..)
-  , TaggedClaim(..)
-  ) where
+module Daml.Finance.Interface.Claims.Types where
 
 import ContingentClaims.Core.Claim (Claim)
 import Daml.Finance.Interface.Types.Common.Types (InstrumentKey)

--- a/src/main/daml/Daml/Finance/Interface/Claims/Types.daml
+++ b/src/main/daml/Daml/Finance/Interface/Claims/Types.daml
@@ -10,10 +10,10 @@ module Daml.Finance.Interface.Claims.Types
   ) where
 
 import ContingentClaims.Core.Claim (Claim)
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (K)
+import Daml.Finance.Interface.Types.Common.Types (InstrumentKey)
 
 -- | Type used to reference assets in the claim tree.
-type Deliverable = Instrument.K
+type Deliverable = InstrumentKey
 
 -- | Type used to reference observables in the claim tree.
 type Observable = Text

--- a/src/main/daml/Daml/Finance/Interface/Holding/Util.daml
+++ b/src/main/daml/Daml/Finance/Interface/Holding/Util.daml
@@ -1,12 +1,7 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Daml.Finance.Interface.Holding.Util
-  ( disclose
-  , getAmount
-  , getInstrument
-  , undisclose
-  ) where
+module Daml.Finance.Interface.Holding.Util where
 
 import Daml.Finance.Interface.Holding.Base qualified as Base (I)
 import Daml.Finance.Interface.Types.Common.Types (InstrumentKey, Parties)

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Bond/FixedRate/Types.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Bond/FixedRate/Types.daml
@@ -3,7 +3,6 @@
 
 module Daml.Finance.Interface.Instrument.Bond.FixedRate.Types where
 
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (K)
 import Daml.Finance.Interface.Types.Common.Types (InstrumentKey)
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
 import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule)
@@ -26,7 +25,7 @@ data FixedRate = FixedRate
       -- ^ The reference data provider to use for the holiday calendar.
     dayCountConvention : DayCountConventionEnum
       -- ^ The day count convention used to calculate day count fractions. For example: Act360.
-    currency : BaseInstrument.K
+    currency : InstrumentKey
       -- ^ The currency of the bond. For example, if the bond pays in USD this should be a USD cash
       --   instrument.
     lastEventTimestamp : Time

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Bond/FloatingRate/Types.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Bond/FloatingRate/Types.daml
@@ -3,7 +3,6 @@
 
 module Daml.Finance.Interface.Instrument.Bond.FloatingRate.Types where
 
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (K)
 import Daml.Finance.Interface.Types.Common.Types (InstrumentKey(..))
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
 import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..))
@@ -29,7 +28,7 @@ data FloatingRate = FloatingRate
       -- ^ The reference data provider to use for the holiday calendar.
     dayCountConvention : DayCountConventionEnum
       -- ^ The day count convention used to calculate day count fractions. For example: Act360.
-    currency : BaseInstrument.K
+    currency : InstrumentKey
       -- ^ The currency of the bond. For example, if the bond pays in USD this should be a USD cash
       --   instrument.
     lastEventTimestamp : Time

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Bond/InflationLinked/Types.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Bond/InflationLinked/Types.daml
@@ -3,7 +3,6 @@
 
 module Daml.Finance.Interface.Instrument.Bond.InflationLinked.Types where
 
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (K)
 import Daml.Finance.Interface.Types.Common.Types (InstrumentKey)
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
 import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule)
@@ -32,7 +31,7 @@ data InflationLinked = InflationLinked
       -- ^ The reference data provider to use for the holiday calendar.
     dayCountConvention : DayCountConventionEnum
       -- ^ The day count convention used to calculate day count fractions. For example: Act360.
-    currency : BaseInstrument.K
+    currency : InstrumentKey
       -- ^ The currency of the bond. For example, if the bond pays in USD this should be a USD cash
       --   instrument.
     lastEventTimestamp : Time

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Bond/ZeroCoupon/Types.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Bond/ZeroCoupon/Types.daml
@@ -3,7 +3,6 @@
 
 module Daml.Finance.Interface.Instrument.Bond.ZeroCoupon.Types where
 
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (K)
 import Daml.Finance.Interface.Types.Common.Types (InstrumentKey)
 
 -- | Describes the attributes of a Zero Coupon bond.
@@ -17,7 +16,7 @@ data ZeroCoupon = ZeroCoupon
       -- ^ The date when the bond was issued.
     maturityDate : Date
       -- ^ The redemption date of the bond.
-    currency : BaseInstrument.K
+    currency : InstrumentKey
       -- ^ The currency of the bond. For example, if the bond pays in USD this should be a USD cash
       --   instrument.
     lastEventTimestamp : Time

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Equity/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Equity/Instrument.daml
@@ -3,9 +3,9 @@
 
 module Daml.Finance.Interface.Instrument.Equity.Instrument where
 
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, Implementation, K, Q, asDisclosure)
+import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, Implementation, asDisclosure)
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I)
-import Daml.Finance.Interface.Types.Common.Types (Id, InstrumentKey)
+import Daml.Finance.Interface.Types.Common.Types (Id, InstrumentKey, InstrumentQuantity)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
 -- | Type synonym for `Instrument`.
@@ -52,9 +52,9 @@ interface Instrument where
         -- ^ Description of the dividend event.
       effectiveTime : Time
         -- ^ Time at which the dividend is distributed.
-      newInstrument : BaseInstrument.K
+      newInstrument : InstrumentKey
         -- ^ Instrument held after the dividend distribution (i.e. "ex-dividend" stock).
-      perUnitDistribution : [BaseInstrument.Q]
+      perUnitDistribution : [InstrumentQuantity]
         -- ^ Distributed quantities per unit held.
     controller (view $ asBaseInstrument this).issuer
     do
@@ -69,7 +69,7 @@ interface Instrument where
         -- ^ Description of the stock split event.
       effectiveTime : Time
         -- ^ Time at which the stock split is effective.
-      newInstrument : BaseInstrument.K
+      newInstrument : InstrumentKey
         -- ^ Instrument to be held after the stock split is executed.
       adjustmentFactor : Decimal
         -- ^ Adjustment factor for the stock split.
@@ -91,7 +91,7 @@ interface Instrument where
         -- ^ Description of the replacement event.
       effectiveTime : Time
         -- ^ Time the replacement is to be executed.
-      perUnitReplacement : [BaseInstrument.Q]
+      perUnitReplacement : [InstrumentQuantity]
         -- ^ Payout offered to shareholders per held share.
     controller (view $ asBaseInstrument this).issuer
     do

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Generic/Election.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Generic/Election.daml
@@ -5,10 +5,9 @@ module Daml.Finance.Interface.Instrument.Generic.Election where
 
 import Daml.Finance.Interface.Claims.Types (C)
 import Daml.Finance.Interface.Data.NumericObservable qualified as NumericObservable (I)
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (K)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (I)
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I, Implementation, getEventTime)
-import Daml.Finance.Interface.Types.Common.Types (Id, PartiesMap)
+import Daml.Finance.Interface.Types.Common.Types (Id, InstrumentKey, PartiesMap)
 
 -- | Type synonym for `Election`.
 type I = Election
@@ -38,7 +37,7 @@ data View = View
     provider : Party
       -- ^ Party that is authorized to process the election and generate the new instrument version
       --   and effects.
-    instrument : Instrument.K
+    instrument : InstrumentKey
       -- ^ The instrument to which the election applies.
   deriving (Eq, Show)
 
@@ -61,7 +60,7 @@ interface Election where
     do
       pure $ view this
 
-  nonconsuming choice Apply : (Optional Instrument.K, [ContractId Effect.I])
+  nonconsuming choice Apply : (Optional InstrumentKey, [ContractId Effect.I])
     -- ^ Applies the election to the instrument, returning the new instrument as well as the
     --   corresponding effects. The election is archived as part of this choice.
     with
@@ -99,7 +98,7 @@ data ExercisableView = ExercisableView
 interface Exercisable where
   viewtype ExercisableView
 
-  applyElection : ApplyElection -> Update (Optional Instrument.K, [ContractId Effect.I])
+  applyElection : ApplyElection -> Update (Optional InstrumentKey, [ContractId Effect.I])
     -- ^ Implementation of the `ApplyElection` choice.
 
   nonconsuming choice Exercisable_GetView : ExercisableView
@@ -111,7 +110,7 @@ interface Exercisable where
     do
       pure $ view this
 
-  nonconsuming choice ApplyElection : (Optional Instrument.K, [ContractId Effect.I])
+  nonconsuming choice ApplyElection : (Optional InstrumentKey, [ContractId Effect.I])
     -- ^ Applies an election to the instrument.
     with
       electionCid : ContractId Election

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Asset/Types.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Asset/Types.daml
@@ -3,7 +3,6 @@
 
 module Daml.Finance.Interface.Instrument.Swap.Asset.Types where
 
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (K)
 import Daml.Finance.Interface.Types.Common.Types (InstrumentKey(..))
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
 import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..))
@@ -33,7 +32,7 @@ data Asset = Asset
       -- ^ The reference data provider to use for the holiday calendar.
     dayCountConvention : DayCountConventionEnum
       -- ^ The day count convention used to calculate day count fractions. For example: Act360.
-    currency : BaseInstrument.K
+    currency : InstrumentKey
       -- ^ The currency of the swap. For example, if the swap pays in USD this should be a USD cash
       --   instrument.
     lastEventTimestamp : Time

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/CreditDefault/Types.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/CreditDefault/Types.daml
@@ -3,7 +3,6 @@
 
 module Daml.Finance.Interface.Instrument.Swap.CreditDefault.Types where
 
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (K)
 import Daml.Finance.Interface.Types.Common.Types (InstrumentKey(..))
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
 import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..))
@@ -37,7 +36,7 @@ data CreditDefault = CreditDefault
       -- ^ The reference data provider to use for the holiday calendar.
     dayCountConvention : DayCountConventionEnum
       -- ^ The day count convention used to calculate day count fractions. For example: Act360.
-    currency : BaseInstrument.K
+    currency : InstrumentKey
       -- ^ The currency of the swap. For example, if the swap pays in USD this should be a USD cash
       --   instrument.
     lastEventTimestamp : Time

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Currency/Types.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Currency/Types.daml
@@ -3,7 +3,6 @@
 
 module Daml.Finance.Interface.Instrument.Swap.Currency.Types where
 
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (K)
 import Daml.Finance.Interface.Types.Common.Types (InstrumentKey)
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
 import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..))
@@ -32,10 +31,10 @@ data CurrencySwap = CurrencySwap
       -- ^ The reference data provider to use for the holiday calendar.
     dayCountConvention : DayCountConventionEnum
       -- ^ The day count convention used to calculate day count fractions. For example: Act360.
-    baseCurrency : BaseInstrument.K
+    baseCurrency : InstrumentKey
       -- ^ The base currency of the swap. For example, in the case of USD this should be a USD cash
       --   instrument.
-    foreignCurrency : BaseInstrument.K
+    foreignCurrency : InstrumentKey
       -- ^ The foreign currency of the swap. For example, in case of EUR this should be a EUR cash
       --   instrument.
     fxRate : Decimal

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/ForeignExchange/Types.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/ForeignExchange/Types.daml
@@ -3,8 +3,7 @@
 
 module Daml.Finance.Interface.Instrument.Swap.ForeignExchange.Types where
 
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (K)
-import Daml.Finance.Interface.Types.Common.Types (InstrumentKey(..))
+import Daml.Finance.Interface.Types.Common.Types (InstrumentKey)
 
 -- | Describes the attributes of a Foreign Exchange swap.
 data ForeignExchange = ForeignExchange
@@ -23,10 +22,10 @@ data ForeignExchange = ForeignExchange
       -- ^ The first payment date of the swap.
     maturityDate : Date
       -- ^ The final payment date of the swap.
-    baseCurrency : BaseInstrument.K
+    baseCurrency : InstrumentKey
       -- ^ The base currency of the swap, which will be exchanged to another (foreign) currency on
       --   the first payment date. For example, in case of USD this should be a USD cash instrument.
-    foreignCurrency : BaseInstrument.K
+    foreignCurrency : InstrumentKey
       -- ^ The foreign currency of the swap. For example, in case of EUR this should be a EUR cash
       --   instrument.
     lastEventTimestamp : Time

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Fpml/Types.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Fpml/Types.daml
@@ -3,7 +3,6 @@
 
 module Daml.Finance.Interface.Instrument.Swap.Fpml.Types where
 
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (K)
 import Daml.Finance.Interface.Instrument.Swap.Fpml.FpmlTypes
 import Daml.Finance.Interface.Types.Common.Types (InstrumentKey)
 
@@ -20,7 +19,7 @@ data Fpml = Fpml
       -- ^ Used to the identify which counterparty is the issuer in the swapStream.
     calendarDataProvider : Party
       -- ^ The reference data provider to use for the holiday calendar.
-    currencies : [BaseInstrument.K]
+    currencies : [InstrumentKey]
       -- ^ The currencies of the different swap legs, one for each swapStream. For example, if one
       --   leg pays in USD this should be a USD cash instrument.
     lastEventTimestamp : Time

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/InterestRate/Types.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/InterestRate/Types.daml
@@ -3,7 +3,6 @@
 
 module Daml.Finance.Interface.Instrument.Swap.InterestRate.Types where
 
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (K)
 import Daml.Finance.Interface.Types.Common.Types (InstrumentKey)
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
 import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..))
@@ -31,7 +30,7 @@ data InterestRate = InterestRate
       -- ^ The reference data provider to use for the holiday calendar.
     dayCountConvention : DayCountConventionEnum
       -- ^ The day count convention used to calculate day count fractions. For example: Act360.
-    currency : BaseInstrument.K
+    currency : InstrumentKey
       -- ^ The currency of the swap. For example, if the swap pays in USD this should be a USD cash
       --   instrument.
     lastEventTimestamp : Time

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Effect.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Effect.daml
@@ -4,8 +4,7 @@
 module Daml.Finance.Interface.Lifecycle.Effect where
 
 import Daml.Finance.Interface.Holding.Base qualified as Base (I)
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (K, Q)
-import Daml.Finance.Interface.Types.Common.Types (Id, Parties)
+import Daml.Finance.Interface.Types.Common.Types (Id, InstrumentKey, InstrumentQuantity, Parties)
 
 -- | Type synonym for `Effect`.
 type I = Effect
@@ -18,9 +17,9 @@ data View = View
   with
     providers : Parties
       -- ^ The parties providing the claim processing.
-    targetInstrument : Instrument.K
+    targetInstrument : InstrumentKey
       -- ^ A holding on this instrument is required to claim the effect.
-    producedInstrument : Optional Instrument.K
+    producedInstrument : Optional InstrumentKey
       -- ^ The new version of the target instrument, when it exists.
     id : Id
       -- ^ A textual identifier.
@@ -28,9 +27,9 @@ data View = View
       -- ^ A human readable description of the Effect.
     settlementTime : Optional Time
       -- ^ The effect's settlement time (if any).
-    otherConsumed : [Instrument.Q]
+    otherConsumed : [InstrumentQuantity]
       -- ^ Consumed quantities (in addition to the target instrument).
-    otherProduced : [Instrument.Q]
+    otherProduced : [InstrumentQuantity]
       -- ^ Produced quantities (in addition to the produced instrument).
   deriving (Eq, Show)
 
@@ -81,8 +80,8 @@ instance HasImplementation I
 -- | Data type encapsulating the effect's calculation result.
 data CalculationResult = CalculationResult
   with
-    consumed : [Instrument.Q]
+    consumed : [InstrumentQuantity]
       -- ^ Consumed quantities.
-    produced : [Instrument.Q]
+    produced : [InstrumentQuantity]
       -- ^ Produced quantities.
   deriving (Eq, Show)

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Event/Distribution.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Event/Distribution.daml
@@ -3,8 +3,8 @@
 
 module Daml.Finance.Interface.Lifecycle.Event.Distribution where
 
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (K, Q)
 import Daml.Finance.Interface.Lifecycle.Event qualified as Base (I, Implementation)
+import Daml.Finance.Interface.Types.Common.Types (InstrumentKey, InstrumentQuantity)
 
 -- | Type synonym for `Event`.
 type I = Event
@@ -17,11 +17,11 @@ data View = View
   with
     effectiveTime : Time
       -- ^ Time on which the distribution is effectuated.
-    targetInstrument : Instrument.K
+    targetInstrument : InstrumentKey
       -- ^ Instrument the distribution event applies to.
-    newInstrument : Instrument.K
+    newInstrument : InstrumentKey
       -- ^ Instrument after the distribution has been claimed.
-    perUnitDistribution : [Instrument.Q]
+    perUnitDistribution : [InstrumentQuantity]
       -- ^ Distributed quantities per unit held.
   deriving (Eq, Show)
 

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Event/Replacement.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Event/Replacement.daml
@@ -3,8 +3,8 @@
 
 module Daml.Finance.Interface.Lifecycle.Event.Replacement where
 
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (K, Q)
 import Daml.Finance.Interface.Lifecycle.Event qualified as Base (I, Implementation)
+import Daml.Finance.Interface.Types.Common.Types (InstrumentKey, InstrumentQuantity)
 
 -- | Type synonym for `Event`.
 type I = Event
@@ -17,9 +17,9 @@ data View = View
   with
     effectiveTime : Time
       -- ^ Time on which the replacement is effectuated.
-    targetInstrument : Instrument.K
+    targetInstrument : InstrumentKey
       -- ^ Instrument the replacement event applies to.
-    perUnitReplacement : [Instrument.Q]
+    perUnitReplacement : [InstrumentQuantity]
       -- ^ Instrument quantities the target instrument is replaced with.
   deriving (Eq, Show)
 

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Rule/Lifecycle.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Rule/Lifecycle.daml
@@ -4,10 +4,9 @@
 module Daml.Finance.Interface.Lifecycle.Rule.Lifecycle where
 
 import Daml.Finance.Interface.Data.NumericObservable qualified as NumericObservable (I)
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument(K)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (I)
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I)
-import Daml.Finance.Interface.Types.Common.Types (Id(..))
+import Daml.Finance.Interface.Types.Common.Types (Id(..), InstrumentKey)
 
 -- | Type synonym for `Lifecycle`.
 type I = Lifecycle
@@ -31,7 +30,7 @@ data View = View
 interface Lifecycle where
   viewtype V
 
-  evolve : Evolve -> Update (Optional Instrument.K, [ContractId Effect.I])
+  evolve : Evolve -> Update (Optional InstrumentKey, [ContractId Effect.I])
     -- ^ Implementation of the `Evolve` choice.
 
   nonconsuming choice GetView : View
@@ -43,13 +42,13 @@ interface Lifecycle where
     do
       pure $ view this
 
-  nonconsuming choice Evolve : (Optional Instrument.K, [ContractId Effect.I])
+  nonconsuming choice Evolve : (Optional InstrumentKey, [ContractId Effect.I])
     -- ^ Process an event. It returns a tuple of the lifecycled instrument (or the original
     --   instrument when the former does not exist) and the effects.
     with
       eventCid : ContractId Event.I
         -- ^ The event.
-      instrument : Instrument.K
+      instrument : InstrumentKey
         -- ^ The target instrument.
       observableCids : [ContractId NumericObservable.I]
         -- ^ Set of numerical time-dependent observables.

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Types.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Types.daml
@@ -4,8 +4,7 @@
 module Daml.Finance.Interface.Settlement.Types where
 
 import Daml.Finance.Interface.Holding.Base qualified as Base (I)
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (Q)
-import Daml.Finance.Interface.Types.Common.Types (AccountKey, Id, Parties)
+import Daml.Finance.Interface.Types.Common.Types (AccountKey, Id, InstrumentQuantity, Parties)
 
 -- | Describes a transfer of a position between two parties.
 data Step = Step
@@ -14,7 +13,7 @@ data Step = Step
       -- ^ Party transferring the asset.
     receiver : Party
       -- ^ Party receiving the asset.
-    quantity : Instrument.Q
+    quantity : InstrumentQuantity
       -- ^ The instrument and amount to be transferred.
   deriving (Eq, Ord, Show)
 
@@ -28,7 +27,7 @@ data RoutedStep = RoutedStep
       -- ^ Party receiving the asset.
     custodian : Party
       -- ^ The custodian at which the asset is held.
-    quantity : Instrument.Q
+    quantity : InstrumentQuantity
       -- ^ The instrument and amount to be transferred.
   deriving (Eq, Ord, Show)
 

--- a/src/main/daml/Daml/Finance/Interface/Types/Common/Types.daml
+++ b/src/main/daml/Daml/Finance/Interface/Types/Common/Types.daml
@@ -5,6 +5,7 @@ module Daml.Finance.Interface.Types.Common.Types
   ( AccountKey(..)
   , Id(..)
   , InstrumentKey(..)
+  , InstrumentQuantity
   , Parties
   , PartiesMap
   , Quantity(..)
@@ -60,3 +61,5 @@ data Quantity u a = Quantity
     amount : a
       -- ^ A numerical amount.
   deriving (Eq, Ord, Show)
+
+type InstrumentQuantity = Quantity InstrumentKey Decimal

--- a/src/main/daml/Daml/Finance/Interface/Types/Common/Types.daml
+++ b/src/main/daml/Daml/Finance/Interface/Types/Common/Types.daml
@@ -1,15 +1,7 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Daml.Finance.Interface.Types.Common.Types
-  ( AccountKey(..)
-  , Id(..)
-  , InstrumentKey(..)
-  , InstrumentQuantity
-  , Parties
-  , PartiesMap
-  , Quantity(..)
-  ) where
+module Daml.Finance.Interface.Types.Common.Types where
 
 import DA.Map (Map)
 import DA.Set (Set)

--- a/src/main/daml/Daml/Finance/Interface/Types/Date/Calendar.daml
+++ b/src/main/daml/Daml/Finance/Interface/Types/Date/Calendar.daml
@@ -1,11 +1,7 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Daml.Finance.Interface.Types.Date.Calendar
-  ( BusinessDayAdjustment(..)
-  , BusinessDayConventionEnum(..)
-  , HolidayCalendarData(..)
-  ) where
+module Daml.Finance.Interface.Types.Date.Calendar where
 
 import DA.Date
 

--- a/src/main/daml/Daml/Finance/Interface/Types/Date/Classes.daml
+++ b/src/main/daml/Daml/Finance/Interface/Types/Date/Classes.daml
@@ -1,9 +1,7 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Daml.Finance.Interface.Types.Date.Classes
-  ( HasUTCTimeConversion(..)
-  ) where
+module Daml.Finance.Interface.Types.Date.Classes where
 
 -- | Types that can be converted to UTC time.
 class HasUTCTimeConversion a where

--- a/src/main/daml/Daml/Finance/Interface/Types/Date/RollConvention.daml
+++ b/src/main/daml/Daml/Finance/Interface/Types/Date/RollConvention.daml
@@ -1,11 +1,7 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Daml.Finance.Interface.Types.Date.RollConvention
-  ( Period(..)
-  , PeriodEnum(..)
-  , RollConventionEnum(..)
-  ) where
+module Daml.Finance.Interface.Types.Date.RollConvention where
 
 -- | A data type to define periods.
 data Period = Period

--- a/src/main/daml/Daml/Finance/Interface/Types/Date/Schedule.daml
+++ b/src/main/daml/Daml/Finance/Interface/Types/Date/Schedule.daml
@@ -1,13 +1,7 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Daml.Finance.Interface.Types.Date.Schedule
-  ( Frequency(..)
-  , Schedule(..)
-  , SchedulePeriod(..)
-  , StubPeriodTypeEnum(..)
-  , PeriodicSchedule(..)
-  ) where
+module Daml.Finance.Interface.Types.Date.Schedule where
 
 import Daml.Finance.Interface.Types.Date.Calendar
 import Daml.Finance.Interface.Types.Date.RollConvention

--- a/src/main/daml/Daml/Finance/Interface/Util/Common.daml
+++ b/src/main/daml/Daml/Finance/Interface/Util/Common.daml
@@ -3,11 +3,9 @@
 
 {-# LANGUAGE AllowAmbiguousTypes #-}
 
-module Daml.Finance.Interface.Util.Common
-  ( exerciseInterfaceByKeyHelper
-  , fetchInterfaceByKey
-  , verify
-  ) where
+module Daml.Finance.Interface.Util.Common where
+
+import Daml.Finance.Interface.Types.Common.Types (InstrumentKey, InstrumentQuantity, Quantity(..))
 
 -- | Verify is assertMsg with its arguments flipped.
 verify : CanAssert m => Bool -> Text -> m ()
@@ -29,3 +27,11 @@ exerciseInterfaceByKeyHelper : forall t i1 i2 k c d r. (HasInterfaceTypeRep i1,
 exerciseInterfaceByKeyHelper k arg1 arg2 = do
   cid <- exerciseByKey @t k arg1
   exercise (coerceInterfaceContractId @i2 cid) arg2
+
+-- | Wraps an amount and an instrument key into an instrument quantity.
+qty : Decimal -> InstrumentKey -> InstrumentQuantity
+qty amount instrument = Quantity with unit = instrument; amount
+
+-- | Scale `quantity` by the provided factor.
+scale : Decimal -> InstrumentQuantity -> InstrumentQuantity
+scale factor quantity = quantity with amount = quantity.amount * factor

--- a/src/main/daml/Daml/Finance/Lifecycle/Effect.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Effect.daml
@@ -5,9 +5,9 @@ module Daml.Finance.Lifecycle.Effect where
 
 import DA.Assert ((===))
 import Daml.Finance.Interface.Holding.Util (getAmount, getInstrument)
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (K, Q, scale, qty)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (Calculate(..), CalculationResult(..), HasImplementation, I, SetProviders(..), View(..))
-import Daml.Finance.Interface.Types.Common.Types (Id, Parties)
+import Daml.Finance.Interface.Types.Common.Types (Id, InstrumentKey, InstrumentQuantity, Parties)
+import Daml.Finance.Interface.Util.Common (qty, scale)
 
 -- | Type synonym for `Effect`.
 type T = Effect
@@ -24,13 +24,13 @@ template Effect
       -- ^ The effect's identifier.
     description : Text
       -- ^ The effect's description.
-    targetInstrument : Instrument.K
+    targetInstrument : InstrumentKey
       -- ^ The target instrument.
-    producedInstrument : Optional Instrument.K
+    producedInstrument : Optional InstrumentKey
       -- ^ The produced instrument, when it exists.
-    otherConsumed : [Instrument.Q]
+    otherConsumed : [InstrumentQuantity]
       -- ^ Consumed quantities (in addition to the target instrument).
-    otherProduced : [Instrument.Q]
+    otherProduced : [InstrumentQuantity]
       -- ^ Produced quantities (in additon to the produced instrument).
     settlementTime : Optional Time
       -- ^ The effect's settlement time (if any).
@@ -48,11 +48,11 @@ template Effect
       calculate Effect.Calculate{holdingCid} _ = do
         holding <- fetch holdingCid
         getInstrument holding === targetInstrument
-        let scaleAll = fmap . Instrument.scale $ getAmount holding
+        let scaleAll = fmap . scale $ getAmount holding
         pure Effect.CalculationResult with
-          consumed = scaleAll $ Instrument.qty 1.0 targetInstrument :: otherConsumed
+          consumed = scaleAll $ qty 1.0 targetInstrument :: otherConsumed
           produced = scaleAll $ case producedInstrument of
-            Some pi -> Instrument.qty 1.0 pi :: otherProduced
+            Some pi -> qty 1.0 pi :: otherProduced
             None -> otherProduced
 
       setProviders Effect.SetProviders{newProviders} =

--- a/src/main/daml/Daml/Finance/Lifecycle/ElectionEffect.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/ElectionEffect.daml
@@ -5,9 +5,9 @@ module Daml.Finance.Lifecycle.ElectionEffect where
 
 import DA.Assert ((===))
 import Daml.Finance.Interface.Holding.Util (getAmount, getInstrument)
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (K, Q, qty, scale)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (Calculate(..), CalculationResult(..), HasImplementation, I, SetProviders(..), View(..))
-import Daml.Finance.Interface.Types.Common.Types (Id, Parties, PartiesMap)
+import Daml.Finance.Interface.Types.Common.Types (Id, InstrumentKey, InstrumentQuantity, Parties, PartiesMap)
+import Daml.Finance.Interface.Util.Common (qty, scale)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (flattenObservers)
 
 -- | Type synonym for `ElectionEffect`.
@@ -29,15 +29,15 @@ template ElectionEffect
       -- ^ The effect's identifier.
     description : Text
       -- ^ The effect's description.
-    targetInstrument : Instrument.K
+    targetInstrument : InstrumentKey
       -- ^ The target instrument.
-    producedInstrument : Optional Instrument.K
+    producedInstrument : Optional InstrumentKey
       -- ^ The produced instrument, when it exists.
     amount : Decimal
       -- ^ The elected amount.
-    otherConsumed : [Instrument.Q]
+    otherConsumed : [InstrumentQuantity]
       -- ^ Consumed quantities (not including the target instrument).
-    otherProduced : [Instrument.Q]
+    otherProduced : [InstrumentQuantity]
       -- ^ Produced quantities (not including the produced instrument).
     settlementTime : Optional Time
       -- ^ The effect's settlement time (if any).
@@ -65,11 +65,11 @@ template ElectionEffect
         assertMsg "Election effects can only be calculated by the elector or their counterparty" $
           actor == owner || actor == custodian
         archive $ fromInterfaceContractId @ElectionEffect self
-        let scaleAll = fmap $ Instrument.scale $ getAmount holding
+        let scaleAll = fmap $ scale $ getAmount holding
         pure Effect.CalculationResult with
-          consumed = scaleAll $ Instrument.qty 1.0 targetInstrument :: otherConsumed
+          consumed = scaleAll $ qty 1.0 targetInstrument :: otherConsumed
           produced = scaleAll $ case producedInstrument of
-            Some pi -> Instrument.qty 1.0 pi :: otherProduced
+            Some pi -> qty 1.0 pi :: otherProduced
             None -> otherProduced
 
       setProviders Effect.SetProviders{newProviders} =

--- a/src/main/daml/Daml/Finance/Lifecycle/Event/Distribution.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Event/Distribution.daml
@@ -3,10 +3,9 @@
 
 module Daml.Finance.Lifecycle.Event.Distribution where
 
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (K, Q)
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I, View(..))
 import Daml.Finance.Interface.Lifecycle.Event.Distribution qualified as Distribution (HasImplementation, I, View(..))
-import Daml.Finance.Interface.Types.Common.Types (Id, Parties)
+import Daml.Finance.Interface.Types.Common.Types (Id, InstrumentKey, InstrumentQuantity, Parties)
 
 -- | Type synonym for `Event`.
 type T = Event
@@ -25,11 +24,11 @@ template Event
       -- ^ Event description.
     effectiveTime : Time
       -- ^ Time on which the distribution is effectuated.
-    targetInstrument : Instrument.K
+    targetInstrument : InstrumentKey
       -- ^ Instrument the distribution event applies to.
-    newInstrument : Instrument.K
+    newInstrument : InstrumentKey
       -- ^ Instrument after the distribution has been claimed.
-    perUnitDistribution : [Instrument.Q]
+    perUnitDistribution : [InstrumentQuantity]
       -- ^ Distributed quantities per unit held.
     observers : Parties
       -- ^ Observers.

--- a/src/main/daml/Daml/Finance/Lifecycle/Event/Replacement.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Event/Replacement.daml
@@ -3,10 +3,9 @@
 
 module Daml.Finance.Lifecycle.Event.Replacement where
 
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (K, Q)
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I, View(..))
 import Daml.Finance.Interface.Lifecycle.Event.Replacement qualified as Replacement (HasImplementation, I, View(..))
-import Daml.Finance.Interface.Types.Common.Types (Id, Parties)
+import Daml.Finance.Interface.Types.Common.Types (Id, InstrumentKey, InstrumentQuantity, Parties)
 
 -- | Type synonym for `Event`.
 type T = Event
@@ -25,9 +24,9 @@ template Event
       -- ^ Event description.
     effectiveTime : Time
       -- ^ Time on which the replacement is effectuated.
-    targetInstrument : Instrument.K
+    targetInstrument : InstrumentKey
       -- ^ Instrument the replacement event applies to.
-    perUnitReplacement : [Instrument.Q]
+    perUnitReplacement : [InstrumentQuantity]
       -- ^ Instrument quantities the target instrument is replaced with.
     observers : Parties
       -- ^ Observers.

--- a/src/main/daml/Daml/Finance/Lifecycle/Rule/Util.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Rule/Util.daml
@@ -5,29 +5,30 @@ module Daml.Finance.Lifecycle.Rule.Util where
 
 import DA.Either (partitionEithers)
 import DA.List (head)
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (K, Q, qty)
+import Daml.Finance.Interface.Types.Common.Types (InstrumentKey, InstrumentQuantity)
+import Daml.Finance.Interface.Util.Common (qty)
 import Daml.Finance.Util.Common (sortAndGroupOn)
 
 -- | Type used to record pending payments.
 data Pending = Pending
   with
-    instrument : Instrument.K
+    instrument : InstrumentKey
     amount : Decimal
   deriving (Eq, Show)
 
 -- | Merge consumed and produced instruments into a list of pending settlements.
 -- This will only reproduce instrument and quantity, not tag or time.
-mergeConsumedAndProduced : [Instrument.Q] -> [Instrument.Q] -> [Pending]
+mergeConsumedAndProduced : [InstrumentQuantity] -> [InstrumentQuantity] -> [Pending]
 mergeConsumedAndProduced consumed produced = pendingConsumed ++ pendingProduced where
   pendingConsumed = map (\q -> Pending with instrument = q.unit, amount = -1.0 * q.amount) consumed
   pendingProduced = map (\q -> Pending with instrument = q.unit, amount = q.amount) produced
 
 -- | Map pending settlements into corresponding instrument quantities and split them into consumed
 -- and produced. Pending items with an amount of `0.0` are discarded.
-splitPending : [Pending] -> ([Instrument.Q],[Instrument.Q])
+splitPending : [Pending] -> ([InstrumentQuantity],[InstrumentQuantity])
 splitPending = partitionEithers . foldr f [] where
-  f p acc | p.amount < 0.0 = Left (Instrument.qty (- 1.0 * p.amount) p.instrument) :: acc
-  f p acc | p.amount > 0.0 = Right (Instrument.qty p.amount p.instrument) :: acc
+  f p acc | p.amount < 0.0 = Left (qty (- 1.0 * p.amount) p.instrument) :: acc
+  f p acc | p.amount > 0.0 = Right (qty p.amount p.instrument) :: acc
   f _ acc = acc
 
 -- | Net pending payments on the same instrument (regardless of tags).

--- a/src/main/daml/Daml/Finance/Settlement/Hierarchy.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Hierarchy.daml
@@ -1,12 +1,7 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Daml.Finance.Settlement.Hierarchy
-  ( Hierarchy(..)
-  , locateParty
-  , getRoute
-  , unfoldStep
-  ) where
+module Daml.Finance.Settlement.Hierarchy where
 
 import DA.List (dedup, isSuffixOf, stripInfix, stripSuffix, tails)
 import DA.Optional (isSome)

--- a/src/main/daml/Daml/Finance/Util/Common.daml
+++ b/src/main/daml/Daml/Finance/Util/Common.daml
@@ -1,12 +1,7 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Daml.Finance.Util.Common
-  ( groupBy
-  , mapWithIndex
-  , notNull
-  , sortAndGroupOn
-  ) where
+module Daml.Finance.Util.Common where
 
 import DA.List qualified as List (groupOn, null, sortOn)
 import DA.Map qualified as M (Map, empty, insert, lookup)

--- a/src/main/daml/Daml/Finance/Util/Date/Calendar.daml
+++ b/src/main/daml/Daml/Finance/Util/Date/Calendar.daml
@@ -1,19 +1,7 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Daml.Finance.Util.Date.Calendar
-  ( addBusinessDays
-  , adjustDate
-  , isBusinessDay
-  , isHoliday
-  , merge
-  , nextBusinessDay
-  , nextOrSameBusinessDay
-  , nextSameOrLastInMonthBusinessDay
-  , previousBusinessDay
-  , previousOrSameBusinessDay
-  , previousSameOrFirstInMonthBusinessDay
-  ) where
+module Daml.Finance.Util.Date.Calendar where
 
 import DA.Date
 import DA.List

--- a/src/main/daml/Daml/Finance/Util/Date/DayCount.daml
+++ b/src/main/daml/Daml/Finance/Util/Date/DayCount.daml
@@ -3,7 +3,13 @@
 
 module Daml.Finance.Util.Date.DayCount
   ( calcDcf
+  , calcDcf30360
+  , calcDcf30360Icma
   , calcDcf30E360
+  , calcDcfActActAfb
+  , calcDcfAct360
+  , calcDcfAct365Fixed
+  , calcDcfAct365L
   , calcPeriodDcf
   , calcPeriodDcfActActIsda
   , calcPeriodDcfActActIsma
@@ -129,7 +135,6 @@ calcPeriodDcfActActIsma p useAdjustedDates maturityDate frequency =
           nDaysP1 = subDate notionalPaymentDate startDate
           nDaysP2 = subDate endDate notionalPaymentDate
 
--- | HIDE
 -- Calculate Actual Actual AFB day count fraction.
 calcDcfActActAfb : Date -> Date -> Decimal
 calcDcfActActAfb fromDate toDate =
@@ -147,19 +152,16 @@ calcDcfActActAfb fromDate toDate =
     then intToDecimal nDays / intToDecimal nTotDays
     else error "coupon period more than one year not supported"
 
--- | HIDE
 -- Calculate Actual 360 day count fraction.
 calcDcfAct360 : Date -> Date -> Decimal
 calcDcfAct360 fromDate toDate =
   (/ 360.0) . intToDecimal $ subDate toDate fromDate
 
--- | HIDE
 -- Calculate Actual 365 (Fixed) day count fraction.
 calcDcfAct365Fixed : Date -> Date -> Decimal
 calcDcfAct365Fixed fromDate toDate =
   (/ 365.0) . intToDecimal $ subDate toDate fromDate
 
--- | HIDE
 -- Calculate Actual 365L (Leap-year) day count fraction.
 calcDcfAct365L : Date -> Date -> Decimal
 calcDcfAct365L fromDate toDate =
@@ -169,7 +171,6 @@ calcDcfAct365L fromDate toDate =
   in
     (/ intToDecimal nTotDaysY2) . intToDecimal $ subDate toDate fromDate
 
--- | HIDE
 -- Calculate 30/360 day count fraction. This is also known as the '30/360 (ISDA)' or 'Bond Basis'
 -- day count convention.
 calcDcf30360 : Date -> Date -> Decimal
@@ -183,7 +184,6 @@ calcDcf30360 fromDate toDate =
     (y1, m1, d1) = toGregorian fromDate
     (y2, m2, d2) = toGregorian toDate
 
--- | HIDE
 -- Calculate 30/360 ICMA day count fraction.
 calcDcf30360Icma : Date -> Date -> Decimal
 calcDcf30360Icma fromDate toDate =

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/FixedRate.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/FixedRate.daml
@@ -8,10 +8,10 @@ import DA.Map qualified as M (fromList)
 import DA.Set (singleton)
 import Daml.Finance.Data.Reference.HolidayCalendar
 import Daml.Finance.Instrument.Bond.Test.Util
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
 import Daml.Finance.Interface.Types.Date.Calendar
 import Daml.Finance.Interface.Types.Date.DayCount
 import Daml.Finance.Interface.Types.Date.RollConvention
+import Daml.Finance.Interface.Util.Common (qty)
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Script
@@ -82,7 +82,7 @@ run = script do
   -- First coupon date: Lifecycle and verify that there is an effect for one coupon.
   let
     expectedConsumedQuantities = []
-    expectedProducedQuantities = [Instrument.qty 0.0035863014 cashInstrumentCid]
+    expectedProducedQuantities = [qty 0.0035863014 cashInstrumentCid]
   Some bondInstrumentAfterFirstCoupon <- lifecycleAndVerifyBondPaymentEffects [publicParty]
     firstCouponDate bondInstrument issuer [] expectedConsumedQuantities expectedProducedQuantities
 
@@ -100,7 +100,7 @@ run = script do
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities =
-      [(Instrument.qty 0.011030137 cashInstrumentCid), (Instrument.qty 1.0 cashInstrumentCid)]
+      [(qty 0.011030137 cashInstrumentCid), (qty 1.0 cashInstrumentCid)]
   None <- lifecycleAndVerifyBondPaymentEffects [publicParty] maturityDate
     bondInstrumentAfterFirstCoupon issuer [] expectedConsumedQuantities expectedProducedQuantities
 

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/FloatingRate.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/FloatingRate.daml
@@ -9,11 +9,11 @@ import DA.Set (singleton)
 import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Reference.HolidayCalendar
 import Daml.Finance.Instrument.Bond.Test.Util
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
 import Daml.Finance.Interface.Types.Common.Types (Id(..))
 import Daml.Finance.Interface.Types.Date.Calendar
 import Daml.Finance.Interface.Types.Date.DayCount
 import Daml.Finance.Interface.Types.Date.RollConvention
+import Daml.Finance.Interface.Util.Common (qty)
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Finance.Test.Util.Time (dateToDateClockTime)
@@ -79,7 +79,7 @@ run = script do
   -- First coupon date: Lifecycle and verify that there is an effect for one coupon.
   let
     expectedConsumedQuantities = []
-    expectedProducedQuantities = [Instrument.qty 0.0006484932 cashInstrumentCid]
+    expectedProducedQuantities = [qty 0.0006484932 cashInstrumentCid]
   Some bondInstrumentAfterFirstCoupon <- lifecycleAndVerifyBondPaymentEffects [publicParty]
     firstCouponDate bondInstrument issuer [observableCid] expectedConsumedQuantities
     expectedProducedQuantities
@@ -98,7 +98,7 @@ run = script do
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities =
-      [(Instrument.qty 0.002033589 cashInstrumentCid), (Instrument.qty 1.0 cashInstrumentCid)]
+      [(qty 0.002033589 cashInstrumentCid), (qty 1.0 cashInstrumentCid)]
   None <- lifecycleAndVerifyBondPaymentEffects [publicParty] maturityDate
     bondInstrumentAfterFirstCoupon issuer [observableCid] expectedConsumedQuantities
     expectedProducedQuantities

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/InflationLinked.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/InflationLinked.daml
@@ -9,11 +9,11 @@ import DA.Set (singleton)
 import Daml.Finance.Data.Numeric.Observation(Observation(..))
 import Daml.Finance.Data.Reference.HolidayCalendar
 import Daml.Finance.Instrument.Bond.Test.Util
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
 import Daml.Finance.Interface.Types.Common.Types (Id(..))
 import Daml.Finance.Interface.Types.Date.Calendar
 import Daml.Finance.Interface.Types.Date.DayCount
 import Daml.Finance.Interface.Types.Date.RollConvention
+import Daml.Finance.Interface.Util.Common (qty)
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Finance.Test.Util.Time (dateToDateClockTime)
@@ -80,7 +80,7 @@ run = script do
   -- First coupon date: Lifecycle and verify that there is an effect for one coupon.
   let
     expectedConsumedQuantities = []
-    expectedProducedQuantities = [Instrument.qty 0.0009493151 cashInstrumentCid]
+    expectedProducedQuantities = [qty 0.0009493151 cashInstrumentCid]
   Some bondInstrumentAfterFirstCoupon <- lifecycleAndVerifyBondPaymentEffects [publicParty]
     firstCouponDate bondInstrument issuer [observableCid] expectedConsumedQuantities
     expectedProducedQuantities
@@ -99,7 +99,7 @@ run = script do
   let
     expectedConsumedQuantities = []
     expectedProducedQuantities =
-      [(Instrument.qty 0.002950411 cashInstrumentCid), (Instrument.qty 1.1 cashInstrumentCid)]
+      [(qty 0.002950411 cashInstrumentCid), (qty 1.1 cashInstrumentCid)]
   None <- lifecycleAndVerifyBondPaymentEffects [publicParty] maturityDate
     bondInstrumentAfterFirstCoupon issuer [observableCid] expectedConsumedQuantities
     expectedProducedQuantities

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
@@ -14,10 +14,9 @@ import Daml.Finance.Instrument.Bond.InflationLinked.Instrument qualified as Infl
 import Daml.Finance.Instrument.Bond.ZeroCoupon.Instrument qualified as ZeroCoupon (Instrument(..))
 import Daml.Finance.Interface.Claims.Types (Deliverable)
 import Daml.Finance.Interface.Data.NumericObservable qualified as NumericObservable (I)
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (K, I, Q)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (I, GetView(..))
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Evolve(..))
-import Daml.Finance.Interface.Types.Common.Types
+import Daml.Finance.Interface.Types.Common.Types (Id(..), InstrumentKey, InstrumentQuantity, Parties)
 import Daml.Finance.Interface.Types.Date.Calendar (BusinessDayAdjustment(..), BusinessDayConventionEnum)
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
 import Daml.Finance.Interface.Types.Date.RollConvention (PeriodEnum, RollConventionEnum(..))
@@ -56,7 +55,7 @@ createPaymentPeriodicSchedule firstCouponDate holidayCalendarIds businessDayConv
 
 originateFixedRateBond : Party -> Party -> Text -> Text -> [(Text, Parties)] -> Time -> Date ->
   [Text] -> Party -> Date-> Date -> DayCountConventionEnum ->
-  BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Script Instrument.K
+  BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> InstrumentKey -> Script InstrumentKey
 originateFixedRateBond depository issuer label description observers lastEventTimestamp issueDate
   holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention
   businessDayConvention couponRate couponPeriod couponPeriodMultiplier currency = do
@@ -64,7 +63,7 @@ originateFixedRateBond depository issuer label description observers lastEventTi
       periodicSchedule = createPaymentPeriodicSchedule firstCouponDate holidayCalendarIds
         businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate
     -- CREATE_FIXED_RATE_BOND_INSTRUMENT_BEGIN
-    cid <- toInterfaceContractId @Instrument.I <$> submitMulti [depository, issuer] [] do
+    cid <- toInterfaceContractId <$> submitMulti [depository, issuer] [] do
       createCmd FixedRate.Instrument with
         depository; issuer; id = Id label; version = "0"; description
         observers = M.fromList observers; lastEventTimestamp; periodicSchedule; holidayCalendarIds
@@ -73,7 +72,7 @@ originateFixedRateBond depository issuer label description observers lastEventTi
     createReference cid depository issuer observers
 
 originateZeroCouponBond : Party -> Party -> Text -> Text -> [(Text, Parties)] -> Time -> Date ->
-  Date -> Deliverable -> Script Instrument.K
+  Date -> Deliverable -> Script InstrumentKey
 originateZeroCouponBond depository issuer label description observers lastEventTimestamp issueDate
   maturityDate currency = do
     -- CREATE_ZERO_COUPON_BOND_INSTRUMENT_BEGIN
@@ -86,8 +85,8 @@ originateZeroCouponBond depository issuer label description observers lastEventT
 
 originateFloatingRateBond : Party -> Party -> Text -> Text -> [(Text, Parties)] -> Time -> Date ->
   [Text] -> Party -> Date -> Date -> DayCountConventionEnum ->
-  BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K ->
-  Text -> Script Instrument.K
+  BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> InstrumentKey ->
+  Text -> Script InstrumentKey
 originateFloatingRateBond depository issuer label description observers lastEventTimestamp issueDate
   holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention
   businessDayConvention couponSpread couponPeriod couponPeriodMultiplier currency
@@ -106,8 +105,8 @@ originateFloatingRateBond depository issuer label description observers lastEven
 
 originateInflationLinkedBond : Party -> Party -> Text -> Text -> [(Text, Parties)] -> Time ->
   Date -> [Text] -> Party -> Date -> Date -> DayCountConventionEnum ->
-  BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Text ->
-  Decimal -> Script Instrument.K
+  BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> InstrumentKey -> Text ->
+  Decimal -> Script InstrumentKey
 originateInflationLinkedBond depository issuer label description observers lastEventTimestamp
   issueDate holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention
   businessDayConvention couponRate couponPeriod couponPeriodMultiplier currency inflationIndexId
@@ -127,8 +126,8 @@ originateInflationLinkedBond depository issuer label description observers lastE
 
 -- | Lifecycle the instrument as of this date. This is a general function that can be used for both
 -- bonds and swaps.
-lifecycleInstrument : [Party] -> Date -> Instrument.K -> Party ->
-  [ContractId NumericObservable.I] -> Script (Optional Instrument.K, [ContractId Effect.I])
+lifecycleInstrument : [Party] -> Date -> InstrumentKey -> Party ->
+  [ContractId NumericObservable.I] -> Script (Optional InstrumentKey, [ContractId Effect.I])
 lifecycleInstrument readAs today instrument issuer observableCids = do
   -- create clock update event
   clockEventCid <- createClockUpdateEvent (singleton issuer) today empty
@@ -153,7 +152,7 @@ lifecycleInstrument readAs today instrument issuer observableCids = do
 
 -- | Verify a that there are no lifecycle effects of the instrument on this date. This is a general
 -- function that can be used for both bonds and swaps.
-verifyNoLifecycleEffects : [Party] -> Date -> Instrument.K -> Party ->
+verifyNoLifecycleEffects : [Party] -> Date -> InstrumentKey -> Party ->
   [ContractId NumericObservable.I] -> Script ()
 verifyNoLifecycleEffects readAs today instrument issuer observableCids = do
   (bondLifecycleCid2, effectCids) <- lifecycleInstrument readAs today instrument issuer
@@ -161,9 +160,9 @@ verifyNoLifecycleEffects readAs today instrument issuer observableCids = do
   assertMsg ("There should be no lifecycle effects on " <> show today) (null effectCids)
 
 -- | Verify the payments from a payment date of a bond (excluding settlement)
-lifecycleAndVerifyBondPaymentEffects : [Party] -> Date -> Instrument.K -> Party ->
-  [ContractId NumericObservable.I] -> [Instrument.Q] -> [Instrument.Q] ->
-  Script (Optional Instrument.K)
+lifecycleAndVerifyBondPaymentEffects : [Party] -> Date -> InstrumentKey -> Party ->
+  [ContractId NumericObservable.I] -> [InstrumentQuantity] -> [InstrumentQuantity] ->
+  Script (Optional InstrumentKey)
 lifecycleAndVerifyBondPaymentEffects readAs today instrument issuer
   observableCids expectedConsumedQuantities expectedProducedQuantities = do
     (newBondInstrumentKey, [effectCid]) <-

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/ZeroCoupon.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/ZeroCoupon.daml
@@ -6,7 +6,7 @@ module Daml.Finance.Instrument.Bond.Test.ZeroCoupon where
 import DA.Date
 import DA.Set (singleton)
 import Daml.Finance.Instrument.Bond.Test.Util
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
+import Daml.Finance.Interface.Util.Common (qty)
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Script
@@ -39,7 +39,7 @@ run = script do
   -- Lifecycle on the expiry date. Verify the lifecycle effect for the redemption amount
   let
     expectedConsumedQuantities = []
-    expectedProducedQuantities = [Instrument.qty 1.0 cashInstrumentCid]
+    expectedProducedQuantities = [qty 1.0 cashInstrumentCid]
   None <- lifecycleAndVerifyBondPaymentEffects [publicParty] maturityDate
     bondInstrument issuer [] expectedConsumedQuantities expectedProducedQuantities
 

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
@@ -7,7 +7,6 @@ import DA.Map qualified as M (fromList)
 import DA.Set (fromList, singleton)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Instrument.Equity.Test.Util (originateEquity)
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
 import Daml.Finance.Interface.Instrument.Equity.Instrument qualified as Equity (DeclareDividend(..), I)
 import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), I)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (Evolve(..), I)
@@ -15,6 +14,7 @@ import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..))
+import Daml.Finance.Interface.Util.Common (qty)
 import Daml.Finance.Lifecycle.Rule.Claim qualified as Claim (Rule(..))
 import Daml.Finance.Lifecycle.Rule.Distribution qualified as Distribution (Rule(..))
 import Daml.Finance.Settlement.Factory (Factory(..))
@@ -69,7 +69,7 @@ run = script do
         description = "Cash Dividend"
         effectiveTime = now
         newInstrument = exEquityInstrument
-        perUnitDistribution = [Instrument.qty 2.0 cashInstrument]
+        perUnitDistribution = [qty 2.0 cashInstrument]
 
   -- Lifecycle cash dividend
   (_, [effectCid]) <- submit issuer do

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Merger.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Merger.daml
@@ -7,7 +7,6 @@ import DA.Map qualified as M (fromList)
 import DA.Set (fromList, singleton)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Instrument.Equity.Test.Util (originateEquity)
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
 import Daml.Finance.Interface.Instrument.Equity.Instrument qualified as Equity (I, DeclareReplacement(..))
 import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), I)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (Evolve(..), I)
@@ -15,6 +14,7 @@ import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..))
+import Daml.Finance.Interface.Util.Common (qty)
 import Daml.Finance.Lifecycle.Rule.Claim qualified as Claim (Rule(..))
 import Daml.Finance.Lifecycle.Rule.Replacement qualified as Replacement (Rule(..))
 import Daml.Finance.Settlement.Factory (Factory(..))
@@ -66,7 +66,7 @@ run = script do
         id = Id $ "ABC merge - " <> show now
         description = "Merge"
         effectiveTime = now
-        perUnitReplacement = [Instrument.qty 0.5 mergedInstrument]
+        perUnitReplacement = [qty 0.5 mergedInstrument]
 
   -- Lifecycle replacement event
   (_, [effectCid]) <- submit merging do

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Util.daml
@@ -5,13 +5,12 @@ module Daml.Finance.Instrument.Equity.Test.Util where
 
 import DA.Map qualified as M
 import Daml.Finance.Instrument.Equity.Instrument (Instrument(..))
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (K)
-import Daml.Finance.Interface.Types.Common.Types (Id(..), Parties)
+import Daml.Finance.Interface.Types.Common.Types (Id(..), InstrumentKey, Parties)
 import Daml.Finance.Test.Util.Instrument (createReference)
 import Daml.Script
 
 originateEquity : Party -> Party -> Text -> Text -> Text -> [(Text, Parties)] -> Time ->
-  Script Instrument.K
+  Script InstrumentKey
 originateEquity depository issuer label version description observers timestamp = do
   cid <- toInterfaceContractId <$> submitMulti [depository, issuer] [] do
     createCmd Instrument with

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
@@ -13,17 +13,15 @@ import DA.Set (empty, fromList, singleton, toList)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Instrument.Generic.Lifecycle.Rule qualified as Lifecycle (Rule(..))
 import Daml.Finance.Instrument.Generic.Test.Util (originateGeneric, mapClaimToUTCTime)
-import Daml.Finance.Interface.Account.Account qualified as Account (K)
 import Daml.Finance.Interface.Holding.Base qualified as Base (I)
 import Daml.Finance.Interface.Holding.Util (getInstrument)
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (K)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (SetProviders(..), GetView(..), I)
 import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), I)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Evolve(..))
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), InstructionKey(..))
-import Daml.Finance.Interface.Types.Common.Types (Id(..), Parties)
+import Daml.Finance.Interface.Types.Common.Types (AccountKey, Id(..), InstrumentKey, Parties)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, AddObservers(..))
 import Daml.Finance.Lifecycle.Rule.Claim qualified as Claim (Rule(..))
 import Daml.Finance.Settlement.Factory (Factory(..))
@@ -90,7 +88,7 @@ data TestParties = TestParties
       -- ^ The public party. Every party can readAs the public party.
 
 -- | Originate USD cash instrument and define settlement route.
-originateCashAndDefineRoute : TestParties -> Time -> Script (BaseInstrument.K, (Text, Hierarchy))
+originateCashAndDefineRoute : TestParties -> Time -> Script (InstrumentKey, (Text, Hierarchy))
 originateCashAndDefineRoute TestParties{bank, centralBank, csd, investor, issuer, publicParty} now =
   do
     let
@@ -118,8 +116,8 @@ originateCashAndDefineRoute TestParties{bank, centralBank, csd, investor, issuer
     pure (instrument, route)
 
 -- | Originate bond instrument and define settlement route.
-originateSecurityAndDefineRoute : TestParties -> Time ->
-  BaseInstrument.K -> Script (BaseInstrument.K, (Text, Hierarchy))
+originateSecurityAndDefineRoute : TestParties -> Time -> InstrumentKey ->
+  Script (InstrumentKey, (Text, Hierarchy))
 originateSecurityAndDefineRoute TestParties{bank, csd, investor, issuer, publicParty} now
   cashInstrument = do
     -- CREATE_CC_INSTRUMENT_VARIABLES_BEGIN
@@ -491,11 +489,11 @@ template EffectSettlementService
       -- ^ Counterparty of the instrument holding. Issuer of the instrument.
     instrumentId : Id
       -- ^ Defines the instrument to which the contract is applicable.
-    securitiesAccount : Account.K
+    securitiesAccount : AccountKey
       -- ^ Security account of CSD @ issuer.
-    issuerCashAccount : Account.K
+    issuerCashAccount : AccountKey
       -- ^ Cash account of Issuer @ Central Bank.
-    csdCashAccount : Account.K
+    csdCashAccount : AccountKey
       -- ^ Cash account of CSD @ Central Bank. Needs to be disclosed to the Issuer (ideally as part
       --   of the creation of this contract).
     settlementRoutes : M.Map Text Hierarchy
@@ -601,7 +599,7 @@ setupParties = do
 
 -- | HIDE
 -- Setup a set of accounts.
-setupAccounts : Text -> Party -> Party -> [Party] -> Script [Account.K]
+setupAccounts : Text -> Party -> Party -> [Party] -> Script [AccountKey]
 setupAccounts description custodian publicParty owners = do
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory custodian []
   holdingFactoryCid <- toInterfaceContractId <$> submit custodian do

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/Util.daml
@@ -9,8 +9,7 @@ import Daml.Finance.Claims.Util (toTime)
 import Daml.Finance.Data.Time.DateClock.Types (Unit(..))
 import Daml.Finance.Instrument.Generic.Instrument (Instrument(..))
 import Daml.Finance.Interface.Claims.Types (C, Deliverable, Observable)
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (K)
-import Daml.Finance.Interface.Types.Common.Types (Id(..), Parties)
+import Daml.Finance.Interface.Types.Common.Types (Id(..), InstrumentKey, Parties)
 import Daml.Finance.Interface.Types.Date.Classes (toUTCTime)
 import Daml.Finance.Test.Util.Instrument (createReference)
 import Daml.Script
@@ -25,7 +24,7 @@ mapClaimToUTCTime = toTime dateToDateClockTime
 
 -- | Originate generic instrument
 originateGeneric : Party -> Party -> Text -> Text -> Time -> C -> [(Text, Parties)] -> Time ->
-  Script Instrument.K
+  Script InstrumentKey
 originateGeneric depository issuer label description acquisitionTime claims observers
   lastEventTimestamp = do
     cid <- toInterfaceContractId <$> submitMulti [depository, issuer] [] do

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Asset.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Asset.daml
@@ -9,11 +9,11 @@ import DA.Set (singleton)
 import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Reference.HolidayCalendar
 import Daml.Finance.Instrument.Swap.Test.Util
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
 import Daml.Finance.Interface.Types.Common.Types (Id(..))
 import Daml.Finance.Interface.Types.Date.Calendar
 import Daml.Finance.Interface.Types.Date.DayCount
 import Daml.Finance.Interface.Types.Date.RollConvention
+import Daml.Finance.Interface.Util.Common (qty)
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Finance.Test.Util.Time (dateToDateClockTime)
@@ -82,8 +82,8 @@ run = script do
   -- First payment date: Lifecycle and verify the lifecycle effects for fix rate and asset
   -- performance payments.
   let
-    expectedConsumedQuantities = [Instrument.qty 0.001675 cashInstrumentCid]
-    expectedProducedQuantities = [Instrument.qty 0.0801561777 cashInstrumentCid]
+    expectedConsumedQuantities = [qty 0.001675 cashInstrumentCid]
+    expectedProducedQuantities = [qty 0.0801561777 cashInstrumentCid]
   Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     firstPaymentDate swapInstrument issuer [observableCid] expectedConsumedQuantities
     expectedProducedQuantities
@@ -100,8 +100,8 @@ run = script do
   -- Lifecycle on the second payment date, which is also the expiry date. Verify the lifecycle
   -- effects for fix rate and asset performance payments.
   let
-    expectedConsumedQuantities = [Instrument.qty 0.0049691667 cashInstrumentCid]
-    expectedProducedQuantities = [Instrument.qty 0.0372102912 cashInstrumentCid]
+    expectedConsumedQuantities = [qty 0.0049691667 cashInstrumentCid]
+    expectedProducedQuantities = [qty 0.0372102912 cashInstrumentCid]
   lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment
     issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
 

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/CreditDefault.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/CreditDefault.daml
@@ -9,11 +9,11 @@ import DA.Set (singleton)
 import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Reference.HolidayCalendar
 import Daml.Finance.Instrument.Swap.Test.Util
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty, K)
-import Daml.Finance.Interface.Types.Common.Types (Id(..))
+import Daml.Finance.Interface.Types.Common.Types (Id(..), InstrumentKey)
 import Daml.Finance.Interface.Types.Date.Calendar
 import Daml.Finance.Interface.Types.Date.DayCount
 import Daml.Finance.Interface.Types.Date.RollConvention
+import Daml.Finance.Interface.Util.Common (qty)
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Finance.Test.Util.Time (dateToDateClockTime)
@@ -94,7 +94,7 @@ runCreditEvent = script do
 
   -- First payment date: Lifecycle and verify the lifecycle effects for the fix payment.
   let
-    expectedConsumedQuantities = [Instrument.qty 0.001675 cashInstrument]
+    expectedConsumedQuantities = [qty 0.001675 cashInstrument]
     expectedProducedQuantities = []
   Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     firstPaymentDate swapInstrument issuer observableCids expectedConsumedQuantities
@@ -109,7 +109,7 @@ runCreditEvent = script do
   -- (1-recoveryRate) payment. Also, verify that the instrument expires.
   let
     expectedConsumedQuantities = []
-    expectedProducedQuantities = [Instrument.qty 0.4 cashInstrument]
+    expectedProducedQuantities = [qty 0.4 cashInstrument]
   None <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     creditEventDate swapInstrumentAfterFirstPayment issuer observableCids expectedConsumedQuantities
     expectedProducedQuantities
@@ -156,7 +156,7 @@ runCreditEventOnPaymentDate = script do
 
   -- First payment date: Lifecycle and verify the lifecycle effects for the fix payment.
   let
-    expectedConsumedQuantities = [Instrument.qty 0.001675 cashInstrument]
+    expectedConsumedQuantities = [qty 0.001675 cashInstrument]
     expectedProducedQuantities = []
   Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     firstPaymentDate swapInstrument issuer observableCids expectedConsumedQuantities
@@ -171,7 +171,7 @@ runCreditEventOnPaymentDate = script do
   -- (1-recoveryRate) payment.
   let
     expectedConsumedQuantities = []
-    expectedProducedQuantities = [Instrument.qty 0.4 cashInstrument]
+    expectedProducedQuantities = [qty 0.4 cashInstrument]
   swapInstrumentAfterCreditEvent <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     creditEventDate swapInstrumentAfterFirstPayment issuer observableCids expectedConsumedQuantities
     expectedProducedQuantities
@@ -218,7 +218,7 @@ runNoCreditEvent = script do
 
   -- First payment date: Lifecycle and verify the lifecycle effects for the fix payment.
   let
-    expectedConsumedQuantities = [Instrument.qty 0.001675 cashInstrument]
+    expectedConsumedQuantities = [qty 0.001675 cashInstrument]
     expectedProducedQuantities = []
   Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     firstPaymentDate swapInstrument issuer observableCids expectedConsumedQuantities
@@ -231,7 +231,7 @@ runNoCreditEvent = script do
 
   -- Second payment date: Lifecycle and verify the lifecycle effects for the fix payment.
   let
-    expectedConsumedQuantities = [Instrument.qty 0.0049691667 cashInstrument]
+    expectedConsumedQuantities = [qty 0.0049691667 cashInstrument]
     expectedProducedQuantities = []
   Some swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     maturityDate swapInstrumentAfterFirstPayment issuer observableCids expectedConsumedQuantities
@@ -275,7 +275,7 @@ runCreditEventAfterMaturity = script do
 
   -- First payment date: Lifecycle and verify the lifecycle effects for the fix payment.
   let
-    expectedConsumedQuantities = [Instrument.qty 0.001675 cashInstrument]
+    expectedConsumedQuantities = [qty 0.001675 cashInstrument]
     expectedProducedQuantities = []
   Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     firstPaymentDate swapInstrument issuer observableCids expectedConsumedQuantities
@@ -283,7 +283,7 @@ runCreditEventAfterMaturity = script do
 
   -- Second payment date: Lifecycle and verify the lifecycle effects for the fix payment.
   let
-    expectedConsumedQuantities = [Instrument.qty 0.0049691667 cashInstrument]
+    expectedConsumedQuantities = [qty 0.0049691667 cashInstrument]
     expectedProducedQuantities = []
   swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     maturityDate swapInstrumentAfterFirstPayment issuer observableCids expectedConsumedQuantities
@@ -323,13 +323,13 @@ setupCalendar TestParties{..} = do
       observers = M.fromList pp
 
 -- | Setup cash instrument.
-setupCash : TestParties -> Time -> Script Instrument.K
+setupCash : TestParties -> Time -> Script InstrumentKey
 setupCash TestParties{..} now = do
   let pp = [("PublicParty", singleton publicParty)]
   Instrument.originate custodian issuer "USD" "US Dollars" pp now
 
 -- | Setup Credit Default Swap instrument.
-setupSwap : TestParties -> Time -> Instrument.K -> Script Instrument.K
+setupSwap : TestParties -> Time -> InstrumentKey -> Script InstrumentKey
 setupSwap TestParties{..} now cashInstrument = do
   let pp = [("PublicParty", singleton publicParty)]
   originateCreditDefaultSwap custodian issuer "SwapTest1" "Credit default swap" pp now issueDate

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Currency.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Currency.daml
@@ -8,10 +8,10 @@ import DA.Map qualified as M (fromList)
 import DA.Set (singleton)
 import Daml.Finance.Data.Reference.HolidayCalendar
 import Daml.Finance.Instrument.Swap.Test.Util
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
 import Daml.Finance.Interface.Types.Date.Calendar
 import Daml.Finance.Interface.Types.Date.DayCount
 import Daml.Finance.Interface.Types.Date.RollConvention
+import Daml.Finance.Interface.Util.Common (qty)
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Script
@@ -73,8 +73,8 @@ run = script do
   -- First payment date: Lifecycle and verify the lifecycle effects for base currency and foreign
   -- currency payments.
   let
-    expectedConsumedQuantities = [Instrument.qty 0.0025 cashInstrumentCid]
-    expectedProducedQuantities = [Instrument.qty 0.0018333333 foreignCashInstrumentCid]
+    expectedConsumedQuantities = [qty 0.0025 cashInstrumentCid]
+    expectedProducedQuantities = [qty 0.0018333333 foreignCashInstrumentCid]
   Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     firstPaymentDate swapInstrument issuer [] expectedConsumedQuantities expectedProducedQuantities
 
@@ -90,8 +90,8 @@ run = script do
   -- Lifecycle on the second payment date, which is also the expiry date. Verify the lifecycle
   -- effects for base currency and foreign currency payments.
   let
-    expectedConsumedQuantities = [Instrument.qty 0.0074166667 cashInstrumentCid]
-    expectedProducedQuantities = [Instrument.qty 0.0054388889 foreignCashInstrumentCid]
+    expectedConsumedQuantities = [qty 0.0074166667 cashInstrumentCid]
+    expectedProducedQuantities = [qty 0.0054388889 foreignCashInstrumentCid]
   lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment
     issuer [] expectedConsumedQuantities expectedProducedQuantities
 

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/ForeignExchange.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/ForeignExchange.daml
@@ -6,7 +6,7 @@ module Daml.Finance.Instrument.Swap.Test.ForeignExchange where
 import DA.Date
 import DA.Set (singleton)
 import Daml.Finance.Instrument.Swap.Test.Util
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
+import Daml.Finance.Interface.Util.Common (qty)
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Script
@@ -49,8 +49,8 @@ run = script do
 
   -- First payment date: Lifecycle and verify the lifecycle effects for the fx payments.
   let
-    expectedConsumedQuantities = [Instrument.qty fxRateSameCurrency cashInstrumentCid]
-    expectedProducedQuantities = [Instrument.qty firstFxRate foreignCashInstrumentCid]
+    expectedConsumedQuantities = [qty fxRateSameCurrency cashInstrumentCid]
+    expectedProducedQuantities = [qty firstFxRate foreignCashInstrumentCid]
   Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     firstPaymentDate swapInstrument issuer [] expectedConsumedQuantities expectedProducedQuantities
 
@@ -66,8 +66,8 @@ run = script do
   -- Lifecycle on the second payment date, which is also the expiry date. Verify the lifecycle
   -- effects for the fx payments.
   let
-    expectedConsumedQuantities = [Instrument.qty finalFxRate foreignCashInstrumentCid]
-    expectedProducedQuantities = [Instrument.qty fxRateSameCurrency cashInstrumentCid]
+    expectedConsumedQuantities = [qty finalFxRate foreignCashInstrumentCid]
+    expectedProducedQuantities = [qty fxRateSameCurrency cashInstrumentCid]
   lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment
     issuer [] expectedConsumedQuantities expectedProducedQuantities
 

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -9,12 +9,12 @@ import DA.Set (singleton)
 import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Reference.HolidayCalendar
 import Daml.Finance.Instrument.Swap.Test.Util
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
 import Daml.Finance.Interface.Instrument.Swap.Fpml.FpmlTypes
 import Daml.Finance.Interface.Types.Common.Types (Id(..))
 import Daml.Finance.Interface.Types.Date.Calendar
 import Daml.Finance.Interface.Types.Date.DayCount
 import Daml.Finance.Interface.Types.Date.RollConvention
+import Daml.Finance.Interface.Util.Common (qty)
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Finance.Test.Util.Time (dateToDateClockTime)
@@ -210,8 +210,8 @@ run = script do
 
   -- First payment date: Lifecycle and verify the lifecycle effects for fix and floating payments.
   let
-    expectedConsumedQuantities = [Instrument.qty 0.001675 cashInstrumentCid]
-    expectedProducedQuantities = [Instrument.qty 0.0002283833 cashInstrumentCid]
+    expectedConsumedQuantities = [qty 0.001675 cashInstrumentCid]
+    expectedProducedQuantities = [qty 0.0002283833 cashInstrumentCid]
   Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     firstPaymentDate swapInstrument issuer [observableCid] expectedConsumedQuantities
     expectedProducedQuantities
@@ -228,8 +228,8 @@ run = script do
   -- Lifecycle on the second payment date, which is also the expiry date. Verify the lifecycle
   -- effects for fix and floating payments.
   let
-    expectedConsumedQuantities = [Instrument.qty 0.0049691667 cashInstrumentCid]
-    expectedProducedQuantities = [Instrument.qty 0.0005030972 cashInstrumentCid]
+    expectedConsumedQuantities = [qty 0.0049691667 cashInstrumentCid]
+    expectedProducedQuantities = [qty 0.0005030972 cashInstrumentCid]
   lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment
     issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
 
@@ -394,7 +394,7 @@ runStubRateInterpolation = script do
   let
     expectedConsumedQuantities = []
     -- interpolated stub rate from the ISDA paper
-    expectedProducedQuantities = [Instrument.qty 0.001867875 cashInstrumentCid]
+    expectedProducedQuantities = [qty 0.001867875 cashInstrumentCid]
   swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     (addDays firstRegularPeriodDate 1) swapInstrument issuer observableCids
     expectedConsumedQuantities expectedProducedQuantities
@@ -620,8 +620,8 @@ runDualStubSampleTrade = script do
 
   -- First payment date: Lifecycle and verify the fix and floating payments (stub period).
   let
-    expectedConsumedQuantities = [Instrument.qty 333.3333 cashInstrumentCid]
-    expectedProducedQuantities = [Instrument.qty 250.0 cashInstrumentCid]
+    expectedConsumedQuantities = [qty 333.3333 cashInstrumentCid]
+    expectedProducedQuantities = [qty 250.0 cashInstrumentCid]
   Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     firstRegularPeriodDate swapInstrument issuer observableCids expectedConsumedQuantities
     expectedProducedQuantities
@@ -629,7 +629,7 @@ runDualStubSampleTrade = script do
   -- Second payment date: Lifecycle and verify the floating payment (regular period, 3M).
   let
     expectedConsumedQuantities = []
-    expectedProducedQuantities = [Instrument.qty 4550.0 cashInstrumentCid]
+    expectedProducedQuantities = [qty 4550.0 cashInstrumentCid]
   Some swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     secondRegularPeriodDate swapInstrumentAfterFirstPayment issuer observableCids
     expectedConsumedQuantities expectedProducedQuantities
@@ -637,7 +637,7 @@ runDualStubSampleTrade = script do
   -- Third payment date: Lifecycle and verify the floating payment (regular period, 3M).
   let
     expectedConsumedQuantities = []
-    expectedProducedQuantities = [Instrument.qty 4500.0 cashInstrumentCid]
+    expectedProducedQuantities = [qty 4500.0 cashInstrumentCid]
   Some swapInstrumentAfterThirdPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     thirdRegularPeriodDate swapInstrumentAfterSecondPayment issuer observableCids
     expectedConsumedQuantities expectedProducedQuantities
@@ -645,15 +645,15 @@ runDualStubSampleTrade = script do
   -- Fourth payment date: Lifecycle and verify the floating payment (regular period, 3M).
   let
     expectedConsumedQuantities = []
-    expectedProducedQuantities = [Instrument.qty 4600.0 cashInstrumentCid]
+    expectedProducedQuantities = [qty 4600.0 cashInstrumentCid]
   Some swapInstrumentAfterFourthPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     lastRegularPeriodDate swapInstrumentAfterThirdPayment issuer observableCids
     expectedConsumedQuantities expectedProducedQuantities
 
   -- Final payment date: Lifecycle and verify the fix and floating payments (stub period).
   let
-    expectedConsumedQuantities = [Instrument.qty 19944.4444 cashInstrumentCid]
-    expectedProducedQuantities = [Instrument.qty 3267.3835 cashInstrumentCid]
+    expectedConsumedQuantities = [qty 19944.4444 cashInstrumentCid]
+    expectedProducedQuantities = [qty 3267.3835 cashInstrumentCid]
   swapInstrumentAfterFinalPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     maturityDate swapInstrumentAfterFourthPayment issuer observableCids expectedConsumedQuantities
     expectedProducedQuantities
@@ -872,15 +872,15 @@ runSeparatePaymentFrequencySampleTrade = script do
 
   -- First payment date: Lifecycle and verify the fix and floating payments (stub period).
   let
-    expectedConsumedQuantities = [Instrument.qty 2500.0 cashInstrumentCid]
-    expectedProducedQuantities = [Instrument.qty 3416.6665 cashInstrumentCid]
+    expectedConsumedQuantities = [qty 2500.0 cashInstrumentCid]
+    expectedProducedQuantities = [qty 3416.6665 cashInstrumentCid]
   Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     firstRegularPeriodDate swapInstrument issuer observableCids expectedConsumedQuantities
     expectedProducedQuantities
 
   -- Lifecycle and verify the fix payment (regular period, 3M).
   let
-    expectedConsumedQuantities = [Instrument.qty 25000.0 cashInstrumentCid]
+    expectedConsumedQuantities = [qty 25000.0 cashInstrumentCid]
     expectedProducedQuantities = []
   Some swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     (date 2023 Jan 26) swapInstrumentAfterFirstPayment issuer observableCids
@@ -889,7 +889,7 @@ runSeparatePaymentFrequencySampleTrade = script do
   -- Lifecycle and verify the fix (regular period, 3M). The 6M float payment is calculated but only
   -- paid every 12M.
   let
-    expectedConsumedQuantities = [Instrument.qty 25000.0 cashInstrumentCid]
+    expectedConsumedQuantities = [qty 25000.0 cashInstrumentCid]
     expectedProducedQuantities = []
   Some swapInstrumentAfterThirdPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     (date 2023 Apr 26) swapInstrumentAfterSecondPayment issuer observableCids
@@ -897,7 +897,7 @@ runSeparatePaymentFrequencySampleTrade = script do
 
   -- Lifecycle and verify the fix payment (regular period, 3M).
   let
-    expectedConsumedQuantities = [Instrument.qty 25000.0 cashInstrumentCid]
+    expectedConsumedQuantities = [qty 25000.0 cashInstrumentCid]
     expectedProducedQuantities = []
   Some swapInstrumentAfterFourthPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     (date 2023 Jul 26) swapInstrumentAfterThirdPayment issuer observableCids
@@ -906,8 +906,8 @@ runSeparatePaymentFrequencySampleTrade = script do
   -- Lifecycle and verify the fix payment (regular period, 3M) + floating payment
   -- (regular period, 12M).
   let
-    expectedConsumedQuantities = [Instrument.qty 25000.0 cashInstrumentCid]
-    expectedProducedQuantities = [Instrument.qty 63368.0555 cashInstrumentCid]
+    expectedConsumedQuantities = [qty 25000.0 cashInstrumentCid]
+    expectedProducedQuantities = [qty 63368.0555 cashInstrumentCid]
   lifecycleAndVerifySwapPaymentEffects [publicParty] (date 2023 Oct 26)
     swapInstrumentAfterFourthPayment issuer observableCids expectedConsumedQuantities
     expectedProducedQuantities
@@ -1162,8 +1162,8 @@ runCurrencySwapSampleTrade = script do
 
   -- Lifecycle and verify initial exchange of principal
   let
-    expectedConsumedQuantities = [Instrument.qty 5100000.0 cashInstrumentUsdCid]
-    expectedProducedQuantities = [Instrument.qty 5000000.0 cashInstrumentEurCid]
+    expectedConsumedQuantities = [qty 5100000.0 cashInstrumentUsdCid]
+    expectedProducedQuantities = [qty 5000000.0 cashInstrumentEurCid]
   Some swapInstrumentAfterFirstPrincipalExchangePayment <- lifecycleAndVerifySwapPaymentEffects
     [publicParty] (date 2022 Oct 17) swapInstrument issuer observableCids expectedConsumedQuantities
     expectedProducedQuantities
@@ -1171,8 +1171,8 @@ runCurrencySwapSampleTrade = script do
   -- Lifecycle and verify Euribor vs Libor payment.
   let
     expectedConsumedQuantities =
-      [Instrument.qty 12777.778 cashInstrumentEurCid, Instrument.qty 50000.0 cashInstrumentUsdCid]
-    expectedProducedQuantities = [Instrument.qty 26066.66661 cashInstrumentUsdCid]
+      [qty 12777.778 cashInstrumentEurCid, qty 50000.0 cashInstrumentUsdCid]
+    expectedProducedQuantities = [qty 26066.66661 cashInstrumentUsdCid]
   Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     (date 2023 Jan 17) swapInstrumentAfterFirstPrincipalExchangePayment issuer observableCids
     expectedConsumedQuantities expectedProducedQuantities
@@ -1180,17 +1180,17 @@ runCurrencySwapSampleTrade = script do
   -- Lifecycle and verify Euribor vs Libor payment.
   let
     expectedConsumedQuantities =
-      [Instrument.qty 12500.0 cashInstrumentEurCid, Instrument.qty 100000.0 cashInstrumentUsdCid]
-    expectedProducedQuantities = [Instrument.qty 25750.0 cashInstrumentUsdCid]
+      [qty 12500.0 cashInstrumentEurCid, qty 100000.0 cashInstrumentUsdCid]
+    expectedProducedQuantities = [qty 25750.0 cashInstrumentUsdCid]
   Some swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     (date 2023 Apr 17) swapInstrumentAfterFirstPayment issuer observableCids
     expectedConsumedQuantities expectedProducedQuantities
 
   -- Lifecycle and verify Euribor vs Libor payment.
   let
-    expectedConsumedQuantities = [Instrument.qty 12638.889 cashInstrumentEurCid]
+    expectedConsumedQuantities = [qty 12638.889 cashInstrumentEurCid]
     expectedProducedQuantities =
-      [Instrument.qty 26541.6669 cashInstrumentUsdCid, Instrument.qty 50000.0 cashInstrumentUsdCid]
+      [qty 26541.6669 cashInstrumentUsdCid, qty 50000.0 cashInstrumentUsdCid]
   Some swapInstrumentAfterThirdPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     (date 2023 Jul 17) swapInstrumentAfterSecondPayment issuer observableCids
     expectedConsumedQuantities expectedProducedQuantities
@@ -1198,9 +1198,9 @@ runCurrencySwapSampleTrade = script do
   -- Lifecycle and verify Euribor vs Libor payment.
   let
     expectedConsumedQuantities =
-      [Instrument.qty 12777.778 cashInstrumentEurCid, Instrument.qty 5000000.0 cashInstrumentEurCid]
-    expectedProducedQuantities = [Instrument.qty 26577.77772 cashInstrumentUsdCid,
-      Instrument.qty 5200000.0 cashInstrumentUsdCid]
+      [qty 12777.778 cashInstrumentEurCid, qty 5000000.0 cashInstrumentEurCid]
+    expectedProducedQuantities = [qty 26577.77772 cashInstrumentUsdCid,
+      qty 5200000.0 cashInstrumentUsdCid]
   swapInstrumentAfterFinalPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     (date 2023 Oct 17) swapInstrumentAfterThirdPayment issuer observableCids
     expectedConsumedQuantities expectedProducedQuantities
@@ -1466,15 +1466,15 @@ runAmortizingNotionalSampleTrade = script do
 
   -- First payment date: Lifecycle and verify the fix and floating payments (stub period).
   let
-    expectedConsumedQuantities = [Instrument.qty 1222.222 cashInstrumentCid]
-    expectedProducedQuantities = [Instrument.qty 833.3335 cashInstrumentCid]
+    expectedConsumedQuantities = [qty 1222.222 cashInstrumentCid]
+    expectedProducedQuantities = [qty 833.3335 cashInstrumentCid]
   Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     (date 2022 Oct 20) swapInstrument issuer observableCids expectedConsumedQuantities
     expectedProducedQuantities
 
   -- Second payment date: Lifecycle and verify the floating payment (regular period, 3M).
   let
-    expectedConsumedQuantities = [Instrument.qty 11500.0002 cashInstrumentCid]
+    expectedConsumedQuantities = [qty 11500.0002 cashInstrumentCid]
     expectedProducedQuantities = []
   Some swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     (date 2023 Jan 20) swapInstrumentAfterFirstPayment issuer observableCids
@@ -1483,8 +1483,8 @@ runAmortizingNotionalSampleTrade = script do
   -- Third payment date: Lifecycle and verify the fix and floating payments (regular period,
   -- 3M float vs 6M fix).
   let
-    expectedConsumedQuantities = [Instrument.qty 11250.0 cashInstrumentCid]
-    expectedProducedQuantities = [Instrument.qty 45000.0 cashInstrumentCid]
+    expectedConsumedQuantities = [qty 11250.0 cashInstrumentCid]
+    expectedProducedQuantities = [qty 45000.0 cashInstrumentCid]
   swapInstrumentAfterThirdPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     (date 2023 Apr 20) swapInstrumentAfterSecondPayment issuer observableCids
     expectedConsumedQuantities expectedProducedQuantities

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/InterestRate.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/InterestRate.daml
@@ -9,11 +9,11 @@ import DA.Set (singleton)
 import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Reference.HolidayCalendar
 import Daml.Finance.Instrument.Swap.Test.Util
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
 import Daml.Finance.Interface.Types.Common.Types (Id(..))
 import Daml.Finance.Interface.Types.Date.Calendar
 import Daml.Finance.Interface.Types.Date.DayCount
 import Daml.Finance.Interface.Types.Date.RollConvention
+import Daml.Finance.Interface.Util.Common (qty)
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Finance.Test.Util.Time (dateToDateClockTime)
@@ -80,8 +80,8 @@ run = script do
 
   -- First payment date: Lifecycle and verify the lifecycle effects for fix and floating payments.
   let
-    expectedConsumedQuantities = [Instrument.qty 0.001675 cashInstrumentCid]
-    expectedProducedQuantities = [Instrument.qty 0.0002283833 cashInstrumentCid]
+    expectedConsumedQuantities = [qty 0.001675 cashInstrumentCid]
+    expectedProducedQuantities = [qty 0.0002283833 cashInstrumentCid]
   Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     firstPaymentDate swapInstrument issuer [observableCid] expectedConsumedQuantities
     expectedProducedQuantities
@@ -98,8 +98,8 @@ run = script do
   -- Lifecycle on the second payment date, which is also the expiry date. Verify the lifecycle
   -- effects for fix and floating payments.
   let
-    expectedConsumedQuantities = [Instrument.qty 0.0049691667 cashInstrumentCid]
-    expectedProducedQuantities = [Instrument.qty 0.0005030972 cashInstrumentCid]
+    expectedConsumedQuantities = [qty 0.0049691667 cashInstrumentCid]
+    expectedProducedQuantities = [qty 0.0005030972 cashInstrumentCid]
   lifecycleAndVerifySwapPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment
     issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
 

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -15,11 +15,10 @@ import Daml.Finance.Instrument.Swap.ForeignExchange.Instrument qualified as Fore
 import Daml.Finance.Instrument.Swap.Fpml.Instrument qualified as FpmlSwap (Instrument(..))
 import Daml.Finance.Instrument.Swap.InterestRate.Instrument qualified as InterestRateSwap (Instrument(..))
 import Daml.Finance.Interface.Data.NumericObservable qualified as NumericObservable (I)
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (K, Q)
 import Daml.Finance.Interface.Instrument.Swap.Fpml.FpmlTypes
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (I, GetView(..))
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (I, Evolve(..))
-import Daml.Finance.Interface.Types.Common.Types
+import Daml.Finance.Interface.Types.Common.Types (Id(..), InstrumentKey, InstrumentQuantity, Parties)
 import Daml.Finance.Interface.Types.Date.Calendar (BusinessDayAdjustment(..), BusinessDayConventionEnum)
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
 import Daml.Finance.Interface.Types.Date.RollConvention (PeriodEnum, RollConventionEnum(..))
@@ -59,8 +58,8 @@ createPaymentPeriodicSchedule firstCouponDate holidayCalendarIds businessDayConv
 -- | Originate an interest rate swap.
 originateInterestRateSwap : Party -> Party -> Text -> Text -> [(Text, Parties)] -> Time -> Date ->
   [Text] -> Party -> Date -> Date -> DayCountConventionEnum ->
-  BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Text ->
-  Bool -> Script Instrument.K
+  BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> InstrumentKey -> Text ->
+  Bool -> Script InstrumentKey
 originateInterestRateSwap depository issuer label description observers lastEventTimestamp issueDate
   holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention
   businessDayConvention fixRate couponPeriod couponPeriodMultiplier currency referenceRateId
@@ -79,7 +78,7 @@ originateInterestRateSwap depository issuer label description observers lastEven
 
 -- | Originate a swap specified by FpML swapStream modules
 originateFpmlSwap : Party -> Party -> Text -> Text -> [(Text, Parties)] -> Time ->
-  [SwapStream] -> Party -> [Instrument.K] -> Text -> Script Instrument.K
+  [SwapStream] -> Party -> [InstrumentKey] -> Text -> Script InstrumentKey
 originateFpmlSwap depository issuer label description observers lastEventTimestamp swapStreams
   calendarDataProvider currencies issuerPartyRef = do
     -- CREATE_FPML_SWAP_INSTRUMENT_BEGIN
@@ -94,8 +93,8 @@ originateFpmlSwap depository issuer label description observers lastEventTimesta
 -- | Originate an asset swap.
 originateAssetSwap : Party -> Party -> Text -> Text -> [(Text, Parties)] -> Time -> Date ->
   [Text] -> Party -> Date -> Date -> DayCountConventionEnum ->
-  BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K -> Text ->
-  Bool -> Script Instrument.K
+  BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> InstrumentKey -> Text ->
+  Bool -> Script InstrumentKey
 originateAssetSwap depository issuer label description observers lastEventTimestamp issueDate
   holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention
   businessDayConvention fixRate couponPeriod couponPeriodMultiplier currency referenceAssetId
@@ -115,8 +114,8 @@ originateAssetSwap depository issuer label description observers lastEventTimest
 -- | Originate a credit default swap.
 originateCreditDefaultSwap : Party -> Party -> Text -> Text -> [(Text, Parties)] -> Time ->
   Date -> [Text] -> Party -> Date -> Date -> DayCountConventionEnum ->
-  BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> Instrument.K ->
-  Text -> Text -> Bool -> Script Instrument.K
+  BusinessDayConventionEnum -> Decimal -> PeriodEnum -> Int -> InstrumentKey ->
+  Text -> Text -> Bool -> Script InstrumentKey
 originateCreditDefaultSwap depository issuer label description observers lastEventTimestamp
   issueDate holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention
   businessDayConvention fixRate couponPeriod couponPeriodMultiplier currency
@@ -137,8 +136,8 @@ originateCreditDefaultSwap depository issuer label description observers lastEve
 -- | Originate a currency swap.
 originateCurrencySwap : Party -> Party -> Text -> Text -> [(Text, Parties)] -> Time -> Date ->
   [Text] -> Party -> Date -> Date -> DayCountConventionEnum ->
-  BusinessDayConventionEnum -> Decimal -> Decimal -> PeriodEnum -> Int -> Instrument.K ->
-  Instrument.K -> Decimal -> Bool -> Script Instrument.K
+  BusinessDayConventionEnum -> Decimal -> Decimal -> PeriodEnum -> Int -> InstrumentKey ->
+  InstrumentKey -> Decimal -> Bool -> Script InstrumentKey
 originateCurrencySwap depository issuer label description observers lastEventTimestamp issueDate
   holidayCalendarIds calendarDataProvider firstCouponDate maturityDate dayCountConvention
   businessDayConvention baseRate foreignRate couponPeriod couponPeriodMultiplier baseCurrency
@@ -158,7 +157,7 @@ originateCurrencySwap depository issuer label description observers lastEventTim
 
 -- | Originate an FX swap.
 originateForeignExchangeSwap : Party -> Party -> Text -> Text -> [(Text, Parties)] -> Time ->
-  Date -> Date -> Date -> Instrument.K -> Instrument.K -> Decimal -> Decimal -> Script Instrument.K
+  Date -> Date -> Date -> InstrumentKey -> InstrumentKey -> Decimal -> Decimal -> Script InstrumentKey
 originateForeignExchangeSwap depository issuer label description observers lastEventTimestamp
   issueDate firstPaymentDate maturityDate baseCurrency foreignCurrency firstFxRate finalFxRate = do
     -- CREATE_FOREIGN_EXCHANGE_SWAP_INSTRUMENT_BEGIN
@@ -172,8 +171,8 @@ originateForeignExchangeSwap depository issuer label description observers lastE
 
 -- | Lifecycle the instrument as of this date. This is a general function that can be used for both
 -- bonds and swaps.
-lifecycleInstrument : [Party] -> Date -> Instrument.K -> Party ->
-  [ContractId NumericObservable.I] -> Script (Optional Instrument.K, [ContractId Effect.I])
+lifecycleInstrument : [Party] -> Date -> InstrumentKey -> Party ->
+  [ContractId NumericObservable.I] -> Script (Optional InstrumentKey, [ContractId Effect.I])
 lifecycleInstrument readAs today instrument issuer observableCids = do
   -- CREATE_CLOCK_FOR_BOND_LIFECYCLING_BEGIN
   -- create clock update event
@@ -200,7 +199,7 @@ lifecycleInstrument readAs today instrument issuer observableCids = do
 
 -- | Verify a that there are no lifecycle effects of the instrument on this date. This is a general
 -- function that can be used for both bonds and swaps.
-verifyNoLifecycleEffects : [Party] -> Date -> Instrument.K -> Party ->
+verifyNoLifecycleEffects : [Party] -> Date -> InstrumentKey -> Party ->
   [ContractId NumericObservable.I] -> Script ()
 verifyNoLifecycleEffects readAs today instrument issuer observableCids = do
   (bondLifecycleCid2, effectCids) <- lifecycleInstrument readAs today instrument issuer
@@ -208,9 +207,9 @@ verifyNoLifecycleEffects readAs today instrument issuer observableCids = do
   assertMsg ("There should be no lifecycle effects on " <> show today) (null effectCids)
 
 -- | Verify the payments from a payment date of a swap (excluding settlement)
-lifecycleAndVerifySwapPaymentEffects : [Party] -> Date -> Instrument.K -> Party ->
-  [ContractId NumericObservable.I] -> [Instrument.Q] -> [Instrument.Q] ->
-  Script (Optional Instrument.K)
+lifecycleAndVerifySwapPaymentEffects : [Party] -> Date -> InstrumentKey -> Party ->
+  [ContractId NumericObservable.I] -> [InstrumentQuantity] -> [InstrumentQuantity] ->
+  Script (Optional InstrumentKey)
 lifecycleAndVerifySwapPaymentEffects readAs today swapInstrument issuer
   observableCids expectedConsumedQuantities expectedProducedQuantities = do
     (newSwapInstrumentKey, effectCids) <- lifecycleInstrument readAs today swapInstrument issuer

--- a/src/test/daml/Daml/Finance/Settlement/Test/Batch.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Batch.daml
@@ -6,13 +6,13 @@ module Daml.Finance.Settlement.Test.Batch where
 import DA.Map qualified as M (fromList)
 import DA.Set (fromList, singleton, toList)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Cancel(..), Settle(..))
 import Daml.Finance.Interface.Settlement.Factory qualified as Factory (I, Instruct(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..), Execute(..))
 import Daml.Finance.Interface.Settlement.RouteProvider qualified as RouteProvider (I, Discover(..))
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), Step(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..))
+import Daml.Finance.Interface.Util.Common (qty)
 import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
@@ -82,11 +82,8 @@ run settleCashOnLedger bankIsRequesting = script do
   -- Settlement steps
   let
     steps =
-      [ Step with
-          sender = seller; receiver = buyer; quantity = Instrument.qty 1_000.0 equityInstrument
-      , Step with
-          sender = buyer; receiver = seller; quantity = Instrument.qty 200_000.0 cashInstrument
-      ]
+      [ Step with sender = seller; receiver = buyer; quantity = qty 1_000.0 equityInstrument
+      , Step with sender = buyer; receiver = seller; quantity = qty 200_000.0 cashInstrument ]
 
   -- Discover settlement routes
   routeProviderCid <- toInterfaceContractId @RouteProvider.I <$> submit bank do

--- a/src/test/daml/Daml/Finance/Settlement/Test/BatchWithIntermediaries.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/BatchWithIntermediaries.daml
@@ -8,13 +8,13 @@ import DA.Map qualified as M (fromList)
 import DA.Set (empty, fromList, singleton)
 import DA.Time (time)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Factory qualified as Factory (I, Instruct(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Settlement.RouteProvider qualified as RouteProvider (I, Discover(..))
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), Step(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..))
+import Daml.Finance.Interface.Util.Common (qty)
 import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.Hierarchy (Hierarchy(..))
 import Daml.Finance.Settlement.RouteProvider.IntermediatedStatic (IntermediatedStatic(..))
@@ -97,11 +97,8 @@ run settleWithOwnAccount = script do
   -- Settlement steps
   let
     steps =
-      [ Step with
-          sender = seller; receiver = buyer; quantity = Instrument.qty 1_000.0 equityInstrument
-      , Step with
-          sender = buyer; receiver = seller; quantity = Instrument.qty 200_000.0 cashInstrument
-      ]
+      [ Step with sender = seller; receiver = buyer; quantity = qty 1_000.0 equityInstrument
+      , Step with sender = buyer; receiver = seller; quantity = qty 200_000.0 cashInstrument ]
     settlementTime = time (addDays (toDateUTC now) 1) 0 0 0
 
   -- Discover settlement routes (by first creating a route provider with intermediaries from Buyer

--- a/src/test/daml/Daml/Finance/Settlement/Test/Intermediated.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Intermediated.daml
@@ -10,13 +10,13 @@ import DA.Time (time)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..), T)
 import Daml.Finance.Interface.Holding.Base qualified as Base (I)
 import Daml.Finance.Interface.Holding.Util (undisclose)
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Factory qualified as Factory (I, Instruct(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..), I)
 import Daml.Finance.Interface.Settlement.RouteProvider qualified as RouteProvider (I, Discover(..))
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), Step(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..))
+import Daml.Finance.Interface.Util.Common (qty)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (AddObservers(..), I, RemoveObservers(..))
 import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.Hierarchy (Hierarchy(..))
@@ -137,8 +137,8 @@ run useDelegatee = script do
 
   -- Settlement steps
   let
-    cashQuantity = Instrument.qty 200_000.0 cashInstrument
-    assetQuantity = Instrument.qty 1_250.0 assetInstrument
+    cashQuantity = qty 200_000.0 cashInstrument
+    assetQuantity = qty 1_250.0 assetInstrument
     steps =
       [ -- Payment step
         Step with sender = buyer; receiver = seller; quantity = cashQuantity

--- a/src/test/daml/Daml/Finance/Settlement/Test/Transfer.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Transfer.daml
@@ -9,13 +9,13 @@ import DA.Map qualified as M (fromList)
 import DA.Set (empty, fromList, singleton)
 import Daml.Finance.Account.Account qualified as Account (T)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (qty)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Factory qualified as Factory (I, Instruct(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Settlement.RouteProvider qualified as RouteProvider (I, Discover(..))
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), InstructionKey(..), Step(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..))
+import Daml.Finance.Interface.Util.Common (qty)
 import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), credit, createAccount, createFactory)
@@ -76,7 +76,7 @@ run = script do
     submit bank do createCmd Factory with provider = bank; observers = empty
 
   -- Settlement step
-  let step = Step with sender; receiver; quantity = Instrument.qty 200_000.0 cashInstrument
+  let step = Step with sender; receiver; quantity = qty 200_000.0 cashInstrument
 
   -- Discover settlement route for the step
   routeProviderCid <- toInterfaceContractId @RouteProvider.I <$> submit bank do
@@ -156,9 +156,9 @@ run2 = script do
     id1 = Id "transfer 1"
     id2 = Id "transfer 2"
     id3 = Id "transfer 3"
-    first = Step with sender; receiver; quantity = Instrument.qty 100_000.0 cashInstrument
-    second = Step with sender; receiver; quantity = Instrument.qty 200_000.0 cashInstrument
-    third = Step with sender; receiver; quantity = Instrument.qty 300_000.0 cashInstrument
+    first = Step with sender; receiver; quantity = qty 100_000.0 cashInstrument
+    second = Step with sender; receiver; quantity = qty 200_000.0 cashInstrument
+    third = Step with sender; receiver; quantity = qty 300_000.0 cashInstrument
 
   -- Discover settlement routes
   routeProviderCid <- toInterfaceContractId @RouteProvider.I <$> submit bank do
@@ -310,7 +310,7 @@ run3 = script do
     createCmd Factory with provider = bank; observers = singleton publicParty
 
   -- Discover settlement
-  let step = Step with sender; receiver; quantity = Instrument.qty 200_000.0 cashInstrument
+  let step = Step with sender; receiver; quantity = qty 200_000.0 cashInstrument
   routeProviderCid <- toInterfaceContractId @RouteProvider.I <$> submit bank do
     createCmd SingleCustodian with provider = bank; observers = empty; custodian = bank
   routedSteps <- submit bank do
@@ -386,8 +386,8 @@ run4 = script do
 
   -- Settlement steps
   let
-    step1 = Step with sender; receiver; quantity = Instrument.qty 200_000.0 cashInstrument1
-    step2 = Step with sender; receiver; quantity = Instrument.qty 100_000.0 cashInstrument1
+    step1 = Step with sender; receiver; quantity = qty 200_000.0 cashInstrument1
+    step2 = Step with sender; receiver; quantity = qty 100_000.0 cashInstrument1
 
   -- Discover settlement routes
   routeProviderCid <- toInterfaceContractId @RouteProvider.I <$> submit bank do
@@ -470,8 +470,8 @@ run5 = script do
 
   -- Settlement steps
   let
-    step1 = Step with sender; receiver = ccp; quantity = Instrument.qty 200_000.0 cashInstrument
-    step2 = Step with sender = ccp; receiver; quantity = Instrument.qty 200_000.0 cashInstrument
+    step1 = Step with sender; receiver = ccp; quantity = qty 200_000.0 cashInstrument
+    step2 = Step with sender = ccp; receiver; quantity = qty 200_000.0 cashInstrument
 
   -- Discover settlement routes
   routeProviderCid <- toInterfaceContractId @RouteProvider.I <$> submit bank do

--- a/src/test/daml/Daml/Finance/Test/Util/Account.daml
+++ b/src/test/daml/Daml/Finance/Test/Util/Account.daml
@@ -14,8 +14,8 @@ import Daml.Finance.Interface.Account.Account qualified as Account (Controllers(
 import Daml.Finance.Interface.Account.Factory qualified as Account (Create(..), F)
 import Daml.Finance.Interface.Holding.Base qualified as Base (GetView(..), I)
 import Daml.Finance.Interface.Holding.Factory qualified as Holding (F)
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (K, qty)
-import Daml.Finance.Interface.Types.Common.Types (Id(..), AccountKey(..), Parties)
+import Daml.Finance.Interface.Types.Common.Types (Id(..), AccountKey(..), InstrumentKey, Parties)
+import Daml.Finance.Interface.Util.Common (qty)
 import Daml.Finance.Test.Util.Common (submitExerciseInterfaceByKeyCmdHelper, submitMustFailExerciseInterfaceByKeyCmdHelper)
 import Daml.Script
 
@@ -64,12 +64,12 @@ createAccount description readAs factoryCid holdingFactoryCid
       pure account
 
 -- | Credit an `Account`.
-credit : [Party] -> Instrument.K -> Decimal -> AccountKey -> Script (ContractId Base.I)
+credit : [Party] -> InstrumentKey -> Decimal -> AccountKey -> Script (ContractId Base.I)
 credit readAs instrument amount account =
   submitExerciseInterfaceByKeyCmdHelper @Account.R @Account.I [account.custodian, account.owner]
   readAs account
   (Account.GetCid with viewer = account.owner)
-  (Account.Credit with quantity = Instrument.qty amount instrument)
+  (Account.Credit with quantity = qty amount instrument)
 
 -- | Debit an `Account`.
 debit : [Party] -> Party -> ContractId Base.I -> Script ()

--- a/src/test/daml/Daml/Finance/Test/Util/Instrument.daml
+++ b/src/test/daml/Daml/Finance/Test/Util/Instrument.daml
@@ -8,15 +8,15 @@ module Daml.Finance.Test.Util.Instrument where
 import DA.List (head)
 import DA.Map qualified as M
 import Daml.Finance.Instrument.Token.Instrument (Instrument(..))
-import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (GetCid(..), GetView(..), I, K, R, Reference(..))
-import Daml.Finance.Interface.Types.Common.Types (Id(..), Parties)
+import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (GetCid(..), GetView(..), I, R, Reference(..))
+import Daml.Finance.Interface.Types.Common.Types (Id(..), InstrumentKey, Parties)
 import Daml.Finance.Test.Util.Common (submitExerciseInterfaceByKeyCmdHelper)
 import Daml.Script
 
 -- | Create a `Reference` for an instrument.
 -- Note: This should only be called together with an instrument creation
 createReference : ContractId Instrument.I -> Party -> Party -> [(Text, Parties)] ->
-  Script Instrument.K
+  Script InstrumentKey
 createReference cid depository issuer observers = do
   instrumentView <- submitMulti [depository, issuer] [] do
     exerciseCmd cid Instrument.GetView with viewer = issuer
@@ -25,7 +25,7 @@ createReference cid depository issuer observers = do
   pure $ key ref
 
 -- | Originate an `Instrument`.
-originate : Party -> Party -> Text -> Text-> [(Text, Parties)] -> Time -> Script Instrument.K
+originate : Party -> Party -> Text -> Text-> [(Text, Parties)] -> Time -> Script InstrumentKey
 originate depository issuer label description observers timestamp = do
   cid <- toInterfaceContractId <$> submitMulti [depository, issuer] [] do
     createCmd Instrument with
@@ -37,6 +37,6 @@ originate depository issuer label description observers timestamp = do
 submitExerciseInterfaceByKeyCmd : forall t2 c2 b.
   ( HasInterfaceTypeRep t2, HasTemplateTypeRep t2, HasToAnyTemplate t2, HasFromAnyTemplate t2,
     HasFromAnyChoice t2 c2 b, HasToAnyChoice t2 c2 b, HasExercise t2 c2 b)
-    => [Party] -> [Party] -> Instrument.K -> c2 -> Script b
+    => [Party] -> [Party] -> InstrumentKey -> c2 -> Script b
 submitExerciseInterfaceByKeyCmd actAs readAs k arg = submitExerciseInterfaceByKeyCmdHelper
   @Instrument.R @t2 actAs readAs k (Instrument.GetCid with viewer = head actAs) arg


### PR DESCRIPTION
- Copy `Instrument.Q` to `D.F.Interface.Types.Common` as `InstrumentQuantity`
- Copy `Instrument.qty` and `Instrument.scale` to `D.F.Interface.Util`
- Remove `Account.K`
- Make use of `InstrumentKey`, `InstrumentQuantity`, and `AccountKey` throughout (except for quickstarter)
- Remove explicit export lists for modules that export everything anyway
