### PR TITLE
GPG key change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,6 +235,8 @@ jobs:
     executor: daml-finance-executor
     steps:
       - checkout
+      - setup_nix
+      - import_gpg_key
       - run:
           name: Download official dars from GitHub
           command: |
@@ -273,26 +275,34 @@ jobs:
       - run:
           name: Process all dars
           command: |
-            # Import the DA private key into GPG
-            echo ${gpg_code_signing} | base64 -d | gpg --import --quiet
+            nix-shell \
+              --pure \
+              --keep GITHUB_TOKEN \
+              --keep gpg_code_signing \
+              --run bash \<<'EOF'
+                  set -euo pipefail
 
-            # Process dars
-            DAR_PATHS=(`ls .gpg/*/*/*.dar`)
-            for DAR_PATH in ${DAR_PATHS[@]}; do
-              MODULE=`echo ${DAR_PATH} | cut -f2 -d "/"`
-              VERSION=`echo ${DAR_PATH} | cut -f3 -d "/"`
-              TAG="${MODULE}/${VERSION}"
-              echo "Processing dar : TAG=${TAG}, DAR_PATH=${DAR_PATH}"
+                  # Import the DA private key into GPG
+                  # echo ${gpg_code_signing} | base64 -d | gpg --import --quiet
 
-              # Remove existing asc file (not required, "--clobber" will overwrite existing files)
-              # gh release delete-asset ${TAG} ${DAR_PATH}.asc -y
+                  # Process dars
+                  DAR_PATHS=(`ls .gpg/*/*/*.dar`)
+                  for DAR_PATH in ${DAR_PATHS[@]}; do
+                    MODULE=`echo ${DAR_PATH} | cut -f2 -d "/"`
+                    VERSION=`echo ${DAR_PATH} | cut -f3 -d "/"`
+                    TAG="${MODULE}/${VERSION}"
+                    echo "Processing dar : TAG=${TAG}, DAR_PATH=${DAR_PATH}"
 
-              # Generate new asc file
-              gpg --armor --detach-sign ${DAR_PATH}
+                    # Remove existing asc file (not required, "--clobber" will overwrite existing files)
+                    # gh release delete-asset ${TAG} ${DAR_PATH}.asc -y
 
-              # Replace existing asc file in Github
-              gh release upload ${TAG} ${DAR_PATH}.asc --clobber
-            done
+                    # Generate new asc file
+                    gpg --armor --detach-sign ${DAR_PATH}
+
+                    # Replace existing asc file in Github
+                    gh release upload ${TAG} ${DAR_PATH}.asc --clobber
+                  done
+            EOF
 workflows:
   version: 2
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,7 +231,68 @@ jobs:
       - checkout
       - setup_nix
       - run_assembly
+  gpg_update:
+    executor: daml-finance-executor
+    steps:
+      - checkout
+      - run:
+          name: Download official dars from GitHub
+          command: |
+            mkdir .gpg
 
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/ContingentClaims.Core/1.0.0/contingent-claims-core-1.0.0.dar -o .gpg/ContingentClaims.Core/1.0.0/contingent-claims-core-1.0.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/ContingentClaims.Lifecycle/1.0.0/contingent-claims-lifecycle-1.0.0.dar -o .gpg/ContingentClaims.Lifecycle/1.0.0/contingent-claims-lifecycle-1.0.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/ContingentClaims.Valuation/0.2.0/contingent-claims-valuation-0.2.0.dar -o .gpg/ContingentClaims.Valuation/0.2.0/contingent-claims-valuation-0.2.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Account/1.0.0/daml-finance-account-1.0.0.dar -o .gpg/Daml.Finance.Account/1.0.0/daml-finance-account-1.0.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Claims/1.0.0/daml-finance-claims-1.0.0.dar -o .gpg/Daml.Finance.Claims/1.0.0/daml-finance-claims-1.0.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Data/1.0.0/daml-finance-data-1.0.0.dar -o .gpg/Daml.Finance.Data/1.0.0/daml-finance-data-1.0.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Holding/1.0.0/daml-finance-holding-1.0.0.dar -o .gpg/Daml.Finance.Holding/1.0.0/daml-finance-holding-1.0.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Instrument.Bond/0.2.0/daml-finance-instrument-bond-0.2.0.dar  -o .gpg/Daml.Finance.Instrument.Bond/0.2.0/daml-finance-instrument-bond-0.2.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Instrument.Equity/0.2.0/daml-finance-instrument-equity-0.2.0.dar  -o .gpg/Daml.Finance.Instrument.Equity/0.2.0/daml-finance-instrument-equity-0.2.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Instrument.Generic/1.0.0/daml-finance-instrument-generic-1.0.0.dar  -o .gpg/Daml.Finance.Instrument.Generic/1.0.0/daml-finance-instrument-generic-1.0.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Instrument.Swap/0.2.0/daml-finance-instrument-swap-0.2.0.dar  -o .gpg/Daml.Finance.Instrument.Swap/0.2.0/daml-finance-instrument-swap-0.2.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Instrument.Token/1.0.0/daml-finance-instrument-token-1.0.0.dar  -o .gpg/Daml.Finance.Instrument.Token/1.0.0/daml-finance-instrument-token-1.0.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Interface.Account/1.0.0/daml-finance-interface-account-1.0.0.dar  -o .gpg/Daml.Finance.Interface.Account/1.0.0/daml-finance-interface-account-1.0.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Interface.Claims/1.0.0/daml-finance-interface-claims-1.0.0.dar  -o .gpg/Daml.Finance.Interface.Claims/1.0.0/daml-finance-interface-claims-1.0.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Interface.Data/1.0.0/daml-finance-interface-data-1.0.0.dar  -o .gpg/Daml.Finance.Interface.Data/1.0.0/daml-finance-interface-data-1.0.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Interface.Holding/1.0.0/daml-finance-interface-holding-1.0.0.dar  -o .gpg/Daml.Finance.Interface.Holding/1.0.0/daml-finance-interface-holding-1.0.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Interface.Instrument.Base/1.0.0/daml-finance-interface-instrument-base-1.0.0.dar -o .gpg/Daml.Finance.Interface.Instrument.Base/1.0.0/daml-finance-interface-instrument-base-1.0.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Interface.Instrument.Bond/0.2.0/daml-finance-interface-instrument-bond-0.2.0.dar -o .gpg/Daml.Finance.Interface.Instrument.Bond/0.2.0/daml-finance-interface-instrument-bond-0.2.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Interface.Instrument.Equity/0.2.0/daml-finance-interface-instrument-equity-0.2.0.dar -o .gpg/Daml.Finance.Interface.Instrument.Equity/0.2.0/daml-finance-interface-instrument-equity-0.2.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Interface.Instrument.Generic/1.0.0/daml-finance-interface-instrument-generic-1.0.0.dar -o .gpg/Daml.Finance.Interface.Instrument.Generic/1.0.0/daml-finance-interface-instrument-generic-1.0.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Interface.Instrument.Swap/0.2.0/daml-finance-interface-instrument-swap-0.2.0.dar -o .gpg/Daml.Finance.Interface.Instrument.Swap/0.2.0/daml-finance-interface-instrument-swap-0.2.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Interface.Instrument.Token/1.0.0/daml-finance-interface-instrument-token-1.0.0.dar -o .gpg/Daml.Finance.Interface.Instrument.Token/1.0.0/daml-finance-interface-instrument-token-1.0.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Interface.Lifecycle/1.0.0/daml-finance-interface-lifecycle-1.0.0.dar  -o .gpg/Daml.Finance.Interface.Lifecycle/1.0.0/daml-finance-interface-lifecycle-1.0.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Interface.Settlement/1.0.0/daml-finance-interface-settlement-1.0.0.dar  -o .gpg/Daml.Finance.Interface.Settlement/1.0.0/daml-finance-interface-settlement-1.0.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Interface.Types.Common/1.0.0/daml-finance-interface-types-common-1.0.0.dar  -o .gpg/Daml.Finance.Interface.Types.Common/1.0.0/daml-finance-interface-types-common-1.0.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Interface.Types.Date/1.0.0/daml-finance-interface-types-date-1.0.0.dar -o .gpg/Daml.Finance.Interface.Types.Date/1.0.0/daml-finance-interface-types-date-1.0.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Interface.Util/1.0.0/daml-finance-interface-util-1.0.0.dar  -o .gpg/Daml.Finance.Interface.Util/1.0.0/daml-finance-interface-util-1.0.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Lifecycle/1.0.0/daml-finance-lifecycle-1.0.0.dar -o .gpg/Daml.Finance.Lifecycle/1.0.0/daml-finance-lifecycle-1.0.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Settlement/1.0.0/daml-finance-settlement-1.0.0.dar -o .gpg/Daml.Finance.Settlement/1.0.0/daml-finance-settlement-1.0.0.dar
+            curl --create-dirs -Lf# https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Util/1.0.0/daml-finance-util-1.0.0.dar -o .gpg/Daml.Finance.Util/1.0.0/daml-finance-util-1.0.0.dar
+      - run:
+          name: Process all dars
+          command: |
+            # Import the DA private key into GPG
+            echo ${gpg_code_signing} | base64 -d | gpg --import --quiet
+
+            # Process dars
+            DAR_PATHS=(`ls .gpg/*/*/*.dar`)
+            for DAR_PATH in ${DAR_PATHS[@]}; do
+              MODULE=`echo ${DAR_PATH} | cut -f2 -d "/"`
+              VERSION=`echo ${DAR_PATH} | cut -f3 -d "/"`
+              TAG="${MODULE}/${VERSION}"
+              echo "Processing dar : TAG=${TAG}, DAR_PATH=${DAR_PATH}"
+
+              # Remove existing asc file (not required, "--clobber" will overwrite existing files)
+              # gh release delete-asset ${TAG} ${DAR_PATH}.asc -y
+
+              # Generate new asc file
+              gpg --armor --detach-sign ${DAR_PATH}
+
+              # Replace existing asc file in Github
+              gh release upload ${TAG} ${DAR_PATH}.asc --clobber
+            done
 workflows:
   version: 2
   build:
@@ -283,3 +344,13 @@ workflows:
                 - /^(A|a)ssembly.*$/
           requires:
             - hold
+  gpg_update:
+    jobs:
+      - gpg_update:
+          context:
+            - github-fin-eng-context
+            - npn-publish
+          filters:
+            branches:
+              only:
+                - /^gpg_upload_run.*$/


### PR DESCRIPTION
Temporary change to the CI configuration to support the GPG key change as part of the CircleCI breach. This branch facilitates the re-generating the `.asc` files associated to each package with the new key. This process needs to be ran as part of the CI as we require the GitHub token and the new private key in order to sign each dar and push the new `.asc` generated files to GitHub releases.

This change isn't going to be part of the `main` branch, but ran as a one off process before removing this branch. Ie., this is a temporary hack.