### PR TITLE
Add three additional Fpml swap sample trades

### DIFF
--- a/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.5.0
 name: daml-finance-instrument-swap
 source: daml
-version: 0.2.0
+version: 0.2.1
 dependencies:
   - daml-prim
   - daml-stdlib
@@ -14,7 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Data/1.0.0/daml-finance-data-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/1.0.0/daml-finance-interface-claims-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/1.0.0/daml-finance-interface-instrument-base-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.2.0/daml-finance-interface-instrument-swap-0.2.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.2.1/daml-finance-interface-instrument-swap-0.2.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.0/daml-finance-interface-types-common-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/1.0.0/daml-finance-interface-types-date-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.0/daml-finance-interface-util-1.0.0.dar

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.5.0
 name: daml-finance-interface-instrument-swap
 source: daml
-version: 0.2.0
+version: 0.2.1
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
@@ -12,8 +12,8 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Claims/1.0.0/daml-finance-claims-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Data/1.0.0/daml-finance-data-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Swap/0.2.0/daml-finance-instrument-swap-0.2.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.2.0/daml-finance-interface-instrument-swap-0.2.0.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Swap/0.2.1/daml-finance-instrument-swap-0.2.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.2.1/daml-finance-interface-instrument-swap-0.2.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/1.0.0/daml-finance-interface-lifecycle-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.0/daml-finance-interface-types-common-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/1.0.0/daml-finance-interface-types-date-1.0.0.dar

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -344,7 +344,10 @@ calculateFloatingPaymentClaimsFromSwapStream floatingRateCalculation s periodicS
             None -> notionalConst
             Some fxRateId -> if fxAdjRequired then notionalConst * fxRateObs else notionalConst
               where fxRateObs = Observe fxRateId
-          floatingRateSpread = floatingRateCalculation.spreadSchedule.initialValue
+          floatingRateSpread = case floatingRateCalculation.spreadSchedule of
+            [] -> 0.0
+            [s] -> s.initialValue
+            _ -> error "Multiple SpreadSchedules not yet supported"
           referenceRateId = floatingRateCalculation.floatingRateIndex
           regularRate = Observe referenceRateId + Const floatingRateSpread
           rate = case c.stubType of

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -321,6 +321,7 @@ calculateFloatingPaymentClaimsFromSwapStream : FloatingRateCalculation -> SwapSt
 calculateFloatingPaymentClaimsFromSwapStream floatingRateCalculation s periodicSchedule
   calculationSchedule paymentScheduleAligned useAdjustedDatesForDcf issuerPaysLeg currency issuer
   calendarDataAgency fxRateId fxFixingDates notionals = do
+    assertMsg "rate rounding not yet supported" $ isNone floatingRateCalculation.finalRateRounding
     (rateFixingDates, rateFixingCalendar) <- getRateFixingsAndCalendars s (fromSome s.resetDates)
       calculationSchedule issuer calendarDataAgency
     case fxFixingDates of
@@ -382,6 +383,8 @@ calculateClaimsFromSwapStream s periodicSchedule calculationSchedule paymentSche
   swapStreamNotionalRef useAdjustedDatesForDcf issuerPaysLeg currency issuer calendarDataAgency = do
     assertMsg "Compounding not yet supported" $
       isNone s.calculationPeriodAmount.calculation.compoundingMethodEnum
+    assertMsg "Payment lag not yet supported" $
+      isNone s.paymentDates.paymentDaysOffset
     case s.calculationPeriodAmount.calculation.notionalScheduleValue of
       NotionalSchedule_FxLinked fxl -> assertMsg
         "swapStream currency does not match swap currency" $

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -380,6 +380,8 @@ calculateClaimsFromSwapStream : SwapStream -> PeriodicSchedule -> [SchedulePerio
   Update [TaggedClaim]
 calculateClaimsFromSwapStream s periodicSchedule calculationSchedule paymentSchedule
   swapStreamNotionalRef useAdjustedDatesForDcf issuerPaysLeg currency issuer calendarDataAgency = do
+    assertMsg "Compounding not yet supported" $
+      isNone s.calculationPeriodAmount.calculation.compoundingMethodEnum
     case s.calculationPeriodAmount.calculation.notionalScheduleValue of
       NotionalSchedule_FxLinked fxl -> assertMsg
         "swapStream currency does not match swap currency" $

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -346,7 +346,7 @@ calculateFloatingPaymentClaimsFromSwapStream floatingRateCalculation s periodicS
               where fxRateObs = Observe fxRateId
           floatingRateSpread = case floatingRateCalculation.spreadSchedule of
             [] -> 0.0
-            [s] -> s.initialValue
+            [se] -> se.initialValue
             _ -> error "Multiple SpreadSchedules not yet supported"
           referenceRateId = floatingRateCalculation.floatingRateIndex
           regularRate = Observe referenceRateId + Const floatingRateSpread

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Fpml/FpmlTypes.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Fpml/FpmlTypes.daml
@@ -205,7 +205,25 @@ data Calculation = Calculation
     notionalScheduleValue : NotionalScheduleValue
     rateTypeValue : RateTypeValue
     dayCountFraction : DayCountConventionEnum
+    compoundingMethodEnum : Optional CompoundingMethodEnum
   deriving (Eq, Show)
+
+-- | The compounding calculation method
+data CompoundingMethodEnum
+  = Flat
+    -- ^ Flat compounding. Compounding excludes the spread.
+    --   Note that the first compounding period has it's
+    --   interest calculated including any spread then
+    --   subsequent periods compound this at a rate excluding
+    --   the spread.
+  | NoCompounding
+    -- ^ No compounding is to be applied.
+  | Straight
+    -- ^ Straight compounding. Compounding includes the
+    --   spread.
+  | SpreadExclusive
+    -- ^ Spread Exclusive compounding.
+  deriving (Eq, Ord, Show)
 
 -- | Specifies whether the swapStream has a fixed or a floating rate.
 data RateTypeValue

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Fpml/FpmlTypes.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Fpml/FpmlTypes.daml
@@ -56,8 +56,39 @@ data PaymentDates = PaymentDates
     firstPaymentDate : Optional Date
     lastRegularPaymentDate : Optional Date
     payRelativeTo : DateRelativeToEnum
+    paymentDaysOffset : Optional DateOffset
     paymentDatesAdjustments : BusinessDayAdjustments
   deriving (Eq, Show)
+
+-- | A type defining an offset used in calculating a date
+--   when this date is defined in reference to another
+--   date through a date offset. The type includes the
+--   convention for adjusting the date and an optional
+--   sequence element to indicate the order in a sequence
+--   of multiple date offsets.
+data DateOffset = DateOffset with
+  -- id : Optional Text
+  periodMultiplier : Int
+    -- ^ A time period multiplier, e.g. 1, 2 or 3 etc. A
+    --   negative value can be used when specifying an offset
+    --   relative to another date, e.g. -2 days.
+  period : PeriodEnum
+    -- ^ A time period, e.g. a day, week, month or year of the
+    --   stream. If the periodMultiplier value is 0 (zero)
+    --   then period must contain the value D (day).
+  dayType : Optional DayTypeEnum
+    -- ^ In the case of an offset specified as a number of
+    --   days, this element defines whether consideration is
+    --   given as to whether a day is a good business day or
+    --   not. If a day type of business days is specified then
+    --   non-business days are ignored when calculating the
+    --   offset. The financial business centers to use for
+    --   determination of business days are implied by the
+    --   context in which this element is used. This element
+    --   must only be included when the offset is specified as
+    --   a number of days. If the offset is zero days then the
+    --   dayType element should not be included.
+    deriving (Eq, Show)
 
 -- | A type for defining a date that shall be subject to adjustment if it would otherwise fall on a
 -- day that is not a business day in the specified business centers, together with the convention
@@ -223,7 +254,7 @@ data CompoundingMethodEnum
     --   spread.
   | SpreadExclusive
     -- ^ Spread Exclusive compounding.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Specifies whether the swapStream has a fixed or a floating rate.
 data RateTypeValue
@@ -396,28 +427,28 @@ data Rounding = Rounding with
       --   the percentage is expressed as a decimal, e.g.
       --   9.876543% (or 0.09876543) being rounded to the
       --   nearest 5 decimal places is 9.87654% (or 0.0987654).
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Show)
 
 -- | The method of rounding a fractional number.
 data RoundingDirectionEnum
-  = RoundingDirectionEnum_Up
+  = Up
     -- ^ A fractional number will be rounded up to the
     --   specified number of decimal places (the precision).
     --   For example, 5.21 and 5.25 rounded up to 1 decimal
     --   place are 5.3 and 5.3 respectively.
-  | RoundingDirectionEnum_Down
+  | Down
     -- ^ A fractional number will be rounded down to the
     --   specified number of decimal places (the precision).
     --   For example, 5.29 and 5.25 rounded down to 1 decimal
     --   place are 5.2 and 5.2 respectively.
-  | RoundingDirectionEnum_Nearest
+  | Nearest
     -- ^ A fractional number will be rounded either up or down
     --   to the specified number of decimal places (the
     --   precision) depending on its value. For example, 5.24
     --   would be rounded down to 5.2 and 5.25 would be
     --   rounded up to 5.3 if a precision of 1 decimal place
     --   were specified.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 -- | Adds an optional spread type element to the Schedule to identify a long or short spread value.
 data SpreadSchedule = SpreadSchedule with

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Fpml/FpmlTypes.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Fpml/FpmlTypes.daml
@@ -63,23 +63,24 @@ data PaymentDates = PaymentDates
 -- | A type defining an offset used in calculating a date when this date is defined in reference to
 -- another date through a date offset. The type includes the convention for adjusting the date and
 -- an optional sequence element to indicate the order in a sequence of multiple date offsets.
-data DateOffset = DateOffset with
-  -- id : Optional Text
-  periodMultiplier : Int
-    -- ^ A time period multiplier, e.g. 1, 2 or 3 etc. A negative value can be used when specifying
-    -- an offset relative to another date, e.g. -2 days.
-  period : PeriodEnum
-    -- ^ A time period, e.g. a day, week, month or year of the stream. If the periodMultiplier value
-    -- is 0 (zero) then period must contain the value D (day).
-  dayType : Optional DayTypeEnum
-    -- ^ In the case of an offset specified as a number of days, this element defines whether
-    -- consideration is given as to whether a day is a good business day or not. If a day type of
-    -- business days is specified then non-business days are ignored when calculating the offset.
-    -- The financial business centers to use for determination of business days are implied by the
-    -- context in which this element is used. This element must only be included when the offset is
-    -- specified as a number of days. If the offset is zero days then the dayType element should not
-    -- be included.
-    deriving (Eq, Show)
+data DateOffset = DateOffset
+  with
+    -- id : Optional Text
+    periodMultiplier : Int
+      -- ^ A time period multiplier, e.g. 1, 2 or 3 etc. A negative value can be used when specifying
+      -- an offset relative to another date, e.g. -2 days.
+    period : PeriodEnum
+      -- ^ A time period, e.g. a day, week, month or year of the stream. If the periodMultiplier value
+      -- is 0 (zero) then period must contain the value D (day).
+    dayType : Optional DayTypeEnum
+      -- ^ In the case of an offset specified as a number of days, this element defines whether
+      -- consideration is given as to whether a day is a good business day or not. If a day type of
+      -- business days is specified then non-business days are ignored when calculating the offset.
+      -- The financial business centers to use for determination of business days are implied by the
+      -- context in which this element is used. This element must only be included when the offset is
+      -- specified as a number of days. If the offset is zero days then the dayType element should not
+      -- be included.
+  deriving (Eq, Show)
 
 -- | A type for defining a date that shall be subject to adjustment if it would otherwise fall on a
 -- day that is not a business day in the specified business centers, together with the convention
@@ -403,15 +404,16 @@ data FloatingRateCalculation = FloatingRateCalculation with
     deriving (Eq, Show)
 
 -- | A type defining a rounding direction and precision to be used in the rounding of a rate.
-data Rounding = Rounding with
-  roundingDirection : RoundingDirectionEnum
+data Rounding = Rounding
+  with
+    roundingDirection : RoundingDirectionEnum
       -- ^ Specifies the rounding direction.
-  precision : Int
+    precision : Int
       -- ^ Specifies the rounding precision in terms of a number  of decimal places. Note how a
       -- percentage rate rounding of 5 decimal places is expressed as a rounding precision of 7 in
       -- the FpML document since the percentage is expressed as a decimal, e.g. 9.876543% (or
       -- 0.09876543) being rounded to the nearest 5 decimal places is 9.87654% (or 0.0987654).
-    deriving (Eq, Show)
+  deriving (Eq, Show)
 
 -- | The method of rounding a fractional number.
 data RoundingDirectionEnum

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Fpml/FpmlTypes.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Fpml/FpmlTypes.daml
@@ -370,7 +370,7 @@ data FloatingRateCalculation = FloatingRateCalculation with
     --   period. It should only be included when the rate is not equal to the rate published on the
     --   source implied by the floating rate index. An initial rate of 5% would be represented as
     --   0.05.
-  -- finalRateRounding : Optional Rounding
+  finalRateRounding : Optional Rounding
     -- ^ The rounding convention to apply to the final rate used in determination of a calculation
     --   period amount.
   -- averagingMethod : Optional AveragingMethodEnum
@@ -382,6 +382,42 @@ data FloatingRateCalculation = FloatingRateCalculation with
     --   rate is negative (either due to a quoted negative floating rate or by operation of a spread
     --   that is subtracted from the floating rate).
     deriving (Eq, Show)
+
+-- | A type defining a rounding direction and precision to
+--   be used in the rounding of a rate.
+data Rounding = Rounding with
+  roundingDirection : RoundingDirectionEnum
+      -- ^ Specifies the rounding direction.
+  precision : Int
+      -- ^ Specifies the rounding precision in terms of a number
+      --   of decimal places. Note how a percentage rate
+      --   rounding of 5 decimal places is expressed as a
+      --   rounding precision of 7 in the FpML document since
+      --   the percentage is expressed as a decimal, e.g.
+      --   9.876543% (or 0.09876543) being rounded to the
+      --   nearest 5 decimal places is 9.87654% (or 0.0987654).
+    deriving (Eq, Ord, Show)
+
+-- | The method of rounding a fractional number.
+data RoundingDirectionEnum
+  = RoundingDirectionEnum_Up
+    -- ^ A fractional number will be rounded up to the
+    --   specified number of decimal places (the precision).
+    --   For example, 5.21 and 5.25 rounded up to 1 decimal
+    --   place are 5.3 and 5.3 respectively.
+  | RoundingDirectionEnum_Down
+    -- ^ A fractional number will be rounded down to the
+    --   specified number of decimal places (the precision).
+    --   For example, 5.29 and 5.25 rounded down to 1 decimal
+    --   place are 5.2 and 5.2 respectively.
+  | RoundingDirectionEnum_Nearest
+    -- ^ A fractional number will be rounded either up or down
+    --   to the specified number of decimal places (the
+    --   precision) depending on its value. For example, 5.24
+    --   would be rounded down to 5.2 and 5.25 would be
+    --   rounded up to 5.3 if a precision of 1 decimal place
+    --   were specified.
+  deriving (Eq, Ord, Show)
 
 -- | Adds an optional spread type element to the Schedule to identify a long or short spread value.
 data SpreadSchedule = SpreadSchedule with

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Fpml/FpmlTypes.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Fpml/FpmlTypes.daml
@@ -60,34 +60,25 @@ data PaymentDates = PaymentDates
     paymentDatesAdjustments : BusinessDayAdjustments
   deriving (Eq, Show)
 
--- | A type defining an offset used in calculating a date
---   when this date is defined in reference to another
---   date through a date offset. The type includes the
---   convention for adjusting the date and an optional
---   sequence element to indicate the order in a sequence
---   of multiple date offsets.
+-- | A type defining an offset used in calculating a date when this date is defined in reference to
+-- another date through a date offset. The type includes the convention for adjusting the date and
+-- an optional sequence element to indicate the order in a sequence of multiple date offsets.
 data DateOffset = DateOffset with
   -- id : Optional Text
   periodMultiplier : Int
-    -- ^ A time period multiplier, e.g. 1, 2 or 3 etc. A
-    --   negative value can be used when specifying an offset
-    --   relative to another date, e.g. -2 days.
+    -- ^ A time period multiplier, e.g. 1, 2 or 3 etc. A negative value can be used when specifying
+    -- an offset relative to another date, e.g. -2 days.
   period : PeriodEnum
-    -- ^ A time period, e.g. a day, week, month or year of the
-    --   stream. If the periodMultiplier value is 0 (zero)
-    --   then period must contain the value D (day).
+    -- ^ A time period, e.g. a day, week, month or year of the stream. If the periodMultiplier value
+    -- is 0 (zero) then period must contain the value D (day).
   dayType : Optional DayTypeEnum
-    -- ^ In the case of an offset specified as a number of
-    --   days, this element defines whether consideration is
-    --   given as to whether a day is a good business day or
-    --   not. If a day type of business days is specified then
-    --   non-business days are ignored when calculating the
-    --   offset. The financial business centers to use for
-    --   determination of business days are implied by the
-    --   context in which this element is used. This element
-    --   must only be included when the offset is specified as
-    --   a number of days. If the offset is zero days then the
-    --   dayType element should not be included.
+    -- ^ In the case of an offset specified as a number of days, this element defines whether
+    -- consideration is given as to whether a day is a good business day or not. If a day type of
+    -- business days is specified then non-business days are ignored when calculating the offset.
+    -- The financial business centers to use for determination of business days are implied by the
+    -- context in which this element is used. This element must only be included when the offset is
+    -- specified as a number of days. If the offset is zero days then the dayType element should not
+    -- be included.
     deriving (Eq, Show)
 
 -- | A type for defining a date that shall be subject to adjustment if it would otherwise fall on a
@@ -242,16 +233,13 @@ data Calculation = Calculation
 -- | The compounding calculation method
 data CompoundingMethodEnum
   = Flat
-    -- ^ Flat compounding. Compounding excludes the spread.
-    --   Note that the first compounding period has it's
-    --   interest calculated including any spread then
-    --   subsequent periods compound this at a rate excluding
-    --   the spread.
+    -- ^ Flat compounding. Compounding excludes the spread. Note that the first compounding period
+    -- has it's interest calculated including any spread then subsequent periods compound this at a
+    -- rate excluding the spread.
   | NoCompounding
     -- ^ No compounding is to be applied.
   | Straight
-    -- ^ Straight compounding. Compounding includes the
-    --   spread.
+    -- ^ Straight compounding. Compounding includes the spread.
   | SpreadExclusive
     -- ^ Spread Exclusive compounding.
   deriving (Eq, Show)
@@ -414,40 +402,31 @@ data FloatingRateCalculation = FloatingRateCalculation with
     --   that is subtracted from the floating rate).
     deriving (Eq, Show)
 
--- | A type defining a rounding direction and precision to
---   be used in the rounding of a rate.
+-- | A type defining a rounding direction and precision to be used in the rounding of a rate.
 data Rounding = Rounding with
   roundingDirection : RoundingDirectionEnum
       -- ^ Specifies the rounding direction.
   precision : Int
-      -- ^ Specifies the rounding precision in terms of a number
-      --   of decimal places. Note how a percentage rate
-      --   rounding of 5 decimal places is expressed as a
-      --   rounding precision of 7 in the FpML document since
-      --   the percentage is expressed as a decimal, e.g.
-      --   9.876543% (or 0.09876543) being rounded to the
-      --   nearest 5 decimal places is 9.87654% (or 0.0987654).
+      -- ^ Specifies the rounding precision in terms of a number  of decimal places. Note how a
+      -- percentage rate rounding of 5 decimal places is expressed as a rounding precision of 7 in
+      -- the FpML document since the percentage is expressed as a decimal, e.g. 9.876543% (or
+      -- 0.09876543) being rounded to the nearest 5 decimal places is 9.87654% (or 0.0987654).
     deriving (Eq, Show)
 
 -- | The method of rounding a fractional number.
 data RoundingDirectionEnum
   = Up
-    -- ^ A fractional number will be rounded up to the
-    --   specified number of decimal places (the precision).
-    --   For example, 5.21 and 5.25 rounded up to 1 decimal
-    --   place are 5.3 and 5.3 respectively.
+    -- ^ A fractional number will be rounded up to the specified number of decimal places (the
+    -- precision). For example, 5.21 and 5.25 rounded up to 1 decimal  place are 5.3 and 5.3
+    -- respectively.
   | Down
-    -- ^ A fractional number will be rounded down to the
-    --   specified number of decimal places (the precision).
-    --   For example, 5.29 and 5.25 rounded down to 1 decimal
-    --   place are 5.2 and 5.2 respectively.
+    -- ^ A fractional number will be rounded down to the specified number of decimal places (the
+    -- precision). For example, 5.29 and 5.25 rounded down to 1 decimal place are 5.2 and 5.2
+    -- respectively.
   | Nearest
-    -- ^ A fractional number will be rounded either up or down
-    --   to the specified number of decimal places (the
-    --   precision) depending on its value. For example, 5.24
-    --   would be rounded down to 5.2 and 5.25 would be
-    --   rounded up to 5.3 if a precision of 1 decimal place
-    --   were specified.
+    -- ^ A fractional number will be rounded either up or down to the specified number of decimal
+    -- places (the precision) depending on its value. For example, 5.24 would be rounded down to 5.2
+    -- and 5.25 would be rounded up to 5.3 if a precision of 1 decimal place were specified.
   deriving (Eq, Show)
 
 -- | Adds an optional spread type element to the Schedule to identify a long or short spread value.

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Fpml/FpmlTypes.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Fpml/FpmlTypes.daml
@@ -315,8 +315,7 @@ data FloatingRateCalculation = FloatingRateCalculation with
     --   calculationPeriodDatesAdjustments. The multiplier can be a positive or negative decimal.
     --   This element should only be included if the multiplier is not equal to 1 (one) for the term
     --   of the stream.
-  -- spreadSchedule : [SpreadSchedule]
-  spreadSchedule : SpreadSchedule
+  spreadSchedule : [SpreadSchedule]
     -- ^ The ISDA Spread or a Spread schedule expressed as explicit spreads and dates. In the case
     --   of a schedule, the step dates may be subject to adjustment in accordance with any
     --   adjustments specified in calculationPeriodDatesAdjustments. The spread is a per annum rate,

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -99,6 +99,7 @@ run = script do
         paymentDatesAdjustments = BusinessDayAdjustments with
             businessDayConvention = ModifiedFollowing
             businessCenters = holidayCalendarId
+        paymentDaysOffset = None
       resetDates = Some ResetDates with
         calculationPeriodDatesReference = "floatingLegCalcPeriodDates"
         resetRelativeTo = CalculationPeriodStartDate
@@ -169,6 +170,7 @@ run = script do
         paymentDatesAdjustments = BusinessDayAdjustments with
             businessDayConvention = ModifiedFollowing
             businessCenters = holidayCalendarId
+        paymentDaysOffset = None
       resetDates = None
       calculationPeriodAmount = CalculationPeriodAmount with
         calculation = Calculation with
@@ -321,6 +323,7 @@ runStubRateInterpolation = script do
         paymentDatesAdjustments = BusinessDayAdjustments with
             businessDayConvention = ModifiedFollowing
             businessCenters = holidayCalendarId
+        paymentDaysOffset = None
       resetDates = Some ResetDates with
         calculationPeriodDatesReference = "floatingLegCalcPeriodDates"
         resetRelativeTo = CalculationPeriodStartDate
@@ -493,6 +496,7 @@ runDualStubSampleTrade = script do
         paymentDatesAdjustments = BusinessDayAdjustments with
             businessDayConvention = ModifiedFollowing
             businessCenters = holidayCalendarId
+        paymentDaysOffset = None
       resetDates = Some ResetDates with
         calculationPeriodDatesReference = "floatingLegCalcPeriodDates"
         resetRelativeTo = CalculationPeriodStartDate
@@ -575,6 +579,7 @@ runDualStubSampleTrade = script do
         paymentDatesAdjustments = BusinessDayAdjustments with
             businessDayConvention = ModifiedFollowing
             businessCenters = holidayCalendarId
+        paymentDaysOffset = None
       resetDates = None
       calculationPeriodAmount = CalculationPeriodAmount with
         calculation = Calculation with
@@ -747,6 +752,7 @@ runSeparatePaymentFrequencySampleTrade = script do
         paymentDatesAdjustments = BusinessDayAdjustments with
             businessDayConvention = ModifiedFollowing
             businessCenters = holidayCalendarId
+        paymentDaysOffset = None
       resetDates = Some ResetDates with
         calculationPeriodDatesReference = "floatingLegCalcPeriodDates"
         resetRelativeTo = CalculationPeriodStartDate
@@ -827,6 +833,7 @@ runSeparatePaymentFrequencySampleTrade = script do
         paymentDatesAdjustments = BusinessDayAdjustments with
             businessDayConvention = ModifiedFollowing
             businessCenters = holidayCalendarId
+        paymentDaysOffset = None
       resetDates = None
       calculationPeriodAmount = CalculationPeriodAmount with
         calculation = Calculation with
@@ -1017,6 +1024,7 @@ runCurrencySwapSampleTrade = script do
         paymentDatesAdjustments = BusinessDayAdjustments with
             businessDayConvention = ModifiedFollowing
             businessCenters = holidayCalendarId
+        paymentDaysOffset = None
       resetDates = Some ResetDates with
         calculationPeriodDatesReference = "eurLegCalcPeriodDates"
         resetRelativeTo = CalculationPeriodStartDate
@@ -1090,6 +1098,7 @@ runCurrencySwapSampleTrade = script do
         paymentDatesAdjustments = BusinessDayAdjustments with
             businessDayConvention = ModifiedFollowing
             businessCenters = holidayCalendarId
+        paymentDaysOffset = None
       resetDates = Some ResetDates with
         calculationPeriodDatesReference = "usdLeg2CalcPeriodDates"
         resetRelativeTo = CalculationPeriodStartDate
@@ -1306,6 +1315,7 @@ runAmortizingNotionalSampleTrade = script do
         paymentDatesAdjustments = BusinessDayAdjustments with
             businessDayConvention = ModifiedFollowing
             businessCenters = holidayCalendarId
+        paymentDaysOffset = None
       resetDates = None
       calculationPeriodAmount = CalculationPeriodAmount with
         calculation = Calculation with
@@ -1370,6 +1380,7 @@ runAmortizingNotionalSampleTrade = script do
         paymentDatesAdjustments = BusinessDayAdjustments with
             businessDayConvention = ModifiedFollowing
             businessCenters = holidayCalendarId
+        paymentDaysOffset = None
       resetDates = Some ResetDates with
         calculationPeriodDatesReference = "floatingLegCalcPeriodDates"
         resetRelativeTo = CalculationPeriodStartDate
@@ -1585,6 +1596,7 @@ run_fpml_1 = script do
         paymentDatesAdjustments = BusinessDayAdjustments with
             businessDayConvention = ModifiedFollowing
             businessCenters = primaryBusinessCenters
+        paymentDaysOffset = None
       resetDates = Some ResetDates with
         calculationPeriodDatesReference = "floatingCalcPeriodDates"
         resetRelativeTo = CalculationPeriodStartDate
@@ -1655,6 +1667,7 @@ run_fpml_1 = script do
         paymentDatesAdjustments = BusinessDayAdjustments with
             businessDayConvention = ModifiedFollowing
             businessCenters = primaryBusinessCenters
+        paymentDaysOffset = None
       resetDates = None
       calculationPeriodAmount = CalculationPeriodAmount with
         calculation = Calculation with
@@ -1805,6 +1818,7 @@ run_fpml_2 = script do
         paymentDatesAdjustments = BusinessDayAdjustments with
             businessDayConvention = ModifiedFollowing
             businessCenters = primaryBusinessCenters
+        paymentDaysOffset = None
       resetDates = Some ResetDates with
         calculationPeriodDatesReference = "floatingCalcPeriodDates"
         resetRelativeTo = CalculationPeriodStartDate
@@ -1904,6 +1918,7 @@ run_fpml_2 = script do
         paymentDatesAdjustments = BusinessDayAdjustments with
             businessDayConvention = ModifiedFollowing
             businessCenters = primaryBusinessCenters
+        paymentDaysOffset = None
       resetDates = None
       calculationPeriodAmount = CalculationPeriodAmount with
         calculation = Calculation with
@@ -2084,13 +2099,13 @@ run_fpml_3 = script do
         firstPaymentDate = None
         lastRegularPaymentDate = None
         payRelativeTo = CalculationPeriodEndDate
-        -- todo: implement Optional payment date offset (similar to fixingDates offset below)
-{-
-        <paymentDaysOffset>
-<periodMultiplier>5</periodMultiplier>
-<period>D</period>
-<dayType>Business</dayType>
- -}
+        {-
+        paymentDaysOffset = Some DateOffset with
+          periodMultiplier = 5
+          period = D
+          dayType = Some Business
+        -}
+        paymentDaysOffset = None -- https://github.com/digital-asset/daml-finance/issues/519
         paymentDatesAdjustments = BusinessDayAdjustments with
             businessDayConvention = ModifiedFollowing
             businessCenters = primaryBusinessCenters
@@ -2124,10 +2139,9 @@ run_fpml_3 = script do
               period = calcPeriodFloat
             spreadSchedule = []
             {-
-            <finalRateRounding>
-            <roundingDirection>Nearest</roundingDirection>
-            <precision>7</precision>
-            </finalRateRounding>
+            finalRateRounding = Some Rounding with
+              roundingDirection = Nearest
+              precision = 7
             -}
             finalRateRounding = None -- https://github.com/digital-asset/daml-finance/issues/518
           dayCountFraction = Act360
@@ -2168,13 +2182,13 @@ run_fpml_3 = script do
         firstPaymentDate = None
         lastRegularPaymentDate = None
         payRelativeTo = CalculationPeriodEndDate
-        -- todo: implement Optional payment date offset (similar to fixingDates offset below)
-{-
-        <paymentDaysOffset>
-<periodMultiplier>5</periodMultiplier>
-<period>D</period>
-<dayType>Business</dayType>
- -}
+        {-
+        paymentDaysOffset = Some DateOffset with
+          periodMultiplier = 5
+          period = D
+          dayType = Some Business
+        -}
+        paymentDaysOffset = None -- https://github.com/digital-asset/daml-finance/issues/519
         paymentDatesAdjustments = BusinessDayAdjustments with
             businessDayConvention = ModifiedFollowing
             businessCenters = primaryBusinessCenters

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -128,6 +128,7 @@ run = script do
               periodMultiplier = paymentPeriodMultiplier
               period = paymentPeriod
             spreadSchedule = []
+            finalRateRounding = None
           dayCountFraction = dayCountConvention
           compoundingMethodEnum = None
       stubCalculationPeriodAmount = None
@@ -349,6 +350,7 @@ runStubRateInterpolation = script do
               periodMultiplier = paymentPeriodMultiplier
               period = paymentPeriod
             spreadSchedule = []
+            finalRateRounding = None
           dayCountFraction = dayCountConvention
           compoundingMethodEnum = None
       stubCalculationPeriodAmount = Some StubCalculationPeriodAmount with
@@ -520,6 +522,7 @@ runDualStubSampleTrade = script do
               periodMultiplier = paymentPeriodMultiplier
               period = paymentPeriod
             spreadSchedule = [SpreadSchedule with initialValue = 0.005]
+            finalRateRounding = None
           dayCountFraction = dayCountConvention
           compoundingMethodEnum = None
       stubCalculationPeriodAmount = Some StubCalculationPeriodAmount with
@@ -773,6 +776,7 @@ runSeparatePaymentFrequencySampleTrade = script do
               periodMultiplier = 6
               period = M
             spreadSchedule = [SpreadSchedule with initialValue = 0.0025]
+            finalRateRounding = None
           dayCountFraction = dayCountConventionFloatingLeg
           compoundingMethodEnum = None
       stubCalculationPeriodAmount = Some StubCalculationPeriodAmount with
@@ -1042,6 +1046,7 @@ runCurrencySwapSampleTrade = script do
               periodMultiplier = paymentPeriodMultiplier
               period = paymentPeriod
             spreadSchedule = []
+            finalRateRounding = None
           dayCountFraction = dayCountConvention
           compoundingMethodEnum = None
       stubCalculationPeriodAmount = None
@@ -1125,6 +1130,7 @@ runCurrencySwapSampleTrade = script do
               periodMultiplier = paymentPeriodMultiplier
               period = paymentPeriod
             spreadSchedule = []
+            finalRateRounding = None
           dayCountFraction = dayCountConvention
           compoundingMethodEnum = None
       stubCalculationPeriodAmount = None
@@ -1416,6 +1422,7 @@ runAmortizingNotionalSampleTrade = script do
               periodMultiplier = paymentPeriodMultiplier
               period = paymentPeriod
             spreadSchedule = []
+            finalRateRounding = None
           dayCountFraction = dayCountConvention
           compoundingMethodEnum = None
       stubCalculationPeriodAmount = Some StubCalculationPeriodAmount with
@@ -1607,6 +1614,7 @@ run_fpml_1 = script do
               periodMultiplier = paymentPeriodMultiplierFloat
               period = paymentPeriodFloat
             spreadSchedule = []
+            finalRateRounding = None
           dayCountFraction = Act360
           compoundingMethodEnum = None
       stubCalculationPeriodAmount = None
@@ -1845,6 +1853,7 @@ run_fpml_2 = script do
               periodMultiplier = paymentPeriodMultiplierFloat
               period = paymentPeriodFloat
             spreadSchedule = []
+            finalRateRounding = None
           dayCountFraction = Act360
           compoundingMethodEnum = None
       stubCalculationPeriodAmount = Some StubCalculationPeriodAmount with
@@ -2113,14 +2122,14 @@ run_fpml_3 = script do
             indexTenor = Some Period with
               periodMultiplier = calcPeriodMultiplierFloat
               period = calcPeriodFloat
-            -- TODO: implement rounding
-{-
-<finalRateRounding>
-<roundingDirection>Nearest</roundingDirection>
-<precision>7</precision>
-</finalRateRounding>
- -}
             spreadSchedule = []
+            {-
+            <finalRateRounding>
+            <roundingDirection>Nearest</roundingDirection>
+            <precision>7</precision>
+            </finalRateRounding>
+            -}
+            finalRateRounding = None -- https://github.com/digital-asset/daml-finance/issues/518
           dayCountFraction = Act360
           -- compoundingMethodEnum = Some Flat
           compoundingMethodEnum = None -- https://github.com/digital-asset/daml-finance/issues/517

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -129,6 +129,7 @@ run = script do
               period = paymentPeriod
             spreadSchedule = []
           dayCountFraction = dayCountConvention
+          compoundingMethodEnum = None
       stubCalculationPeriodAmount = None
       principalExchanges = None
 
@@ -179,6 +180,7 @@ run = script do
           rateTypeValue = RateType_Fixed FixedRateSchedule with
             initialValue = fixRate
           dayCountFraction = dayCountConvention
+          compoundingMethodEnum = None
       stubCalculationPeriodAmount = None
       principalExchanges = None
 
@@ -348,6 +350,7 @@ runStubRateInterpolation = script do
               period = paymentPeriod
             spreadSchedule = []
           dayCountFraction = dayCountConvention
+          compoundingMethodEnum = None
       stubCalculationPeriodAmount = Some StubCalculationPeriodAmount with
         calculationPeriodDatesReference = "floatingLegCalcPeriodDates"
         initialStub = Some $ StubValue_FloatingRate
@@ -518,6 +521,7 @@ runDualStubSampleTrade = script do
               period = paymentPeriod
             spreadSchedule = [SpreadSchedule with initialValue = 0.005]
           dayCountFraction = dayCountConvention
+          compoundingMethodEnum = None
       stubCalculationPeriodAmount = Some StubCalculationPeriodAmount with
         calculationPeriodDatesReference = "floatingLegCalcPeriodDates"
         initialStub = Some $ StubValue_StubRate 0.015
@@ -580,6 +584,8 @@ runDualStubSampleTrade = script do
           rateTypeValue = RateType_Fixed FixedRateSchedule with
             initialValue = fixRate
           dayCountFraction = dayCountConvention
+          -- compoundingMethodEnum = Some Straight
+          compoundingMethodEnum = None -- https://github.com/digital-asset/daml-finance/issues/517
       stubCalculationPeriodAmount = None
       principalExchanges = None
     -- CREATE_FPML_SWAP_FIX_LEG_END
@@ -768,6 +774,7 @@ runSeparatePaymentFrequencySampleTrade = script do
               period = M
             spreadSchedule = [SpreadSchedule with initialValue = 0.0025]
           dayCountFraction = dayCountConventionFloatingLeg
+          compoundingMethodEnum = None
       stubCalculationPeriodAmount = Some StubCalculationPeriodAmount with
         calculationPeriodDatesReference = "floatingLegCalcPeriodDates"
         initialStub = Some $ StubValue_FloatingRate
@@ -828,6 +835,7 @@ runSeparatePaymentFrequencySampleTrade = script do
           rateTypeValue = RateType_Fixed FixedRateSchedule with
             initialValue = fixRate
           dayCountFraction = dayCountConventionFixLeg
+          compoundingMethodEnum = None
       stubCalculationPeriodAmount = None
       principalExchanges = None
 
@@ -1035,6 +1043,7 @@ runCurrencySwapSampleTrade = script do
               period = paymentPeriod
             spreadSchedule = []
           dayCountFraction = dayCountConvention
+          compoundingMethodEnum = None
       stubCalculationPeriodAmount = None
       principalExchanges = Some PrincipalExchanges with
         initialExchange = True
@@ -1117,6 +1126,7 @@ runCurrencySwapSampleTrade = script do
               period = paymentPeriod
             spreadSchedule = []
           dayCountFraction = dayCountConvention
+          compoundingMethodEnum = None
       stubCalculationPeriodAmount = None
       principalExchanges = Some PrincipalExchanges with
         initialExchange = True
@@ -1315,6 +1325,7 @@ runAmortizingNotionalSampleTrade = script do
           rateTypeValue = RateType_Fixed FixedRateSchedule with
             initialValue = fixRate
           dayCountFraction = Basis30360
+          compoundingMethodEnum = None
       stubCalculationPeriodAmount = None
       principalExchanges = None
 
@@ -1406,6 +1417,7 @@ runAmortizingNotionalSampleTrade = script do
               period = paymentPeriod
             spreadSchedule = []
           dayCountFraction = dayCountConvention
+          compoundingMethodEnum = None
       stubCalculationPeriodAmount = Some StubCalculationPeriodAmount with
         calculationPeriodDatesReference = "floatingLegCalcPeriodDates"
         initialStub = Some $ StubValue_FloatingRate
@@ -1548,7 +1560,7 @@ run_fpml_1 = script do
             businessCenters = primaryBusinessCenters
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
-          businessCenters = primaryBusinessCenters -- TODO: implement businessCentersReference?
+          businessCenters = primaryBusinessCenters
         firstRegularPeriodStartDate = None
         lastRegularPeriodEndDate = None
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -1596,6 +1608,7 @@ run_fpml_1 = script do
               period = paymentPeriodFloat
             spreadSchedule = []
           dayCountFraction = Act360
+          compoundingMethodEnum = None
       stubCalculationPeriodAmount = None
       principalExchanges = None
 
@@ -1646,6 +1659,7 @@ run_fpml_1 = script do
           rateTypeValue = RateType_Fixed FixedRateSchedule with
             initialValue = fixRate
           dayCountFraction = Basis30E360
+          compoundingMethodEnum = None
       stubCalculationPeriodAmount = None
       principalExchanges = None
 
@@ -1765,7 +1779,7 @@ run_fpml_2 = script do
             businessCenters = primaryBusinessCenters
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
-          businessCenters = primaryBusinessCenters -- TODO: implement businessCentersReference?
+          businessCenters = primaryBusinessCenters
         firstRegularPeriodStartDate = Some firstRegularDateFloat
         lastRegularPeriodEndDate = None
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -1832,6 +1846,7 @@ run_fpml_2 = script do
               period = paymentPeriodFloat
             spreadSchedule = []
           dayCountFraction = Act360
+          compoundingMethodEnum = None
       stubCalculationPeriodAmount = Some StubCalculationPeriodAmount with
         calculationPeriodDatesReference = "floatingCalcPeriodDates"
         initialStub = Some $ StubValue_FloatingRate
@@ -1908,6 +1923,7 @@ run_fpml_2 = script do
           rateTypeValue = RateType_Fixed FixedRateSchedule with
             initialValue = fixRate
           dayCountFraction = Basis30E360
+          compoundingMethodEnum = None
       stubCalculationPeriodAmount = None
       principalExchanges = None
 
@@ -2044,7 +2060,7 @@ run_fpml_3 = script do
             businessCenters = primaryBusinessCenters
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
-          businessCenters = primaryBusinessCenters -- TODO: implement businessCentersReference?
+          businessCenters = primaryBusinessCenters
         firstRegularPeriodStartDate = None
         lastRegularPeriodEndDate = None
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -2106,10 +2122,8 @@ run_fpml_3 = script do
  -}
             spreadSchedule = []
           dayCountFraction = Act360
-          -- TODO: implement compounding
-{-
-<compoundingMethod>Flat</compoundingMethod>
- -}
+          -- compoundingMethodEnum = Some Flat
+          compoundingMethodEnum = None -- https://github.com/digital-asset/daml-finance/issues/517
       stubCalculationPeriodAmount = None
       principalExchanges = None
 
@@ -2167,6 +2181,7 @@ run_fpml_3 = script do
           rateTypeValue = RateType_Fixed FixedRateSchedule with
             initialValue = fixRate
           dayCountFraction = Basis30360
+          compoundingMethodEnum = None
       stubCalculationPeriodAmount = None
       principalExchanges = None
 

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -1875,10 +1875,10 @@ run_fpml_2 = script do
         initialStub = Some $ StubValue_FloatingRate
           [ StubFloatingRate with
               floatingRateIndex = referenceRate4MId
-              indexTenor = Some (Period with period = M; periodMultiplier = 4)
+              indexTenor = Some Period with period = M; periodMultiplier = 4
           , StubFloatingRate with
               floatingRateIndex = referenceRate5MId
-              indexTenor = Some (Period with period = M; periodMultiplier = 5)
+              indexTenor = Some Period with period = M; periodMultiplier = 5
           ]
         finalStub = None
       principalExchanges = None

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -1974,3 +1974,237 @@ run_fpml_2 = script do
     expectedConsumedQuantities expectedProducedQuantities
 
   pure ()
+
+-- fpml.org Example 3 - Fixed/Floating Single Currency Interest Rate Swap with Compounding, Payment
+-- Delay and Final Rate Rounding
+-- https://www.fpml.org/spec/fpml-5-11-7-rec-1/html/confirmation/fpml-5-11-examples.html#s2
+run_fpml_3 : Script ()
+run_fpml_3 = script do
+  [custodian, issuer, calendarDataProvider, publicParty] <-
+    createParties ["Custodian", "Issuer", "Calendar Data Provider", "PublicParty"]
+
+  -- Create commercial-bank cash
+  now <- getTime
+  let observers = [("PublicParty", singleton publicParty)]
+  cashInstrumentCid <- Instrument.originate custodian issuer "EUR" "Euro" observers now
+
+  -- Create swap
+  let
+    rollDay = 27
+    issueDate = date 2000 Apr rollDay
+    firstRegularDateFloat = date 1995 Jun rollDay
+    firstRegularDateFixed = date 1995 Dec rollDay
+    maturityDate = date 2002 Apr rollDay
+    referenceRateId = "EUR/LIBOR/BBA/3M"
+    fixRate = 0.0585
+    notional = 100000000.0
+    ccy = "EUR"
+    paymentPeriod = M
+    paymentPeriodMultiplier = 6
+    calcPeriodFloat = M
+    calcPeriodMultiplierFloat = 3
+    businessDayConvention = ModifiedFollowing
+    observations = M.fromList
+      [ (dateToDateClockTime (date 2000 Apr 25), 0.063)
+      , (dateToDateClockTime (date 2000 Jul 25), 0.065)
+      , (dateToDateClockTime (date 2000 Oct 25), 0.067)
+      , (dateToDateClockTime (date 2001 Jan 25), 0.069)
+      , (dateToDateClockTime (date 2001 Apr 25), 0.071)
+      ]
+    primaryBusinessCenters = ["GBLO", "USNY"]
+    cal =
+      HolidayCalendarData with
+        id = "USNY"
+        weekend = [Saturday, Sunday]
+        holidays = []
+    fixingBusinessCenters = ["GBLO"]
+    fixingCal =
+      HolidayCalendarData with
+        id = "GBLO"
+        weekend = [Saturday, Sunday]
+        holidays = []
+
+    issuerPartyRef = "party2"
+    clientPartyRef = "party1"
+
+    swapStreamFloatingLeg = SwapStream with
+      payerPartyReference = issuerPartyRef
+      receiverPartyReference = clientPartyRef
+      calculationPeriodDates = CalculationPeriodDates with
+        id = "floatingCalcPeriodDates"
+        effectiveDate = AdjustableDate with
+          unadjustedDate = issueDate
+          dateAdjustments = BusinessDayAdjustments with
+            businessDayConvention = NoAdjustment
+            businessCenters = []
+        terminationDate = AdjustableDate with
+          unadjustedDate = maturityDate
+          dateAdjustments = BusinessDayAdjustments with
+            businessDayConvention = ModifiedFollowing
+            businessCenters = primaryBusinessCenters
+        calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
+          businessDayConvention = ModifiedFollowing
+          businessCenters = primaryBusinessCenters -- TODO: implement businessCentersReference?
+        firstRegularPeriodStartDate = None
+        lastRegularPeriodEndDate = None
+        calculationPeriodFrequency = CalculationPeriodFrequency with
+          periodMultiplier = calcPeriodMultiplierFloat
+          period = calcPeriodFloat
+          rollConvention = DOM rollDay
+      paymentDates = PaymentDates with
+        calculationPeriodDatesReference = "floatingCalcPeriodDates"
+        paymentFrequency = PaymentFrequency with
+          periodMultiplier = paymentPeriodMultiplier
+          period = paymentPeriod
+        firstPaymentDate = None
+        lastRegularPaymentDate = None
+        payRelativeTo = CalculationPeriodEndDate
+        -- todo: implement Optional payment date offset (similar to fixingDates offset below)
+{-
+        <paymentDaysOffset>
+<periodMultiplier>5</periodMultiplier>
+<period>D</period>
+<dayType>Business</dayType>
+ -}
+        paymentDatesAdjustments = BusinessDayAdjustments with
+            businessDayConvention = ModifiedFollowing
+            businessCenters = primaryBusinessCenters
+      resetDates = Some ResetDates with
+        calculationPeriodDatesReference = "floatingCalcPeriodDates"
+        resetRelativeTo = CalculationPeriodStartDate
+        fixingDates = FixingDates with
+          periodMultiplier = -2
+          period = D
+          dayType = Business
+          businessDayConvention = NoAdjustment
+          businessCenters = fixingBusinessCenters
+        resetFrequency = ResetFrequency with
+          periodMultiplier = calcPeriodMultiplierFloat
+          period = calcPeriodFloat
+        resetDatesAdjustments = ResetDatesAdjustments with
+          businessDayConvention = ModifiedFollowing
+          businessCenters = primaryBusinessCenters
+      calculationPeriodAmount = CalculationPeriodAmount with
+        calculation = Calculation with
+          notionalScheduleValue = NotionalSchedule_Regular NotionalSchedule with
+            id = "floatingLegNotionalSchedule"
+            notionalStepSchedule = NotionalStepSchedule with
+              initialValue = notional
+              step = []
+              currency = ccy
+          rateTypeValue = RateType_Floating FloatingRateCalculation with
+            floatingRateIndex = referenceRateId
+            indexTenor = Some Period with
+              periodMultiplier = calcPeriodMultiplierFloat
+              period = calcPeriodFloat
+            -- TODO: implement rounding
+{-
+<finalRateRounding>
+<roundingDirection>Nearest</roundingDirection>
+<precision>7</precision>
+</finalRateRounding>
+ -}
+            spreadSchedule = []
+          dayCountFraction = Act360
+          -- TODO: implement compounding
+{-
+<compoundingMethod>Flat</compoundingMethod>
+ -}
+      stubCalculationPeriodAmount = None
+      principalExchanges = None
+
+    swapStreamFixedLeg = SwapStream with
+      payerPartyReference = clientPartyRef
+      receiverPartyReference = issuerPartyRef
+      calculationPeriodDates = CalculationPeriodDates with
+        id = "fixedCalcPeriodDates"
+        effectiveDate = AdjustableDate with
+          unadjustedDate = issueDate
+          dateAdjustments = BusinessDayAdjustments with
+            businessDayConvention = NoAdjustment
+            businessCenters = []
+        terminationDate = AdjustableDate with
+          unadjustedDate = maturityDate
+          dateAdjustments = BusinessDayAdjustments with
+            businessDayConvention = ModifiedFollowing
+            businessCenters = primaryBusinessCenters
+        calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
+          businessDayConvention = ModifiedFollowing
+          businessCenters = primaryBusinessCenters
+        firstRegularPeriodStartDate = None
+        lastRegularPeriodEndDate = None
+        calculationPeriodFrequency = CalculationPeriodFrequency with
+          periodMultiplier = paymentPeriodMultiplier
+          period = paymentPeriod
+          rollConvention = DOM rollDay
+      paymentDates = PaymentDates with
+        calculationPeriodDatesReference = "fixedCalcPeriodDates"
+        paymentFrequency = PaymentFrequency with
+          periodMultiplier = paymentPeriodMultiplier
+          period = paymentPeriod
+        firstPaymentDate = None
+        lastRegularPaymentDate = None
+        payRelativeTo = CalculationPeriodEndDate
+        -- todo: implement Optional payment date offset (similar to fixingDates offset below)
+{-
+        <paymentDaysOffset>
+<periodMultiplier>5</periodMultiplier>
+<period>D</period>
+<dayType>Business</dayType>
+ -}
+        paymentDatesAdjustments = BusinessDayAdjustments with
+            businessDayConvention = ModifiedFollowing
+            businessCenters = primaryBusinessCenters
+      resetDates = None
+      calculationPeriodAmount = CalculationPeriodAmount with
+        calculation = Calculation with
+          notionalScheduleValue = NotionalSchedule_Regular NotionalSchedule with
+            id = "fixedLegNotionalSchedule"
+            notionalStepSchedule = NotionalStepSchedule with
+              initialValue = notional
+              step = []
+              currency = ccy
+          rateTypeValue = RateType_Fixed FixedRateSchedule with
+            initialValue = fixRate
+          dayCountFraction = Basis30360
+      stubCalculationPeriodAmount = None
+      principalExchanges = None
+
+    swapStreams = [swapStreamFloatingLeg, swapStreamFixedLeg]
+    currencies = [cashInstrumentCid, cashInstrumentCid]
+
+  -- A reference data provider publishes the holiday calendars on the ledger
+  calendarCid <- submit calendarDataProvider do
+    createCmd HolidayCalendar with
+      provider = calendarDataProvider; calendar = cal
+      observers = M.fromList observers
+  fixingCalendarCid <- submit calendarDataProvider do
+    createCmd HolidayCalendar with
+      provider = calendarDataProvider; calendar = fixingCal
+      observers = M.fromList observers
+
+  observableCid <- toInterfaceContractId <$> submit issuer do
+    createCmd Observation with
+      provider = issuer; id = Id referenceRateId; observations; observers = M.empty
+  let observableCids = [observableCid]
+
+  swapInstrument <- originateFpmlSwap custodian issuer "SwapTest1" "Interest rate swap" observers
+    now swapStreams calendarDataProvider currencies issuerPartyRef
+
+  -- First payment date: Lifecycle and verify the fix and floating payments (regular 6M period)
+  let
+    expectedConsumedQuantities = [qty 2925000.0 cashInstrumentCid]
+    expectedProducedQuantities = [qty 3253611.11 cashInstrumentCid]
+  Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
+    (date 2000 Oct 27) swapInstrument issuer observableCids expectedConsumedQuantities
+    expectedProducedQuantities
+
+  -- Second payment date: Lifecycle and verify the fix and floating payments (regular 6M period)
+  let
+    expectedConsumedQuantities = [qty 2925000.0 cashInstrumentCid]
+    expectedProducedQuantities = [qty 3436111.11 cashInstrumentCid]
+  Some swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
+    (date 2001 Apr 27) swapInstrumentAfterFirstPayment issuer observableCids
+    expectedConsumedQuantities expectedProducedQuantities
+
+  pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -1840,15 +1840,15 @@ run_fpml_2 = script do
             id = "floatingLegNotionalSchedule"
             notionalStepSchedule = NotionalStepSchedule with
               initialValue = notional
+              {-
               step =
-{-
                 [ Step with stepDate = date 1995 Dec 14; stepValue = 40000000.0
                 , Step with stepDate = date 1996 Dec 14; stepValue = 30000000.0
                 , Step with stepDate = date 1997 Dec 14; stepValue = 20000000.0
                 , Step with stepDate = date 1998 Dec 14; stepValue = 10000000.0
-                ]
- -}
-
+                ] -- https://github.com/digital-asset/daml-finance/issues/520
+              -}
+              step =
                 [ Step with stepDate = date 1995 Jan 16; stepValue = 50000000.0
                 , Step with stepDate = date 1995 Jun 14; stepValue = 50000000.0
                 , Step with stepDate = date 1995 Dec 14; stepValue = 40000000.0
@@ -1926,15 +1926,14 @@ run_fpml_2 = script do
             id = "fixedLegNotionalSchedule"
             notionalStepSchedule = NotionalStepSchedule with
               initialValue = notional
-{-
+              {-
               step =
                 [ Step with stepDate = date 1995 Dec 14; stepValue = 40000000.0
                 , Step with stepDate = date 1996 Dec 14; stepValue = 30000000.0
                 , Step with stepDate = date 1997 Dec 14; stepValue = 20000000.0
                 , Step with stepDate = date 1998 Dec 14; stepValue = 10000000.0
-                ]
-                 -}
-
+                ] -- https://github.com/digital-asset/daml-finance/issues/520
+              -}
               step =
                 [ Step with stepDate = date 1995 Jan 16; stepValue = 50000000.0
                 , Step with stepDate = date 1995 Dec 14; stepValue = 40000000.0
@@ -1942,7 +1941,6 @@ run_fpml_2 = script do
                 , Step with stepDate = date 1997 Dec 14; stepValue = 20000000.0
                 , Step with stepDate = date 1998 Dec 14; stepValue = 10000000.0
                 ]
-
               currency = ccy
           rateTypeValue = RateType_Fixed FixedRateSchedule with
             initialValue = fixRate

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -1528,10 +1528,10 @@ run_fpml_1 = script do
         id = "DEFR"
         weekend = [Saturday, Sunday]
         holidays = []
-    fixingBusinessCenters = ["LIB"]
+    fixingBusinessCenters = ["GBLO"]
     fixingCal =
       HolidayCalendarData with
-        id = "LIB"
+        id = "GBLO"
         weekend = [Saturday, Sunday]
         holidays = []
 
@@ -1693,6 +1693,291 @@ run_fpml_1 = script do
     expectedProducedQuantities = [qty 1601250.0 cashInstrumentCid]
   Some swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     (date 1995 Dec 14) swapInstrumentAfterFirstPayment issuer observableCids
+    expectedConsumedQuantities expectedProducedQuantities
+
+  pure ()
+
+-- fpml.org Example 2 - Fixed/Floating Single Currency Interest Rate Swap with Initial Stub Period
+-- and Notional Amortization
+-- https://www.fpml.org/spec/fpml-5-11-7-rec-1/html/confirmation/fpml-5-11-examples.html#s2
+run_fpml_2 : Script ()
+run_fpml_2 = script do
+  [custodian, issuer, calendarDataProvider, publicParty] <-
+    createParties ["Custodian", "Issuer", "Calendar Data Provider", "PublicParty"]
+
+  -- Create commercial-bank cash
+  now <- getTime
+  let observers = [("PublicParty", singleton publicParty)]
+  cashInstrumentCid <- Instrument.originate custodian issuer "EUR" "Euro" observers now
+
+  -- Create swap
+  let
+    rollDay = 14
+    issueDate = date 1995 Jan 16
+    firstRegularDateFloat = date 1995 Jun rollDay
+    firstRegularDateFixed = date 1995 Dec rollDay
+    maturityDate = date 1999 Dec rollDay
+    referenceRateId = "EUR/LIBOR/BBA/6M"
+    referenceRate4MId = "EUR/LIBOR/BBA/4M"
+    referenceRate5MId = "EUR/LIBOR/BBA/5M"
+    fixRate = 0.06
+    notional = 50000000.0
+    ccy = "EUR"
+    paymentPeriodFloat = M
+    paymentPeriodMultiplierFloat = 6
+    paymentPeriodFixed = Y
+    paymentPeriodMultiplierFixed = 1
+    businessDayConvention = ModifiedFollowing
+    observations = M.fromList
+      [ (dateToDateClockTime (date 1995 Jun 12), 0.063)
+      , (dateToDateClockTime (date 1995 Dec 12), 0.065)
+      , (dateToDateClockTime (date 1996 Jun 12), 0.065)
+      , (dateToDateClockTime (date 1996 Dec 12), 0.065)
+      ]
+    observations4M = M.fromList
+      [ (dateToDateClockTime (date 1995 Jan 12), 0.050)
+      ]
+    observations5M = M.fromList
+      [ (dateToDateClockTime (date 1995 Jan 12), 0.060)
+      ]
+    primaryBusinessCenters = ["DEFR"]
+    cal =
+      HolidayCalendarData with
+        id = "DEFR"
+        weekend = [Saturday, Sunday]
+        holidays = []
+    fixingBusinessCenters = ["GBLO"]
+    fixingCal =
+      HolidayCalendarData with
+        id = "GBLO"
+        weekend = [Saturday, Sunday]
+        holidays = []
+
+    issuerPartyRef = "party1"
+    clientPartyRef = "party2"
+
+    swapStreamFloatingLeg = SwapStream with
+      payerPartyReference = issuerPartyRef
+      receiverPartyReference = clientPartyRef
+      calculationPeriodDates = CalculationPeriodDates with
+        id = "floatingCalcPeriodDates"
+        effectiveDate = AdjustableDate with
+          unadjustedDate = issueDate
+          dateAdjustments = BusinessDayAdjustments with
+            businessDayConvention = NoAdjustment
+            businessCenters = []
+        terminationDate = AdjustableDate with
+          unadjustedDate = maturityDate
+          dateAdjustments = BusinessDayAdjustments with
+            businessDayConvention = ModifiedFollowing
+            businessCenters = primaryBusinessCenters
+        calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
+          businessDayConvention = ModifiedFollowing
+          businessCenters = primaryBusinessCenters -- TODO: implement businessCentersReference?
+        firstRegularPeriodStartDate = Some firstRegularDateFloat
+        lastRegularPeriodEndDate = None
+        calculationPeriodFrequency = CalculationPeriodFrequency with
+          periodMultiplier = paymentPeriodMultiplierFloat
+          period = paymentPeriodFloat
+          rollConvention = DOM rollDay
+      paymentDates = PaymentDates with
+        calculationPeriodDatesReference = "floatingCalcPeriodDates"
+        paymentFrequency = PaymentFrequency with
+          periodMultiplier = paymentPeriodMultiplierFloat
+          period = paymentPeriodFloat
+        firstPaymentDate = Some firstRegularDateFloat
+        lastRegularPaymentDate = None
+        payRelativeTo = CalculationPeriodEndDate
+        paymentDatesAdjustments = BusinessDayAdjustments with
+            businessDayConvention = ModifiedFollowing
+            businessCenters = primaryBusinessCenters
+      resetDates = Some ResetDates with
+        calculationPeriodDatesReference = "floatingCalcPeriodDates"
+        resetRelativeTo = CalculationPeriodStartDate
+        fixingDates = FixingDates with
+          periodMultiplier = -2
+          period = D
+          dayType = Business
+          businessDayConvention = NoAdjustment
+          businessCenters = fixingBusinessCenters
+        resetFrequency = ResetFrequency with
+          periodMultiplier = paymentPeriodMultiplierFloat
+          period = paymentPeriodFloat
+        resetDatesAdjustments = ResetDatesAdjustments with
+          businessDayConvention = ModifiedFollowing
+          businessCenters = primaryBusinessCenters
+      calculationPeriodAmount = CalculationPeriodAmount with
+        calculation = Calculation with
+          notionalScheduleValue = NotionalSchedule_Regular NotionalSchedule with
+            id = "floatingLegNotionalSchedule"
+            notionalStepSchedule = NotionalStepSchedule with
+              initialValue = notional
+              step =
+{-
+                [ Step with stepDate = date 1995 Dec 14; stepValue = 40000000.0
+                , Step with stepDate = date 1996 Dec 14; stepValue = 30000000.0
+                , Step with stepDate = date 1997 Dec 14; stepValue = 20000000.0
+                , Step with stepDate = date 1998 Dec 14; stepValue = 10000000.0
+                ]
+ -}
+
+                [ Step with stepDate = date 1995 Jan 16; stepValue = 50000000.0
+                , Step with stepDate = date 1995 Jun 14; stepValue = 50000000.0
+                , Step with stepDate = date 1995 Dec 14; stepValue = 40000000.0
+                , Step with stepDate = date 1996 Jun 14; stepValue = 40000000.0
+                , Step with stepDate = date 1996 Dec 14; stepValue = 30000000.0
+                , Step with stepDate = date 1997 Jun 14; stepValue = 30000000.0
+                , Step with stepDate = date 1997 Dec 14; stepValue = 20000000.0
+                , Step with stepDate = date 1998 Jun 14; stepValue = 20000000.0
+                , Step with stepDate = date 1998 Dec 14; stepValue = 10000000.0
+                , Step with stepDate = date 1999 Jun 14; stepValue = 10000000.0
+                ]
+              currency = ccy
+          rateTypeValue = RateType_Floating FloatingRateCalculation with
+            floatingRateIndex = referenceRateId
+            indexTenor = Some Period with
+              periodMultiplier = paymentPeriodMultiplierFloat
+              period = paymentPeriodFloat
+            spreadSchedule = SpreadSchedule with -- TODO: Change to optional or list?
+              initialValue = 0.0
+          dayCountFraction = Act360
+      stubCalculationPeriodAmount = Some StubCalculationPeriodAmount with
+        calculationPeriodDatesReference = "floatingCalcPeriodDates"
+        initialStub = Some $ StubValue_FloatingRate
+          [ StubFloatingRate with
+              floatingRateIndex = referenceRate4MId
+              indexTenor = Some (Period with period = M; periodMultiplier = 4)
+          , StubFloatingRate with
+              floatingRateIndex = referenceRate5MId
+              indexTenor = Some (Period with period = M; periodMultiplier = 5)
+          ]
+        finalStub = None
+      principalExchanges = None
+
+    swapStreamFixedLeg = SwapStream with
+      payerPartyReference = clientPartyRef
+      receiverPartyReference = issuerPartyRef
+      calculationPeriodDates = CalculationPeriodDates with
+        id = "fixedCalcPeriodDates"
+        effectiveDate = AdjustableDate with
+          unadjustedDate = issueDate
+          dateAdjustments = BusinessDayAdjustments with
+            businessDayConvention = NoAdjustment
+            businessCenters = []
+        terminationDate = AdjustableDate with
+          unadjustedDate = maturityDate
+          dateAdjustments = BusinessDayAdjustments with
+            businessDayConvention = ModifiedFollowing
+            businessCenters = primaryBusinessCenters
+        calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
+          businessDayConvention = ModifiedFollowing
+          businessCenters = primaryBusinessCenters
+        firstRegularPeriodStartDate = Some firstRegularDateFixed
+        lastRegularPeriodEndDate = None
+        calculationPeriodFrequency = CalculationPeriodFrequency with
+          periodMultiplier = paymentPeriodMultiplierFixed
+          period = paymentPeriodFixed
+          rollConvention = DOM rollDay
+      paymentDates = PaymentDates with
+        calculationPeriodDatesReference = "fixedCalcPeriodDates"
+        paymentFrequency = PaymentFrequency with
+          periodMultiplier = paymentPeriodMultiplierFixed
+          period = paymentPeriodFixed
+        firstPaymentDate = Some firstRegularDateFixed
+        lastRegularPaymentDate = None
+        payRelativeTo = CalculationPeriodEndDate
+        paymentDatesAdjustments = BusinessDayAdjustments with
+            businessDayConvention = ModifiedFollowing
+            businessCenters = primaryBusinessCenters
+      resetDates = None
+      calculationPeriodAmount = CalculationPeriodAmount with
+        calculation = Calculation with
+          notionalScheduleValue = NotionalSchedule_Regular NotionalSchedule with
+            id = "fixedLegNotionalSchedule"
+            notionalStepSchedule = NotionalStepSchedule with
+              initialValue = notional
+{-
+              step =
+                [ Step with stepDate = date 1995 Dec 14; stepValue = 40000000.0
+                , Step with stepDate = date 1996 Dec 14; stepValue = 30000000.0
+                , Step with stepDate = date 1997 Dec 14; stepValue = 20000000.0
+                , Step with stepDate = date 1998 Dec 14; stepValue = 10000000.0
+                ]
+ -}
+              step =
+                [ Step with stepDate = date 1995 Jan 16; stepValue = 50000000.0
+                , Step with stepDate = date 1995 Dec 14; stepValue = 40000000.0
+                , Step with stepDate = date 1996 Dec 14; stepValue = 30000000.0
+                , Step with stepDate = date 1997 Dec 14; stepValue = 20000000.0
+                , Step with stepDate = date 1998 Dec 14; stepValue = 10000000.0
+                ]
+              currency = ccy
+          rateTypeValue = RateType_Fixed FixedRateSchedule with
+            initialValue = fixRate
+          dayCountFraction = Basis30E360
+      stubCalculationPeriodAmount = None
+      principalExchanges = None
+
+    swapStreams = [swapStreamFloatingLeg, swapStreamFixedLeg]
+    currencies = [cashInstrumentCid, cashInstrumentCid]
+
+  -- A reference data provider publishes the holiday calendars on the ledger
+  calendarCid <- submit calendarDataProvider do
+    createCmd HolidayCalendar with
+      provider = calendarDataProvider; calendar = cal
+      observers = M.fromList observers
+  fixingCalendarCid <- submit calendarDataProvider do
+    createCmd HolidayCalendar with
+      provider = calendarDataProvider; calendar = fixingCal
+      observers = M.fromList observers
+
+  observableCid <- toInterfaceContractId <$> submit issuer do
+    createCmd Observation with
+      provider = issuer; id = Id referenceRateId; observations; observers = M.empty
+  observable4MCid <- toInterfaceContractId <$> submit issuer do
+    createCmd Observation with
+      provider = issuer; id = Id referenceRate4MId; observations=observations4M; observers = M.empty
+  observable5MCid <- toInterfaceContractId <$> submit issuer do
+    createCmd Observation with
+      provider = issuer; id = Id referenceRate5MId; observations=observations5M; observers = M.empty
+  let observableCids = [observableCid, observable4MCid, observable5MCid]
+
+  swapInstrument <- originateFpmlSwap custodian issuer "SwapTest1" "Interest rate swap" observers
+    now swapStreams calendarDataProvider currencies issuerPartyRef
+
+  -- First payment date: Lifecycle and verify the floating payment (short stub period).
+  let
+    expectedConsumedQuantities = []
+    expectedProducedQuantities = [qty 1228315.41 cashInstrumentCid]
+  Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
+    (date 1995 Jun 14) swapInstrument issuer observableCids expectedConsumedQuantities
+    expectedProducedQuantities
+
+  -- Second payment date: Lifecycle and verify the fix and floating payments (regular 6M float
+  -- period, short stub fix period).
+  let
+    expectedConsumedQuantities = [qty 2733333.335 cashInstrumentCid]
+    expectedProducedQuantities = [qty 1601250.0 cashInstrumentCid]
+  Some swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
+    (date 1995 Dec 14) swapInstrumentAfterFirstPayment issuer observableCids
+    expectedConsumedQuantities expectedProducedQuantities
+
+  -- Third payment date: Lifecycle and verify the floating payment (regular 6M period, amortized
+  -- notional).
+  let
+    expectedConsumedQuantities = []
+    expectedProducedQuantities = [qty 1321666.668 cashInstrumentCid]
+  Some swapInstrumentAfterThirdPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
+    (date 1996 Jun 14) swapInstrumentAfterSecondPayment issuer observableCids
+    expectedConsumedQuantities expectedProducedQuantities
+
+  -- Fourth payment date: Lifecycle and verify the fix and floating payments (regular periods:
+  -- 6M float / 1Y fix, amortized notional).
+  let
+    expectedConsumedQuantities = [qty 2413333.332 cashInstrumentCid]
+    expectedProducedQuantities = [qty 1336111.112 cashInstrumentCid]
+  Some swapInstrumentAfterFourthPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
+    (date 1996 Dec 16) swapInstrumentAfterThirdPayment issuer observableCids
     expectedConsumedQuantities expectedProducedQuantities
 
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -1490,3 +1490,209 @@ runAmortizingNotionalSampleTrade = script do
     expectedConsumedQuantities expectedProducedQuantities
 
   pure ()
+
+-- fpml.org Example 1 - Fixed/Floating Single Currency Interest Rate Swap
+-- https://www.fpml.org/spec/fpml-5-11-7-rec-1/html/confirmation/fpml-5-11-examples.html#s2
+run_fpml_1 : Script ()
+run_fpml_1 = script do
+  [custodian, issuer, calendarDataProvider, publicParty] <-
+    createParties ["Custodian", "Issuer", "Calendar Data Provider", "PublicParty"]
+
+  -- Create commercial-bank cash
+  now <- getTime
+  let observers = [("PublicParty", singleton publicParty)]
+  cashInstrumentCid <- Instrument.originate custodian issuer "EUR" "Euro" observers now
+
+  -- Create swap
+  let
+    rollDay = 14
+    issueDate = date 1994 Dec rollDay
+    maturityDate = date 1999 Dec rollDay
+    referenceRateId = "EUR/LIBOR/BBA/6M"
+    fixRate = 0.06
+    notional = 50000000.0
+    ccy = "EUR"
+    paymentPeriodFloat = M
+    paymentPeriodMultiplierFloat = 6
+    paymentPeriodFixed = Y
+    paymentPeriodMultiplierFixed = 1
+    businessDayConvention = ModifiedFollowing
+    observations = M.fromList
+      [ (dateToDateClockTime (date 1994 Dec 12), 0.061)
+      , (dateToDateClockTime (date 1995 Jun 12), 0.063)
+      , (dateToDateClockTime (date 1995 Dec 12), 0.065)
+      ]
+    primaryBusinessCenters = ["DEFR"]
+    cal =
+      HolidayCalendarData with
+        id = "DEFR"
+        weekend = [Saturday, Sunday]
+        holidays = []
+    fixingBusinessCenters = ["LIB"]
+    fixingCal =
+      HolidayCalendarData with
+        id = "LIB"
+        weekend = [Saturday, Sunday]
+        holidays = []
+
+    issuerPartyRef = "party1"
+    clientPartyRef = "party2"
+
+    swapStreamFloatingLeg = SwapStream with
+      payerPartyReference = issuerPartyRef
+      receiverPartyReference = clientPartyRef
+      calculationPeriodDates = CalculationPeriodDates with
+        id = "floatingCalcPeriodDates"
+        effectiveDate = AdjustableDate with
+          unadjustedDate = issueDate
+          dateAdjustments = BusinessDayAdjustments with
+            businessDayConvention = NoAdjustment
+            businessCenters = []
+        terminationDate = AdjustableDate with
+          unadjustedDate = maturityDate
+          dateAdjustments = BusinessDayAdjustments with
+            businessDayConvention = ModifiedFollowing
+            businessCenters = primaryBusinessCenters
+        calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
+          businessDayConvention = ModifiedFollowing
+          businessCenters = primaryBusinessCenters -- TODO: implement businessCentersReference?
+        firstRegularPeriodStartDate = None
+        lastRegularPeriodEndDate = None
+        calculationPeriodFrequency = CalculationPeriodFrequency with
+          periodMultiplier = paymentPeriodMultiplierFloat
+          period = paymentPeriodFloat
+          rollConvention = DOM rollDay
+      paymentDates = PaymentDates with
+        calculationPeriodDatesReference = "floatingCalcPeriodDates"
+        paymentFrequency = PaymentFrequency with
+          periodMultiplier = paymentPeriodMultiplierFloat
+          period = paymentPeriodFloat
+        firstPaymentDate = None
+        lastRegularPaymentDate = None
+        payRelativeTo = CalculationPeriodEndDate
+        paymentDatesAdjustments = BusinessDayAdjustments with
+            businessDayConvention = ModifiedFollowing
+            businessCenters = primaryBusinessCenters
+      resetDates = Some ResetDates with
+        calculationPeriodDatesReference = "floatingCalcPeriodDates"
+        resetRelativeTo = CalculationPeriodStartDate
+        fixingDates = FixingDates with
+          periodMultiplier = -2
+          period = D
+          dayType = Business
+          businessDayConvention = NoAdjustment
+          businessCenters = fixingBusinessCenters
+        resetFrequency = ResetFrequency with
+          periodMultiplier = paymentPeriodMultiplierFloat
+          period = paymentPeriodFloat
+        resetDatesAdjustments = ResetDatesAdjustments with
+          businessDayConvention = ModifiedFollowing
+          businessCenters = primaryBusinessCenters
+      calculationPeriodAmount = CalculationPeriodAmount with
+        calculation = Calculation with
+          notionalScheduleValue = NotionalSchedule_Regular NotionalSchedule with
+            id = "floatingLegNotionalSchedule"
+            notionalStepSchedule = NotionalStepSchedule with
+              initialValue = notional
+              step = []
+              currency = ccy
+          rateTypeValue = RateType_Floating FloatingRateCalculation with
+            floatingRateIndex = referenceRateId
+            indexTenor = Some Period with
+              periodMultiplier = paymentPeriodMultiplierFloat
+              period = paymentPeriodFloat
+            spreadSchedule = SpreadSchedule with -- TODO: Change to optional or list?
+              initialValue = 0.0
+          dayCountFraction = Act360
+      stubCalculationPeriodAmount = None
+      principalExchanges = None
+
+    swapStreamFixedLeg = SwapStream with
+      payerPartyReference = clientPartyRef
+      receiverPartyReference = issuerPartyRef
+      calculationPeriodDates = CalculationPeriodDates with
+        id = "fixedCalcPeriodDates"
+        effectiveDate = AdjustableDate with
+          unadjustedDate = issueDate
+          dateAdjustments = BusinessDayAdjustments with
+            businessDayConvention = NoAdjustment
+            businessCenters = []
+        terminationDate = AdjustableDate with
+          unadjustedDate = maturityDate
+          dateAdjustments = BusinessDayAdjustments with
+            businessDayConvention = ModifiedFollowing
+            businessCenters = primaryBusinessCenters
+        calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
+          businessDayConvention = ModifiedFollowing
+          businessCenters = primaryBusinessCenters
+        firstRegularPeriodStartDate = None
+        lastRegularPeriodEndDate = None
+        calculationPeriodFrequency = CalculationPeriodFrequency with
+          periodMultiplier = paymentPeriodMultiplierFixed
+          period = paymentPeriodFixed
+          rollConvention = DOM rollDay
+      paymentDates = PaymentDates with
+        calculationPeriodDatesReference = "fixedCalcPeriodDates"
+        paymentFrequency = PaymentFrequency with
+          periodMultiplier = paymentPeriodMultiplierFixed
+          period = paymentPeriodFixed
+        firstPaymentDate = None
+        lastRegularPaymentDate = None
+        payRelativeTo = CalculationPeriodEndDate
+        paymentDatesAdjustments = BusinessDayAdjustments with
+            businessDayConvention = ModifiedFollowing
+            businessCenters = primaryBusinessCenters
+      resetDates = None
+      calculationPeriodAmount = CalculationPeriodAmount with
+        calculation = Calculation with
+          notionalScheduleValue = NotionalSchedule_Regular NotionalSchedule with
+            id = "fixedLegNotionalSchedule"
+            notionalStepSchedule = NotionalStepSchedule with
+              initialValue = notional
+              step = []
+              currency = ccy
+          rateTypeValue = RateType_Fixed FixedRateSchedule with
+            initialValue = fixRate
+          dayCountFraction = Basis30E360
+      stubCalculationPeriodAmount = None
+      principalExchanges = None
+
+    swapStreams = [swapStreamFloatingLeg, swapStreamFixedLeg]
+    currencies = [cashInstrumentCid, cashInstrumentCid]
+
+  -- A reference data provider publishes the holiday calendars on the ledger
+  calendarCid <- submit calendarDataProvider do
+    createCmd HolidayCalendar with
+      provider = calendarDataProvider; calendar = cal
+      observers = M.fromList observers
+  fixingCalendarCid <- submit calendarDataProvider do
+    createCmd HolidayCalendar with
+      provider = calendarDataProvider; calendar = fixingCal
+      observers = M.fromList observers
+
+  observableCid <- toInterfaceContractId <$> submit issuer do
+    createCmd Observation with
+      provider = issuer; id = Id referenceRateId; observations; observers = M.empty
+  let observableCids = [observableCid]
+
+  swapInstrument <- originateFpmlSwap custodian issuer "SwapTest1" "Interest rate swap" observers
+    now swapStreams calendarDataProvider currencies issuerPartyRef
+
+  -- First payment date: Lifecycle and verify the floating payment (regular period, 6M).
+  let
+    expectedConsumedQuantities = []
+    expectedProducedQuantities = [qty 1541944.445 cashInstrumentCid]
+  Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
+    (date 1995 Jun 14) swapInstrument issuer observableCids expectedConsumedQuantities
+    expectedProducedQuantities
+
+  -- Second payment date: Lifecycle and verify the fix and floating payments (regular period,
+  -- 6M float vs 12M fix).
+  let
+    expectedConsumedQuantities = [qty 3000000.0 cashInstrumentCid]
+    expectedProducedQuantities = [qty 1601250.0 cashInstrumentCid]
+  Some swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
+    (date 1995 Dec 14) swapInstrumentAfterFirstPayment issuer observableCids
+    expectedConsumedQuantities expectedProducedQuantities
+
+  pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -127,8 +127,7 @@ run = script do
             indexTenor = Some Period with
               periodMultiplier = paymentPeriodMultiplier
               period = paymentPeriod
-            spreadSchedule = SpreadSchedule with
-              initialValue = 0.0
+            spreadSchedule = []
           dayCountFraction = dayCountConvention
       stubCalculationPeriodAmount = None
       principalExchanges = None
@@ -347,8 +346,7 @@ runStubRateInterpolation = script do
             indexTenor = Some Period with
               periodMultiplier = paymentPeriodMultiplier
               period = paymentPeriod
-            spreadSchedule = SpreadSchedule with
-              initialValue = 0.0
+            spreadSchedule = []
           dayCountFraction = dayCountConvention
       stubCalculationPeriodAmount = Some StubCalculationPeriodAmount with
         calculationPeriodDatesReference = "floatingLegCalcPeriodDates"
@@ -518,8 +516,7 @@ runDualStubSampleTrade = script do
             indexTenor = Some Period with
               periodMultiplier = paymentPeriodMultiplier
               period = paymentPeriod
-            spreadSchedule = SpreadSchedule with
-              initialValue = 0.005
+            spreadSchedule = [SpreadSchedule with initialValue = 0.005]
           dayCountFraction = dayCountConvention
       stubCalculationPeriodAmount = Some StubCalculationPeriodAmount with
         calculationPeriodDatesReference = "floatingLegCalcPeriodDates"
@@ -769,8 +766,7 @@ runSeparatePaymentFrequencySampleTrade = script do
             indexTenor = Some Period with
               periodMultiplier = 6
               period = M
-            spreadSchedule = SpreadSchedule with
-              initialValue = 0.0025
+            spreadSchedule = [SpreadSchedule with initialValue = 0.0025]
           dayCountFraction = dayCountConventionFloatingLeg
       stubCalculationPeriodAmount = Some StubCalculationPeriodAmount with
         calculationPeriodDatesReference = "floatingLegCalcPeriodDates"
@@ -1037,8 +1033,7 @@ runCurrencySwapSampleTrade = script do
             indexTenor = Some Period with
               periodMultiplier = paymentPeriodMultiplier
               period = paymentPeriod
-            spreadSchedule = SpreadSchedule with -- make optional?
-              initialValue = 0.0
+            spreadSchedule = []
           dayCountFraction = dayCountConvention
       stubCalculationPeriodAmount = None
       principalExchanges = Some PrincipalExchanges with
@@ -1120,8 +1115,7 @@ runCurrencySwapSampleTrade = script do
             indexTenor = Some Period with
               periodMultiplier = paymentPeriodMultiplier
               period = paymentPeriod
-            spreadSchedule = SpreadSchedule with
-              initialValue = 0.0
+            spreadSchedule = []
           dayCountFraction = dayCountConvention
       stubCalculationPeriodAmount = None
       principalExchanges = Some PrincipalExchanges with
@@ -1410,8 +1404,7 @@ runAmortizingNotionalSampleTrade = script do
             indexTenor = Some Period with
               periodMultiplier = paymentPeriodMultiplier
               period = paymentPeriod
-            spreadSchedule = SpreadSchedule with -- make optional?
-              initialValue = 0.0
+            spreadSchedule = []
           dayCountFraction = dayCountConvention
       stubCalculationPeriodAmount = Some StubCalculationPeriodAmount with
         calculationPeriodDatesReference = "floatingLegCalcPeriodDates"
@@ -1601,8 +1594,7 @@ run_fpml_1 = script do
             indexTenor = Some Period with
               periodMultiplier = paymentPeriodMultiplierFloat
               period = paymentPeriodFloat
-            spreadSchedule = SpreadSchedule with -- TODO: Change to optional or list?
-              initialValue = 0.0
+            spreadSchedule = []
           dayCountFraction = Act360
       stubCalculationPeriodAmount = None
       principalExchanges = None
@@ -1838,8 +1830,7 @@ run_fpml_2 = script do
             indexTenor = Some Period with
               periodMultiplier = paymentPeriodMultiplierFloat
               period = paymentPeriodFloat
-            spreadSchedule = SpreadSchedule with -- TODO: Change to optional or list?
-              initialValue = 0.0
+            spreadSchedule = []
           dayCountFraction = Act360
       stubCalculationPeriodAmount = Some StubCalculationPeriodAmount with
         calculationPeriodDatesReference = "floatingCalcPeriodDates"
@@ -1903,7 +1894,8 @@ run_fpml_2 = script do
                 , Step with stepDate = date 1997 Dec 14; stepValue = 20000000.0
                 , Step with stepDate = date 1998 Dec 14; stepValue = 10000000.0
                 ]
- -}
+                 -}
+
               step =
                 [ Step with stepDate = date 1995 Jan 16; stepValue = 50000000.0
                 , Step with stepDate = date 1995 Dec 14; stepValue = 40000000.0
@@ -1911,6 +1903,7 @@ run_fpml_2 = script do
                 , Step with stepDate = date 1997 Dec 14; stepValue = 20000000.0
                 , Step with stepDate = date 1998 Dec 14; stepValue = 10000000.0
                 ]
+
               currency = ccy
           rateTypeValue = RateType_Fixed FixedRateSchedule with
             initialValue = fixRate

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -220,11 +220,6 @@ lifecycleAndVerifySwapPaymentEffects readAs today swapInstrument issuer
     effectView <- submit issuer do
       exerciseCmd effectCid Effect.GetView with viewer = issuer
 
-    debug expectedConsumedQuantities
-    debug effectView.otherConsumed
-    debug expectedProducedQuantities
-    debug effectView.otherProduced
-
     -- Verify that the consumed/produced quantities match the expected ones
     assertMsg "The consumed quantities do not match the expected ones" $
       sort expectedConsumedQuantities == sort effectView.otherConsumed

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -220,6 +220,11 @@ lifecycleAndVerifySwapPaymentEffects readAs today swapInstrument issuer
     effectView <- submit issuer do
       exerciseCmd effectCid Effect.GetView with viewer = issuer
 
+    debug expectedConsumedQuantities
+    debug effectView.otherConsumed
+    debug expectedProducedQuantities
+    debug effectView.otherProduced
+
     -- Verify that the consumed/produced quantities match the expected ones
     assertMsg "The consumed quantities do not match the expected ones" $
       sort expectedConsumedQuantities == sort effectView.otherConsumed


### PR DESCRIPTION
Implement selected, official FpML IRS examples as test cases, the first 3 of these:
https://www.fpml.org/spec/fpml-5-11-7-rec-1/html/confirmation/fpml-5-11-examples.html#s2

- Example 1 - Fixed/Floating Single Currency Interest Rate Swap
- Example 2 - Fixed/Floating Single Currency Interest Rate Swap with Initial Stub Period and Notional Amortization
- Example 3 - Fixed/Floating Single Currency Interest Rate Swap with Compounding, Payment Delay and Final Rate Rounding

Turns out four new features are needed to cover these properly. I have opened separate issues for that. In order to make this easier to review, I have so far implemented these sample trades using currently supported configurations and added links to issues in the Test. I plan to cover those one PR at a time.