### PR TITLE
Implement straight compounding of interest for FpML swaps

### DIFF
--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -336,9 +336,9 @@ roundRate rate rounding =
 calculateCompoundedFloatingPaymentClaimsFromSwapStream : FloatingRateCalculation -> SwapStream ->
   PeriodicSchedule -> [SchedulePeriod] -> [SchedulePeriod] -> Bool -> Bool -> Deliverable ->
   Party -> Party -> Optional Text -> Optional [Date] -> [(Decimal, Bool)] -> Update [TaggedClaim]
-calculateCompoundedFloatingPaymentClaimsFromSwapStream floatingRateCalculation s periodicSchedule
-  calculationSchedule paymentSchedule useAdjustedDatesForDcf issuerPaysLeg currency issuer
-  calendarDataAgency fxRateId fxFixingDates notionals = do
+calculateCompoundedFloatingPaymentClaimsFromSwapStream floatingRateCalculation s 
+periodicSchedule calculationSchedule paymentSchedule useAdjustedDatesForDcf issuerPaysLeg currency 
+issuer calendarDataAgency fxRateId fxFixingDates notionals = do
     assertMsg "rate rounding not yet supported" $ isNone floatingRateCalculation.finalRateRounding
     (rateFixingDates, rateFixingCalendar) <- getRateFixingsAndCalendars s (fromSome s.resetDates)
       calculationSchedule issuer calendarDataAgency

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -336,9 +336,9 @@ roundRate rate rounding =
 calculateCompoundedFloatingPaymentClaimsFromSwapStream : FloatingRateCalculation -> SwapStream ->
   PeriodicSchedule -> [SchedulePeriod] -> [SchedulePeriod] -> Bool -> Bool -> Deliverable ->
   Party -> Party -> Optional Text -> Optional [Date] -> [(Decimal, Bool)] -> Update [TaggedClaim]
-calculateCompoundedFloatingPaymentClaimsFromSwapStream floatingRateCalculation s 
-periodicSchedule calculationSchedule paymentSchedule useAdjustedDatesForDcf issuerPaysLeg currency 
-issuer calendarDataAgency fxRateId fxFixingDates notionals = do
+calculateCompoundedFloatingPaymentClaimsFromSwapStream floatingRateCalculation s
+  periodicSchedule calculationSchedule paymentSchedule useAdjustedDatesForDcf issuerPaysLeg currency
+  issuer calendarDataAgency fxRateId fxFixingDates notionals = do
     assertMsg "rate rounding not yet supported" $ isNone floatingRateCalculation.finalRateRounding
     (rateFixingDates, rateFixingCalendar) <- getRateFixingsAndCalendars s (fromSome s.resetDates)
       calculationSchedule issuer calendarDataAgency

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -9,7 +9,7 @@ import DA.BigNumeric qualified as BN
 import DA.Date
 import DA.Foldable (foldMap)
 import DA.List (dedup, head, init, last, tail)
-import DA.Optional (fromOptional, fromSome, isNone, isSome)
+import DA.Optional (fromOptional, fromSome, isNone, isSome, whenSome)
 import Daml.Finance.Claims.Util.Builders (prepareAndTagClaims)
 import Daml.Finance.Instrument.Swap.Util
 import Daml.Finance.Interface.Claims.Types (Deliverable, Observable, TaggedClaim(..))
@@ -343,10 +343,9 @@ calculateCompoundedFloatingPaymentClaimsFromSwapStream floatingRateCalculation s
     (rateFixingDates, rateFixingCalendar) <- getRateFixingsAndCalendars s (fromSome s.resetDates)
       calculationSchedule issuer calendarDataAgency
 
-    case fxFixingDates of
-      Some fxDates ->
-        assertMsg "fxFixingDates must match rateFixingDates" $ fxDates == rateFixingDates
-      None -> assertMsg "No fx fixing dates provided" True
+    whenSome fxFixingDates $ \fxDates ->
+      assertMsg "fxFixingDates must match rateFixingDates" $ fxDates == rateFixingDates
+
     let
       fixLeg = False
       calculationNotionalFixings = zip3 calculationSchedule notionals rateFixingDates
@@ -395,18 +394,16 @@ calculateCompoundedFloatingPaymentClaimsFromSwapStream floatingRateCalculation s
             where
               dcf = Const (calcPeriodDcf s.calculationPeriodAmount.calculation.dayCountFraction c
                 useAdjustedDatesForDcf periodicSchedule.terminationDate periodicSchedule.frequency)
-              rate = case c.stubType of
-                None -> regularRate
-                Some stubType -> case s.stubCalculationPeriodAmount of
-                  None -> regularRate
-                  Some scpa -> fromOptional regularRate $
-                    getStubRate
-                      scpa
-                      (stubType == LongInitial || stubType == ShortInitial)
-                      p
-                      rateFixingCalendar
-                      s.calculationPeriodDates.calculationPeriodDatesAdjustments.businessDayConvention
-                      fixLeg
+              rate = case (c.stubType, s.stubCalculationPeriodAmount) of
+                (Some stubType, Some scpa) -> fromOptional regularRate $
+                  getStubRate
+                    scpa
+                    (stubType == LongInitial || stubType == ShortInitial)
+                    p
+                    rateFixingCalendar
+                    s.calculationPeriodDates.calculationPeriodDatesAdjustments.businessDayConvention
+                    fixLeg
+                _ -> regularRate
 
           compoundedRates = foldl
             foldRates
@@ -446,10 +443,8 @@ calculateFloatingPaymentClaimsFromSwapStream floatingRateCalculation s periodicS
     assertMsg "rate rounding not yet supported" $ isNone floatingRateCalculation.finalRateRounding
     (rateFixingDates, rateFixingCalendar) <- getRateFixingsAndCalendars s (fromSome s.resetDates)
       calculationSchedule issuer calendarDataAgency
-    case fxFixingDates of
-      Some fxDates ->
-        assertMsg "fxFixingDates must match rateFixingDates" $ fxDates == rateFixingDates
-      None -> assertMsg "No fx fixing dates provided" True
+    whenSome fxFixingDates $ \fxDates ->
+      assertMsg "fxFixingDates must match rateFixingDates" $ fxDates == rateFixingDates
     let
       fixLeg = False
       -- calculate floating rate claims
@@ -473,18 +468,16 @@ calculateFloatingPaymentClaimsFromSwapStream floatingRateCalculation s periodicS
             _ -> error "Multiple SpreadSchedules not yet supported"
           referenceRateId = floatingRateCalculation.floatingRateIndex
           regularRate = Observe referenceRateId + Const floatingRateSpread
-          rate = case c.stubType of
-            None -> regularRate
-            Some stubType -> case s.stubCalculationPeriodAmount of
-              None -> regularRate
-              Some scpa -> fromOptional regularRate $
-                getStubRate
-                  scpa
-                  (stubType == LongInitial || stubType == ShortInitial)
-                  p
-                  rateFixingCalendar
-                  s.calculationPeriodDates.calculationPeriodDatesAdjustments.businessDayConvention
-                  fixLeg
+          rate = case (c.stubType, s.stubCalculationPeriodAmount) of
+            (Some stubType, Some scpa) -> fromOptional regularRate $
+              getStubRate
+                scpa
+                (stubType == LongInitial || stubType == ShortInitial)
+                p
+                rateFixingCalendar
+                s.calculationPeriodDates.calculationPeriodDatesAdjustments.businessDayConvention
+                fixLeg
+            _ -> regularRate
       claimAmounts = mconcat $ zipWith3 createClaim (zip calculationSchedule notionals)
         paymentScheduleAligned rateFixingDates
       claims = if issuerPaysLeg then claimAmounts else give claimAmounts

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -330,8 +330,9 @@ roundRate rate rounding =
         Nearest -> RoundingHalfUp
 
 -- | Create claims from swapStream that describes a floating coupon stream.
--- This function can handle compounding of rates.
--- TODO: integrate this in calculateFloatingPaymentClaimsFromSwapStream
+-- This function can handle compounding of rates (currently only straight compounding)
+-- Integrate this in calculateFloatingPaymentClaimsFromSwapStream once the other compounding
+-- methods have been implemented.
 calculateCompoundedFloatingPaymentClaimsFromSwapStream : FloatingRateCalculation -> SwapStream ->
   PeriodicSchedule -> [SchedulePeriod] -> [SchedulePeriod] -> Bool -> Bool -> Deliverable ->
   Party -> Party -> Optional Text -> Optional [Date] -> [(Decimal, Bool)] -> Update [TaggedClaim]
@@ -551,9 +552,6 @@ calculateClaimsFromSwapStream s periodicSchedule calculationSchedule paymentSche
     assertMsg "notionals list must be of same length as calculationSchedule" $
       length notionals == length calculationSchedule
     paymentScheduleAligned <- alignPaymentSchedule calculationSchedule paymentSchedule
-    debug paymentSchedule
-    debug paymentScheduleAligned
-    -- TODO: move paymentScheduleAligned to fixed leg only, not needed for floating (driven off payment dates)
     case s.calculationPeriodAmount.calculation.rateTypeValue of
       RateType_Fixed fixedRateSchedule ->
         calculateFixPaymentClaimsFromSwapStream fixedRateSchedule s periodicSchedule

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -435,11 +435,12 @@ calculateCompoundedFloatingPaymentClaimsFromSwapStream floatingRateCalculation s
 
 -- | Create claims from swapStream that describes a floating coupon stream.
 calculateFloatingPaymentClaimsFromSwapStream : FloatingRateCalculation -> SwapStream ->
-  PeriodicSchedule -> [SchedulePeriod] -> [SchedulePeriod] -> Bool -> Bool -> Deliverable ->
-  Party -> Party -> Optional Text -> Optional [Date] -> [(Decimal, Bool)] -> Update [TaggedClaim]
-calculateFloatingPaymentClaimsFromSwapStream floatingRateCalculation s periodicSchedule
-  calculationSchedule paymentScheduleAligned useAdjustedDatesForDcf issuerPaysLeg currency issuer
-  calendarDataAgency fxRateId fxFixingDates notionals = do
+  PeriodicSchedule -> [SchedulePeriod] -> [SchedulePeriod] -> Bool -> Bool ->
+  Deliverable -> Party -> Party -> Optional Text -> Optional [Date] -> [(Decimal, Bool)] ->
+  Update [TaggedClaim]
+calculateFloatingPaymentClaimsFromSwapStream floatingRateCalculation s
+  periodicSchedule calculationSchedule paymentScheduleAligned useAdjustedDatesForDcf issuerPaysLeg
+  currency issuer calendarDataAgency fxRateId fxFixingDates notionals = do
     assertMsg "rate rounding not yet supported" $ isNone floatingRateCalculation.finalRateRounding
     (rateFixingDates, rateFixingCalendar) <- getRateFixingsAndCalendars s (fromSome s.resetDates)
       calculationSchedule issuer calendarDataAgency

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -386,6 +386,7 @@ calculateFloatingPaymentClaimsFromSwapStream floatingRateCalculation s periodicS
           where
             principalClaimsTagged = calculatePrincipalExchangePaymentClaims paymentScheduleAligned
               issuerPaysLeg currency fxRateId notionals rateFixingDates principalExchanges
+    debug allTaggedClaims
     pure allTaggedClaims
 
 -- | Create claims from swapStream that describes a fixed or floating coupon stream.

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -8,7 +8,7 @@ import ContingentClaims.Core.Observation (Observation(..))
 import DA.BigNumeric qualified as BN
 import DA.Date
 import DA.Foldable (foldMap)
-import DA.List (head, init, last, tail)
+import DA.List (dedup, head, init, last, tail)
 import DA.Optional (fromOptional, fromSome, isNone, isSome)
 import Daml.Finance.Claims.Util.Builders (prepareAndTagClaims)
 import Daml.Finance.Instrument.Swap.Util
@@ -229,7 +229,7 @@ getRateFixingsAndCalendars s r calculationSchedule issuer calendarDataAgency = d
       ) calculationSchedule
   pure (rateFixingDates, rateFixingCalendar)
 
--- | Create claims from swapStream that describes a fixed or floating coupon stream.
+-- | Create claims from swapStream that describes a fixed coupon stream.
 calculateFixPaymentClaimsFromSwapStream : FixedRateSchedule -> SwapStream -> PeriodicSchedule ->
   [SchedulePeriod] -> [SchedulePeriod] -> Bool -> Bool -> Deliverable -> Party -> Party ->
   Optional Text -> Optional [Date] -> [(Decimal, Bool)] -> Update [TaggedClaim]
@@ -240,6 +240,8 @@ calculateFixPaymentClaimsFromSwapStream fixedRateSchedule s periodicSchedule cal
       isNone s.principalExchanges
     assertMsg "Non-standard stub rates not supported for the fixed rate leg" $
       isNone s.stubCalculationPeriodAmount
+    assertMsg "Compounding not supported for the fixed rate leg" $
+      isNone s.calculationPeriodAmount.calculation.compoundingMethodEnum
     let
       -- calculate fix rate claims
       createClaim (c, (n, fxAdjRequired)) p =
@@ -327,7 +329,113 @@ roundRate rate rounding =
         Down -> RoundingFloor
         Nearest -> RoundingHalfUp
 
--- | Create claims from swapStream that describes a fixed or floating coupon stream.
+-- | Create claims from swapStream that describes a floating coupon stream.
+-- This function can handle compounding of rates.
+-- TODO: integrate this in calculateFloatingPaymentClaimsFromSwapStream
+calculateCompoundedFloatingPaymentClaimsFromSwapStream : FloatingRateCalculation -> SwapStream ->
+  PeriodicSchedule -> [SchedulePeriod] -> [SchedulePeriod] -> Bool -> Bool -> Deliverable ->
+  Party -> Party -> Optional Text -> Optional [Date] -> [(Decimal, Bool)] -> Update [TaggedClaim]
+calculateCompoundedFloatingPaymentClaimsFromSwapStream floatingRateCalculation s periodicSchedule
+  calculationSchedule paymentSchedule useAdjustedDatesForDcf issuerPaysLeg currency issuer
+  calendarDataAgency fxRateId fxFixingDates notionals = do
+    assertMsg "rate rounding not yet supported" $ isNone floatingRateCalculation.finalRateRounding
+    (rateFixingDates, rateFixingCalendar) <- getRateFixingsAndCalendars s (fromSome s.resetDates)
+      calculationSchedule issuer calendarDataAgency
+
+    case fxFixingDates of
+      Some fxDates ->
+        assertMsg "fxFixingDates must match rateFixingDates" $ fxDates == rateFixingDates
+      None -> assertMsg "No fx fixing dates provided" True
+    let
+      fixLeg = False
+      calculationNotionalFixings = zip3 calculationSchedule notionals rateFixingDates
+
+      -- calculate the notional and fixing dates for a payment period
+      calculateNotionalAndFixings p =
+        (notional, fxAdjRequired, calculationNotionalFixingsFiltered)
+          where
+            calculationNotionalFixingsFiltered = filter (\(c, nf, f) ->
+              c.unadjustedEndDate <= p.unadjustedEndDate &&
+              c.unadjustedStartDate >= p.unadjustedStartDate)
+              calculationNotionalFixings
+
+            -- Ensure that all notionals and fxAdjRequireds are the same for each paymentPeriod
+            notionals = map (\(_, (n, _), _) -> n) calculationNotionalFixingsFiltered
+            n = if length (dedup notionals) <= 1 then head notionals
+              else error "notional must be constant within a payment period"
+            fxAdjRequireds = map (\(_, (_, fxAdjRequired), _) -> fxAdjRequired)
+              calculationNotionalFixingsFiltered
+            fxAdjRequired = if length (dedup fxAdjRequireds) <= 1 then
+              head fxAdjRequireds
+              else error "fxAdjRequired must be constant within a payment period"
+
+            notionalConst = Const n
+            notional = case fxRateId of
+              None -> notionalConst
+              Some fxRateId -> if fxAdjRequired then notionalConst * fxRateObs else notionalConst
+                where fxRateObs = Observe fxRateId
+
+      -- calculate floating rate claim for a payment period
+      createClaim p =
+        scale notional $ compoundedRates
+        where
+          (notional, fxAdjRequired, calculationNotionalFixingsFiltered) =
+            calculateNotionalAndFixings p
+
+          floatingRateSpread = case floatingRateCalculation.spreadSchedule of
+            [] -> 0.0
+            [se] -> se.initialValue
+            _ -> error "Multiple SpreadSchedules not yet supported"
+          referenceRateId = floatingRateCalculation.floatingRateIndex
+          regularRate = Observe referenceRateId + Const floatingRateSpread
+
+          foldRates acc (c, (n, fxAdjRequired), f) =
+            when (TimeGte f) $ scale (Const 1.0 + rate * dcf) acc
+            where
+              dcf = Const (calcPeriodDcf s.calculationPeriodAmount.calculation.dayCountFraction c
+                useAdjustedDatesForDcf periodicSchedule.terminationDate periodicSchedule.frequency)
+              rate = case c.stubType of
+                None -> regularRate
+                Some stubType -> case s.stubCalculationPeriodAmount of
+                  None -> regularRate
+                  Some scpa -> fromOptional regularRate $
+                    getStubRate
+                      scpa
+                      (stubType == LongInitial || stubType == ShortInitial)
+                      p
+                      rateFixingCalendar
+                      s.calculationPeriodDates.calculationPeriodDatesAdjustments.businessDayConvention
+                      fixLeg
+
+          compoundedRates = foldl
+            foldRates
+            (when (TimeGte p.adjustedEndDate) $ one currency)
+            (reverse calculationNotionalFixingsFiltered)
+
+      -- Calculate a floating rate correction claim for a payment period
+      -- (corresponding to the "-1" in a perf calculation)
+      createCorrectionClaim p =
+        scale notional $ when (TimeGte p.adjustedEndDate) $ one currency
+        where
+          (notional, _, _) = calculateNotionalAndFixings p
+
+      claimAmounts = mconcat $ map createClaim paymentSchedule
+      claims = if issuerPaysLeg then claimAmounts else give claimAmounts
+      correctionClaimAmounts = mconcat $ map createCorrectionClaim paymentSchedule
+      correctionClaims = if issuerPaysLeg then give correctionClaimAmounts else
+        correctionClaimAmounts
+      claimsTagged = prepareAndTagClaims dateToDateClockTime [claims, correctionClaims]
+        "Floating rate payment"
+      allTaggedClaims = case s.principalExchanges of
+        None -> [claimsTagged]
+        Some principalExchanges -> [claimsTagged, principalClaimsTagged]
+          where
+            principalClaimsTagged = calculatePrincipalExchangePaymentClaims paymentSchedule
+              issuerPaysLeg currency fxRateId notionals rateFixingDates principalExchanges
+
+    pure allTaggedClaims
+
+-- | Create claims from swapStream that describes a floating coupon stream.
 calculateFloatingPaymentClaimsFromSwapStream : FloatingRateCalculation -> SwapStream ->
   PeriodicSchedule -> [SchedulePeriod] -> [SchedulePeriod] -> Bool -> Bool -> Deliverable ->
   Party -> Party -> Optional Text -> Optional [Date] -> [(Decimal, Bool)] -> Update [TaggedClaim]
@@ -395,8 +503,6 @@ calculateClaimsFromSwapStream : SwapStream -> PeriodicSchedule -> [SchedulePerio
   Update [TaggedClaim]
 calculateClaimsFromSwapStream s periodicSchedule calculationSchedule paymentSchedule
   swapStreamNotionalRef useAdjustedDatesForDcf issuerPaysLeg currency issuer calendarDataAgency = do
-    assertMsg "Compounding not yet supported" $
-      isNone s.calculationPeriodAmount.calculation.compoundingMethodEnum
     assertMsg "Payment lag not yet supported" $
       isNone s.paymentDates.paymentDaysOffset
     case s.calculationPeriodAmount.calculation.notionalScheduleValue of
@@ -445,12 +551,22 @@ calculateClaimsFromSwapStream s periodicSchedule calculationSchedule paymentSche
     assertMsg "notionals list must be of same length as calculationSchedule" $
       length notionals == length calculationSchedule
     paymentScheduleAligned <- alignPaymentSchedule calculationSchedule paymentSchedule
+    debug paymentSchedule
+    debug paymentScheduleAligned
+    -- TODO: move paymentScheduleAligned to fixed leg only, not needed for floating (driven off payment dates)
     case s.calculationPeriodAmount.calculation.rateTypeValue of
       RateType_Fixed fixedRateSchedule ->
         calculateFixPaymentClaimsFromSwapStream fixedRateSchedule s periodicSchedule
           calculationSchedule paymentScheduleAligned useAdjustedDatesForDcf issuerPaysLeg currency
           issuer calendarDataAgency fxRateId fxFixingDates notionals
       RateType_Floating floatingRateCalculation ->
-        calculateFloatingPaymentClaimsFromSwapStream floatingRateCalculation s periodicSchedule
-          calculationSchedule paymentScheduleAligned useAdjustedDatesForDcf issuerPaysLeg currency
-          issuer calendarDataAgency fxRateId fxFixingDates notionals
+        case s.calculationPeriodAmount.calculation.compoundingMethodEnum of
+          None ->
+            calculateFloatingPaymentClaimsFromSwapStream floatingRateCalculation s periodicSchedule
+              calculationSchedule paymentScheduleAligned useAdjustedDatesForDcf issuerPaysLeg currency
+              issuer calendarDataAgency fxRateId fxFixingDates notionals
+          Some Straight ->
+            calculateCompoundedFloatingPaymentClaimsFromSwapStream floatingRateCalculation s periodicSchedule
+              calculationSchedule paymentSchedule useAdjustedDatesForDcf issuerPaysLeg currency
+              issuer calendarDataAgency fxRateId fxFixingDates notionals
+          _ -> error "Compounding method not supported"

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -495,7 +495,6 @@ calculateFloatingPaymentClaimsFromSwapStream floatingRateCalculation s periodicS
           where
             principalClaimsTagged = calculatePrincipalExchangePaymentClaims paymentScheduleAligned
               issuerPaysLeg currency fxRateId notionals rateFixingDates principalExchanges
-    debug allTaggedClaims
     pure allTaggedClaims
 
 -- | Create claims from swapStream that describes a fixed or floating coupon stream.

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -2293,9 +2293,9 @@ run_compounding = script do
     calcPeriodMultiplierFloat = 1
     businessDayConvention = ModifiedFollowing
     observations = M.fromList
-      [ (dateToDateClockTime (date 2022 Apr 25), 0.041) -- TODO: 0.1% spread, reduce rates
-      , (dateToDateClockTime (date 2022 May 25), 0.046)
-      , (dateToDateClockTime (date 2022 Jun 23), 0.051)
+      [ (dateToDateClockTime (date 2022 Apr 25), 0.040)
+      , (dateToDateClockTime (date 2022 May 25), 0.045)
+      , (dateToDateClockTime (date 2022 Jun 23), 0.050)
       , (dateToDateClockTime (date 2022 Jul 25), 0.000)
       ]
     primaryBusinessCenters = ["GBLO", "USNY"]
@@ -2378,11 +2378,10 @@ run_compounding = script do
             indexTenor = Some Period with
               periodMultiplier = calcPeriodMultiplierFloat
               period = calcPeriodFloat
-            spreadSchedule = [SpreadSchedule with initialValue = 0.000]
+            spreadSchedule = [SpreadSchedule with initialValue = 0.001]
             finalRateRounding = None
           dayCountFraction = Basis30360ICMA
-          -- compoundingMethodEnum = Some Straight
-          compoundingMethodEnum = None -- https://github.com/digital-asset/daml-finance/issues/517
+          compoundingMethodEnum = Some Straight
       stubCalculationPeriodAmount = None
       principalExchanges = None
 
@@ -2407,10 +2406,10 @@ run_compounding = script do
   swapInstrument <- originateFpmlSwap custodian issuer "SwapTest1" "Interest rate swap" observers
     now swapStreams calendarDataProvider currencies issuerPartyRef
 
-  -- First payment date: Lifecycle and verify the floating payment (compound 3 periods of 1M each)
+  -- First payment date: Lifecycle and verify the floating payment (3 compounded 1M periods)
   let
     expectedConsumedQuantities = []
-    expectedProducedQuantities = [qty 115439.65 cashInstrumentCid]
+    expectedProducedQuantities = [qty 115439.6538543061 cashInstrumentCid]
   Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     (date 2022 Jul 27) swapInstrument issuer observableCids expectedConsumedQuantities
     expectedProducedQuantities

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -2267,7 +2267,7 @@ run_fpml_rate_rounding = script do
 
   pure ()
 
--- ISDA calculation example for compounding, example 4.1:
+-- ISDA calculation example for straight compounding, example 4.1:
 -- https://www.isda.org/a/2KiDE/isda-compounding-memo.pdf
 run_compounding : Script ()
 run_compounding = script do

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -2266,3 +2266,153 @@ run_fpml_rate_rounding = script do
   0.0987654 === roundRate 0.09876543 Rounding with roundingDirection = Nearest, precision = 7
 
   pure ()
+
+-- ISDA calculation example for compounding, example 4.1:
+-- https://www.isda.org/a/2KiDE/isda-compounding-memo.pdf
+run_compounding : Script ()
+run_compounding = script do
+  [custodian, issuer, calendarDataProvider, publicParty] <-
+    createParties ["Custodian", "Issuer", "Calendar Data Provider", "PublicParty"]
+
+  -- Create commercial-bank cash
+  now <- getTime
+  let observers = [("PublicParty", singleton publicParty)]
+  cashInstrumentCid <- Instrument.originate custodian issuer "USD" "US Dollar" observers now
+
+  -- Create swap
+  let
+    rollDay = 27
+    issueDate = date 2022 Apr rollDay
+    maturityDate = date 2023 Apr rollDay
+    referenceRateId = "USD/LIBOR/BBA/1M"
+    notional = 10000000.0
+    ccy = "USD"
+    paymentPeriod = M
+    paymentPeriodMultiplier = 3
+    calcPeriodFloat = M
+    calcPeriodMultiplierFloat = 1
+    businessDayConvention = ModifiedFollowing
+    observations = M.fromList
+      [ (dateToDateClockTime (date 2022 Apr 25), 0.041) -- TODO: 0.1% spread, reduce rates
+      , (dateToDateClockTime (date 2022 May 25), 0.046)
+      , (dateToDateClockTime (date 2022 Jun 23), 0.051)
+      , (dateToDateClockTime (date 2022 Jul 25), 0.000)
+      ]
+    primaryBusinessCenters = ["GBLO", "USNY"]
+    cal =
+      HolidayCalendarData with
+        id = "USNY"
+        weekend = [Saturday, Sunday]
+        holidays = []
+    fixingBusinessCenters = ["GBLO"]
+    fixingCal =
+      HolidayCalendarData with
+        id = "GBLO"
+        weekend = [Saturday, Sunday]
+        holidays = []
+
+    issuerPartyRef = "party2"
+    clientPartyRef = "party1"
+
+    swapStreamFloatingLeg = SwapStream with
+      payerPartyReference = issuerPartyRef
+      receiverPartyReference = clientPartyRef
+      calculationPeriodDates = CalculationPeriodDates with
+        id = "floatingCalcPeriodDates"
+        effectiveDate = AdjustableDate with
+          unadjustedDate = issueDate
+          dateAdjustments = BusinessDayAdjustments with
+            businessDayConvention = NoAdjustment
+            businessCenters = []
+        terminationDate = AdjustableDate with
+          unadjustedDate = maturityDate
+          dateAdjustments = BusinessDayAdjustments with
+            businessDayConvention = ModifiedFollowing
+            businessCenters = primaryBusinessCenters
+        calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
+          businessDayConvention = ModifiedFollowing
+          businessCenters = primaryBusinessCenters
+        firstRegularPeriodStartDate = None
+        lastRegularPeriodEndDate = None
+        calculationPeriodFrequency = CalculationPeriodFrequency with
+          periodMultiplier = calcPeriodMultiplierFloat
+          period = calcPeriodFloat
+          rollConvention = DOM rollDay
+      paymentDates = PaymentDates with
+        calculationPeriodDatesReference = "floatingCalcPeriodDates"
+        paymentFrequency = PaymentFrequency with
+          periodMultiplier = paymentPeriodMultiplier
+          period = paymentPeriod
+        firstPaymentDate = None
+        lastRegularPaymentDate = None
+        payRelativeTo = CalculationPeriodEndDate
+        paymentDaysOffset = None
+        paymentDatesAdjustments = BusinessDayAdjustments with
+            businessDayConvention = ModifiedFollowing
+            businessCenters = primaryBusinessCenters
+      resetDates = Some ResetDates with
+        calculationPeriodDatesReference = "floatingCalcPeriodDates"
+        resetRelativeTo = CalculationPeriodStartDate
+        fixingDates = FixingDates with
+          periodMultiplier = -2
+          period = D
+          dayType = Business
+          businessDayConvention = NoAdjustment
+          businessCenters = fixingBusinessCenters
+        resetFrequency = ResetFrequency with
+          periodMultiplier = calcPeriodMultiplierFloat
+          period = calcPeriodFloat
+        resetDatesAdjustments = ResetDatesAdjustments with
+          businessDayConvention = ModifiedFollowing
+          businessCenters = primaryBusinessCenters
+      calculationPeriodAmount = CalculationPeriodAmount with
+        calculation = Calculation with
+          notionalScheduleValue = NotionalSchedule_Regular NotionalSchedule with
+            id = "floatingLegNotionalSchedule"
+            notionalStepSchedule = NotionalStepSchedule with
+              initialValue = notional
+              step = []
+              currency = ccy
+          rateTypeValue = RateType_Floating FloatingRateCalculation with
+            floatingRateIndex = referenceRateId
+            indexTenor = Some Period with
+              periodMultiplier = calcPeriodMultiplierFloat
+              period = calcPeriodFloat
+            spreadSchedule = [SpreadSchedule with initialValue = 0.000]
+            finalRateRounding = None
+          dayCountFraction = Basis30360ICMA
+          -- compoundingMethodEnum = Some Straight
+          compoundingMethodEnum = None -- https://github.com/digital-asset/daml-finance/issues/517
+      stubCalculationPeriodAmount = None
+      principalExchanges = None
+
+    swapStreams = [swapStreamFloatingLeg]
+    currencies = [cashInstrumentCid]
+
+  -- A reference data provider publishes the holiday calendars on the ledger
+  calendarCid <- submit calendarDataProvider do
+    createCmd HolidayCalendar with
+      provider = calendarDataProvider; calendar = cal
+      observers = M.fromList observers
+  fixingCalendarCid <- submit calendarDataProvider do
+    createCmd HolidayCalendar with
+      provider = calendarDataProvider; calendar = fixingCal
+      observers = M.fromList observers
+
+  observableCid <- toInterfaceContractId <$> submit issuer do
+    createCmd Observation with
+      provider = issuer; id = Id referenceRateId; observations; observers = M.empty
+  let observableCids = [observableCid]
+
+  swapInstrument <- originateFpmlSwap custodian issuer "SwapTest1" "Interest rate swap" observers
+    now swapStreams calendarDataProvider currencies issuerPartyRef
+
+  -- First payment date: Lifecycle and verify the floating payment (compound 3 periods of 1M each)
+  let
+    expectedConsumedQuantities = []
+    expectedProducedQuantities = [qty 115439.65 cashInstrumentCid]
+  Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
+    (date 2022 Jul 27) swapInstrument issuer observableCids expectedConsumedQuantities
+    expectedProducedQuantities
+
+  pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -1519,8 +1519,8 @@ runAmortizingNotionalSampleTrade = script do
 
 -- fpml.org Example 1 - Fixed/Floating Single Currency Interest Rate Swap
 -- https://www.fpml.org/spec/fpml-5-11-7-rec-1/html/confirmation/fpml-5-11-examples.html#s2
-run_fpml_1 : Script ()
-run_fpml_1 = script do
+runFpml1 : Script ()
+runFpml1 = script do
   [custodian, issuer, calendarDataProvider, publicParty] <-
     createParties ["Custodian", "Issuer", "Calendar Data Provider", "PublicParty"]
 
@@ -1730,8 +1730,8 @@ run_fpml_1 = script do
 -- fpml.org Example 2 - Fixed/Floating Single Currency Interest Rate Swap with Initial Stub Period
 -- and Notional Amortization
 -- https://www.fpml.org/spec/fpml-5-11-7-rec-1/html/confirmation/fpml-5-11-examples.html#s2
-run_fpml_2 : Script ()
-run_fpml_2 = script do
+runFpml2 : Script ()
+runFpml2 = script do
   [custodian, issuer, calendarDataProvider, publicParty] <-
     createParties ["Custodian", "Issuer", "Calendar Data Provider", "PublicParty"]
 
@@ -2019,8 +2019,8 @@ run_fpml_2 = script do
 -- fpml.org Example 3 - Fixed/Floating Single Currency Interest Rate Swap with Compounding, Payment
 -- Delay and Final Rate Rounding
 -- https://www.fpml.org/spec/fpml-5-11-7-rec-1/html/confirmation/fpml-5-11-examples.html#s2
-run_fpml_3 : Script ()
-run_fpml_3 = script do
+runFpml3 : Script ()
+runFpml3 = script do
   [custodian, issuer, calendarDataProvider, publicParty] <-
     createParties ["Custodian", "Issuer", "Calendar Data Provider", "PublicParty"]
 
@@ -2250,8 +2250,8 @@ run_fpml_3 = script do
 
 -- Test Rate Rounding methods.
 -- https://www.fpml.org/spec/fpml-5-11-3-lcwd-1/html/confirmation/schemaDocumentation/schemas/fpml-shared-5-11_xsd/complexTypes/FloatingRateCalculation/finalRateRounding.html
-run_fpml_rate_rounding : Script ()
-run_fpml_rate_rounding = script do
+runFpmlRateRounding : Script ()
+runFpmlRateRounding = script do
   -- Test rounding direction, using the test cases here:
   -- https://www.fpml.org/spec/fpml-5-11-3-lcwd-1/html/confirmation/schemaDocumentation/schemas/fpml-shared-5-11_xsd/complexTypes/Rounding/roundingDirection.html
   0.053 === roundRate 0.0521 Rounding with roundingDirection = Up, precision = 3
@@ -2269,8 +2269,8 @@ run_fpml_rate_rounding = script do
 
 -- ISDA calculation example for straight compounding, example 4.1:
 -- https://www.isda.org/a/2KiDE/isda-compounding-memo.pdf
-run_compounding : Script ()
-run_compounding = script do
+runCompounding : Script ()
+runCompounding = script do
   [custodian, issuer, calendarDataProvider, publicParty] <-
     createParties ["Custodian", "Issuer", "Calendar Data Provider", "PublicParty"]
 

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -220,11 +220,6 @@ lifecycleAndVerifySwapPaymentEffects readAs today swapInstrument issuer
     effectView <- submit issuer do
       exerciseCmd effectCid Effect.GetView with viewer = issuer
 
-    debug expectedConsumedQuantities
-    debug effectView.otherConsumed
-    debug expectedProducedQuantities
-    debug effectView.otherProduced
-
     -- Verify that the consumed/produced quantities match the expected ones
     assertMsg "The consumed quantities do not match the expected ones" $
       sort expectedConsumedQuantities == sort effectView.otherConsumed

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -220,6 +220,11 @@ lifecycleAndVerifySwapPaymentEffects readAs today swapInstrument issuer
     effectView <- submit issuer do
       exerciseCmd effectCid Effect.GetView with viewer = issuer
 
+    debug expectedConsumedQuantities
+    debug effectView.otherConsumed
+    debug expectedProducedQuantities
+    debug effectView.otherProduced
+
     -- Verify that the consumed/produced quantities match the expected ones
     assertMsg "The consumed quantities do not match the expected ones" $
       sort expectedConsumedQuantities == sort effectView.otherConsumed


### PR DESCRIPTION
I used to drive the floating interest rate calculation from the calculationSchedule (and treat each calculation period independently, relying on claims netting). With interest compounding I had to drive the calculation from the paymentSchedule, in order to combine the calculation periods as specified in the FpML. 

This was quite a significant change, so I have only implemented one compounding method in this PR. Once merged, I plan to implement the others and then merge the calculations into one single function, `calculateFloatingPaymentClaimsFromSwapStream`.
 