### PR TITLE
Test/document cash dividends on fractional holdings

### DIFF
--- a/docs/source/tutorials/instrument-modeling/equity-extension.rst
+++ b/docs/source/tutorials/instrument-modeling/equity-extension.rst
@@ -54,6 +54,14 @@ longer include the dividend):
   :start-after: -- CREATE_EQUITY_INSTRUMENTS_BEGIN
   :end-before: -- CREATE_EQUITY_INSTRUMENTS_END
 
+After the instrument has been created, you can book a holding on it. This is not limited to integer
+holdings, but fractional holdings are supported as well:
+
+.. literalinclude:: ../../../../src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
+  :language: daml
+  :start-after: -- CREATE_EQUITY_HOLDING_BEGIN
+  :end-before: -- CREATE_EQUITY_HOLDING_END
+
 We create a distribution rule for the cash dividend. It defines the business logic for the dividend
 and it has the issuer as signatory:
 
@@ -62,7 +70,8 @@ and it has the issuer as signatory:
   :start-after: -- CREATE_EQUITY_DISTRIBUTION_RULE_BEGIN
   :end-before: -- CREATE_EQUITY_DISTRIBUTION_RULE_END
 
-We also need a distribution event, which defines the terms of the dividend:
+We also need a distribution event, which defines the terms of the dividend. In this case, it is
+2 USD cash per share (this also works for a fractional amount of shares):
 
 .. literalinclude:: ../../../../src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
   :language: daml

--- a/docs/source/tutorials/instrument-modeling/equity-extension.rst
+++ b/docs/source/tutorials/instrument-modeling/equity-extension.rst
@@ -71,7 +71,7 @@ and it has the issuer as signatory:
   :end-before: -- CREATE_EQUITY_DISTRIBUTION_RULE_END
 
 We also need a distribution event, which defines the terms of the dividend. In this case, it is
-2 USD cash per share (this also works for a fractional amount of shares):
+USD 2 cash per share (this also works for a fractional amount of shares):
 
 .. literalinclude:: ../../../../src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
   :language: daml

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
@@ -69,7 +69,7 @@ run = script do
   -- CREATE_EQUITY_DISTRIBUTION_RULE_END
 
   -- CREATE_EQUITY_DISTRIBUTION_EVENT_BEGIN
-  -- Create cash dividend event: 2 USD per share (this also works with fractional shares)
+  -- Create cash dividend event: USD 2 per share (this also works with fractional shares)
   distributionEventCid <-
     Instrument.submitExerciseInterfaceByKeyCmd @Equity.I [issuer] [] cumEquityInstrument
       Equity.DeclareDividend with

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
@@ -21,7 +21,7 @@ import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (verifyOwnerAndAmountOfHolding)
 import Daml.Finance.Test.Util.Instrument (originate)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (submitExerciseInterfaceByKeyCmd)
 import Daml.Script
@@ -52,8 +52,10 @@ run = script do
   exEquityInstrument <- originateEquity issuer issuer "EQUITY-INST-1" "1" "APPL" [] now
   -- CREATE_EQUITY_INSTRUMENTS_END
 
-  -- Distribute holdings
-  investorEquityCid <- Account.credit [publicParty] cumEquityInstrument 1_000.0 investorAccount
+  -- CREATE_EQUITY_HOLDING_BEGIN
+  -- Distribute holdings: fractional holdings are also supported.
+  investorEquityCid <- Account.credit [publicParty] cumEquityInstrument 1000.25 investorAccount
+  -- CREATE_EQUITY_HOLDING_END
 
   -- CREATE_EQUITY_DISTRIBUTION_RULE_BEGIN
   -- Create cash dividend rule
@@ -67,7 +69,7 @@ run = script do
   -- CREATE_EQUITY_DISTRIBUTION_RULE_END
 
   -- CREATE_EQUITY_DISTRIBUTION_EVENT_BEGIN
-  -- Create cash dividend event
+  -- Create cash dividend event: 2 USD per share (this also works with fractional shares)
   distributionEventCid <-
     Instrument.submitExerciseInterfaceByKeyCmd @Equity.I [issuer] [] cumEquityInstrument
       Equity.DeclareDividend with
@@ -142,7 +144,7 @@ run = script do
     exerciseCmd result.batchCid Batch.Settle with actors = singleton custodian
 
   -- Assert state
-  Holding.verifyOwnerOfHolding [(investor, investorEquityHoldingCid),
-    (investor, coerceInterfaceContractId investorCashHoldingCid)]
+  Holding.verifyOwnerAndAmountOfHolding [(investor, 1000.25, investorEquityHoldingCid),
+    (investor, 2000.50, investorCashHoldingCid)]
 
   pure ()

--- a/src/test/daml/Daml/Finance/Test/Util/Holding.daml
+++ b/src/test/daml/Daml/Finance/Test/Util/Holding.daml
@@ -18,6 +18,16 @@ verifyOwnerOfHolding l = forA l
       exerciseCmd (toInterfaceContractId @Base.I holdingCid) Base.GetView with viewer = owner
     v.account.owner === owner
 
+-- | Verify that a party is the owner of a holding and that the holding has the expected amount.
+verifyOwnerAndAmountOfHolding : (HasToInterface a Base.I, HasToInterface a Disclosure.I) =>
+  [(Party, Decimal, ContractId a)] -> Script [()]
+verifyOwnerAndAmountOfHolding l = forA l
+  \(owner, amount, holdingCid) -> do
+    v <- submit owner do
+      exerciseCmd (toInterfaceContractId @Base.I holdingCid) Base.GetView with viewer = owner
+    v.account.owner === owner
+    v.amount === amount
+
 -- | Verify that a holding has no observers.
 verifyNoObservers : (HasToInterface a Disclosure.I) => [(Party, ContractId a)] -> Script [()]
 verifyNoObservers l = forA l


### PR DESCRIPTION
- Change cash dividend test from integer holding to fractional holding
- Change cash dividend test to also verify the dividend amount (the cash holding after settlement)
- Update the Equity Tutorial

Fixes https://github.com/digital-asset/daml-finance/issues/489