### PR TITLE
Add an `ObserveAt` observation builder which is observed at an explicit point in time

### DIFF
--- a/src/main/daml/ContingentClaims/Core/Claim.daml
+++ b/src/main/daml/ContingentClaims/Core/Claim.daml
@@ -161,7 +161,7 @@ infix 4 <=
 -- This function is used to convert an abstract inequalityvation, e.g. `S ≤ 50.0` to the actual
 -- observation function `t -> m Bool`. The function is only total when the first argument is too
 -- (typically it will fail on `t` > today).
-compare : (Ord t, Ord x, Number x, Divisible x, Action m) =>
+compare : (Ord t, Ord x, Number x, Divisible x, CanAbort m) =>
   (o -> t -> m x) -> Inequality t x o -> t -> m Bool
 compare doObserve (Lte (f, f')) t = liftA2 (Prelude.<=) (eval doObserve f t) (eval doObserve f' t)
 compare _ (TimeGte s) t = pure $ t >= s

--- a/src/main/daml/ContingentClaims/Core/Claim.daml
+++ b/src/main/daml/ContingentClaims/Core/Claim.daml
@@ -118,7 +118,7 @@ mapParams :  (t -> i)
           -> (x -> x')
           -> Claim i x a o -> Claim t x' a' o'
 mapParams ft' ft fa fk fv =
-  let f = Observation.mapParams ft' fk fv
+  let f = Observation.mapParams ft fk fv
   in cata \case
     ZeroF -> Zero
     OneF a -> One $ fa a

--- a/src/main/daml/ContingentClaims/Core/Observation.daml
+++ b/src/main/daml/ContingentClaims/Core/Observation.daml
@@ -149,14 +149,3 @@ instance (Show t, Show x, Show o) => Show (Observation t x o) where
     MulF ss -> pair "Mul" ss
     DivF ss -> pair "Div" ss
     where pair o (s, s') = o <> " (" <> s <> ", " <> s' <> ")"
-
--- | Given a time `t`, converts all `Observe key` to `ObserveAt key t`
-fixObservationTime : t -> Observation t x o -> Observation t x o
-fixObservationTime t = cata \case
-  ConstF x -> Const x
-  ObserveF a -> ObserveAt a t
-  ObserveAtF a t' -> ObserveAt a t'
-  AddF ss -> Add ss
-  NegF s -> Neg s
-  MulF ss -> Mul ss
-  DivF ss -> Div ss

--- a/src/main/daml/ContingentClaims/Core/Observation.daml
+++ b/src/main/daml/ContingentClaims/Core/Observation.daml
@@ -19,6 +19,8 @@ data Observation t x o
       -- ^ A numerical constant, e.g. `10.0`.
   | Observe with key: o
       -- ^ A named parameter, e.g. "LIBOR 3M".
+  | ObserveAt with key: o, t: t
+      -- ^ A named parameter, e.g. "LIBOR 3M", observed at an explicit point in time
   | Add (Observation t x o, Observation t x o)
       -- ^ Sum of two observations.
   | Neg (Observation t x o)
@@ -37,11 +39,13 @@ data ObservationF t x o b
   | NegF (b)
   | MulF (b, b)
   | DivF (b, b)
+  | ObserveAtF with key: o, t: t
   deriving (Eq, Show, Functor)
 
 instance Recursive (Observation t x o) (ObservationF t x o) where
   project (Const value) = ConstF value
   project (Observe key) = ObserveF key
+  project (ObserveAt key t) = ObserveAtF key t
   project (Add (x, x')) = AddF (x, x')
   project (Neg x) = NegF x
   project (Mul (x, x')) = MulF (x, x')
@@ -50,6 +54,7 @@ instance Recursive (Observation t x o) (ObservationF t x o) where
 instance Corecursive (Observation t x o) (ObservationF t x o) where
   embed (ConstF value) = Const value
   embed (ObserveF key) = Observe key
+  embed (ObserveAtF key t) = ObserveAt key t
   embed (AddF (x, x')) = Add (x, x)
   embed (NegF x) = Neg x
   embed (MulF (x, x')) = Mul (x, x')
@@ -73,6 +78,7 @@ eval doObserve obs t = cataM alg obs
     alg = \case
       ConstF x -> Prelude.pure x
       ObserveF key -> doObserve key t
+      ObserveAtF key t' -> doObserve key t'
       AddF (x, x') -> Prelude.pure $ x Prelude.+ x'
       NegF x -> Prelude.pure $ negate x
       MulF (x, x') -> Prelude.pure $ x * x'
@@ -84,13 +90,14 @@ eval doObserve obs t = cataM alg obs
 --
 -- @ mapParams identity = bimap
 --
-mapParams : (t -> i)
+mapParams : (i -> t)
           -> (o -> o')
           -> (x -> x')
           -> Observation i x o -> Observation t x' o'
-mapParams _ g f = cata \case
+mapParams h g f = cata \case
   ConstF x -> Const (f x)
   ObserveF key -> Observe (g key)
+  ObserveAtF key i -> ObserveAt (g key) (h i)
   AddF (b, b') -> Add (b, b')
   NegF b -> Neg b
   MulF (b, b') -> Mul (b, b')
@@ -116,7 +123,8 @@ instance Multiplicative x => Divisible (Observation t x o) where
 
 instance Foldable (ObservationF t x o) where
   foldr f seed (ConstF _) = seed
-  foldr f seed (ObserveF key) = seed
+  foldr f seed (ObserveF _) = seed
+  foldr f seed (ObserveAtF _ _) = seed
   foldr f seed (NegF b) = f b seed
   foldr f seed (AddF (b, b')) = f b $ f b' seed
   foldr f seed (MulF (b, b')) = f b $ f b' seed
@@ -125,6 +133,7 @@ instance Foldable (ObservationF t x o) where
 instance Traversable (ObservationF t x o) where
   sequence (ConstF x) = Prelude.pure $ ConstF x
   sequence (ObserveF key) = Prelude.pure $ ObserveF key
+  sequence (ObserveAtF key t) = Prelude.pure $ ObserveAtF key t
   sequence (NegF m) = NegF <$> m
   sequence (AddF (m, m')) = curry AddF <$> m <*> m'
   sequence (MulF (m, m')) = curry MulF <$> m <*> m'
@@ -134,8 +143,20 @@ instance (Show t, Show x, Show o) => Show (Observation t x o) where
   show = cata \case
     ConstF x -> "Const " <> show x
     ObserveF a -> "Observe " <> show a
+    ObserveAtF a t -> "Observe " <> show a <> "at " <> show t
     AddF ss -> pair "Add" ss
     NegF s -> "Neg (" <> s <> ")"
     MulF ss -> pair "Mul" ss
     DivF ss -> pair "Div" ss
     where pair o (s, s') = o <> " (" <> s <> ", " <> s' <> ")"
+
+-- | Given a time `t`, converts all `Observe key` to `ObserveAt key t`
+fixObservationTime : t -> Observation t x o -> Observation t x o
+fixObservationTime t = cata \case
+  ConstF x -> Const x
+  ObserveF a -> ObserveAt a t
+  ObserveAtF a t' -> ObserveAt a t'
+  AddF ss -> Add ss
+  NegF s -> Neg s
+  MulF ss -> Mul ss
+  DivF ss -> Div ss

--- a/src/main/daml/ContingentClaims/Core/Observation.daml
+++ b/src/main/daml/ContingentClaims/Core/Observation.daml
@@ -72,12 +72,13 @@ observe = Observe
 -- This function is used to convert an abstract observation, e.g. `LIBOR 3M + 0.005` to the actual
 -- observation function `t -> m x`. The function is only total when the first argument is too
 -- (typically it will fail on `t` > today).
-eval : (Number x, Divisible x, Action m) => (o -> t -> m x) -> Observation t x o -> t -> m x
+eval : (Ord t, Number x, Divisible x, CanAbort m) => (o -> t -> m x) -> Observation t x o -> t -> m x
 eval doObserve obs t = cataM alg obs
   where
     alg = \case
       ConstF x -> Prelude.pure x
       ObserveF key -> doObserve key t
+      ObserveAtF key t' | t' > t -> abort "Trying to observe in the future."
       ObserveAtF key t' -> doObserve key t'
       AddF (x, x') -> Prelude.pure $ x Prelude.+ x'
       NegF x -> Prelude.pure $ negate x

--- a/src/main/daml/ContingentClaims/Core/Observation.daml
+++ b/src/main/daml/ContingentClaims/Core/Observation.daml
@@ -20,7 +20,7 @@ data Observation t x o
   | Observe with key: o
       -- ^ A named parameter, e.g. "LIBOR 3M".
   | ObserveAt with key: o, t: t
-      -- ^ A named parameter, e.g. "LIBOR 3M", observed at an explicit point in time
+      -- ^ A named parameter, e.g. "LIBOR 3M", observed at an explicit point in time.
   | Add (Observation t x o, Observation t x o)
       -- ^ Sum of two observations.
   | Neg (Observation t x o)

--- a/src/main/daml/ContingentClaims/Lifecycle/Util.daml
+++ b/src/main/daml/ContingentClaims/Lifecycle/Util.daml
@@ -39,11 +39,11 @@ expiry c = case fixings c of
 
 -- | Return a list of possible scale-factor/payoff pairs.
 -- This does not discriminate between conditional and outright payoffs.
-payoffs : (Eq x, Eq o, Multiplicative x) => Claim t x a o -> [(Observation t x o, a)]
+payoffs : (Eq t, Eq x, Eq o, Multiplicative x) => Claim t x a o -> [(Observation t x o, a)]
 payoffs = fmap (first ($ munit)) . cata payoffs'
 
 -- | Algebra for `payoffs`. This also applies 'multiplication by one' identity,
-payoffs' : (Eq x, Eq o, Multiplicative x) =>
+payoffs' : (Eq t, Eq x, Eq o, Multiplicative x) =>
   ClaimF t x a o [(Observation t x o -> Observation t x o, a)] ->
   [(Observation t x o -> Observation t x o, a)]
 payoffs' ZeroF = []

--- a/src/main/daml/ContingentClaims/Valuation/Stochastic.daml
+++ b/src/main/daml/ContingentClaims/Valuation/Stochastic.daml
@@ -172,7 +172,7 @@ fapf ccy disc exch val today = flip evalState 0 . futuM coalg . Left . (, today)
   -- υ : (Observable, t) -> State Int (ExprF t (Free (ExprF t) (Observation, t)))
   υ (O.Const {value=k}, _) = pure $ ConstF k
   υ (O.Observe {key=obs}, t) = pure $ val' obs t
-  υ (O.ObserveAt {key=obs, t = t'}, _) = pure $ val' obs t' -- verify if correct
+  υ (O.ObserveAt {key=obs, t = t'}, _) = pure $ val' obs t'
   υ (O.Add (x, x'), t) = pure $ SumF [obs (x, t), obs (x', t)]
   υ (O.Neg x, t) = pure . NegF $ obs (x, t)
   υ (O.Mul (x, x'), t) = pure $ obs (x, t) `MulF` obs (x', t)

--- a/src/main/daml/ContingentClaims/Valuation/Stochastic.daml
+++ b/src/main/daml/ContingentClaims/Valuation/Stochastic.daml
@@ -172,6 +172,7 @@ fapf ccy disc exch val today = flip evalState 0 . futuM coalg . Left . (, today)
   -- υ : (Observable, t) -> State Int (ExprF t (Free (ExprF t) (Observation, t)))
   υ (O.Const {value=k}, _) = pure $ ConstF k
   υ (O.Observe {key=obs}, t) = pure $ val' obs t
+  υ (O.ObserveAt {key=obs, t = t'}, _) = pure $ val' obs t' -- verify if correct
   υ (O.Add (x, x'), t) = pure $ SumF [obs (x, t), obs (x', t)]
   υ (O.Neg x, t) = pure . NegF $ obs (x, t)
   υ (O.Mul (x, x'), t) = pure $ obs (x, t) `MulF` obs (x', t)

--- a/src/main/daml/Daml/Finance/Claims/Util/Builders.daml
+++ b/src/main/daml/Daml/Finance/Claims/Util/Builders.daml
@@ -11,6 +11,7 @@ module Daml.Finance.Claims.Util.Builders where
 import ContingentClaims.Core.Builders (european)
 import ContingentClaims.Core.Claim (Claim, Inequality(..), and, at, cond, give, one, orList, scale, until, upTo, when, zero)
 import ContingentClaims.Core.Observation (Observation(..))
+import DA.Foldable (foldMap)
 import Daml.Finance.Claims.Util (toTime)
 import Daml.Finance.Interface.Claims.Types (Deliverable, Observable, TaggedClaim(..))
 import Daml.Finance.Interface.Types.Common.Types (InstrumentQuantity)
@@ -134,7 +135,7 @@ createAssetPerformancePaymentClaims : (Date -> Time) -> Schedule -> PeriodicSche
 createAssetPerformancePaymentClaims dateToTime schedule periodicSchedule useAdjustedDatesForDcf
   ownerReceives dayCountConvention notional cashInstrument referenceAssetId =
   let
-    assetClaimAmounts = mconcat $ map (\p ->
+    assetClaimAmounts = foldMap (\p ->
       let
         performance =
           Observe referenceAssetId / ObserveAt referenceAssetId p.adjustedStartDate - Const 1.0

--- a/src/main/daml/Daml/Finance/Claims/Util/Builders.daml
+++ b/src/main/daml/Daml/Finance/Claims/Util/Builders.daml
@@ -109,13 +109,12 @@ createFloatingRatePaymentClaims dateToTime schedule periodicSchedule useAdjusted
   floatingRateSpread ownerReceives dayCountConvention notional cashInstrument referenceRateId =
   let
     couponClaimAmounts = mconcat $ map (\p ->
-        when (TimeGte p.adjustedStartDate)
+        when (TimeGte p.adjustedEndDate)
         $ scale (
-          (Observe referenceRateId + Const floatingRateSpread) *
+          (ObserveAt referenceRateId p.adjustedStartDate + Const floatingRateSpread) *
           (Const (calcPeriodDcf dayCountConvention p useAdjustedDatesForDcf
                     periodicSchedule.terminationDate periodicSchedule.frequency)
           ))
-        $ when (TimeGte p.adjustedEndDate)
         $ scale (Const notional)
         $ one cashInstrument
       ) schedule

--- a/src/main/daml/Daml/Finance/Claims/Util/Builders.daml
+++ b/src/main/daml/Daml/Finance/Claims/Util/Builders.daml
@@ -137,10 +137,12 @@ createAssetPerformancePaymentClaims dateToTime schedule periodicSchedule useAdju
   let
     assetClaimAmounts = mconcat $ map (\p ->
       let
-        endClaim = when (TimeGte p.adjustedEndDate) $ scale (Const notional) $ one cashInstrument
+        performance =
+          Observe referenceAssetId / ObserveAt referenceAssetId p.adjustedStartDate - Const 1.0
       in
-        scaleByAssetPerformance p.adjustedStartDate p.adjustedEndDate (Observe referenceAssetId)
-          endClaim
+        when (TimeGte p.adjustedEndDate)
+          $ scale (Const notional * performance)
+          $ one cashInstrument
       ) schedule
     assetClaims = if ownerReceives then assetClaimAmounts else give assetClaimAmounts
   in

--- a/src/test/daml/ContingentClaims/Test/Lifecycle.daml
+++ b/src/test/daml/ContingentClaims/Test/Lifecycle.daml
@@ -464,11 +464,8 @@ testFloatingRateNote = script do
     fixingDate = date 2022 Mar 05
     paymentDate = date 2022 Mar 10
 
-    -- FRN written using nested `When` nodes
+    -- Floating Rate Note written using nested `When` nodes
     frn1 = when (TimeGte fixingDate) $ scale (O.Observe a) $ when (TimeGte paymentDate) $ one b
-
-    -- The same FRN, written using `ObserveAt`
-    frn2 = when (TimeGte paymentDate) $ scale (O.ObserveAt a fixingDate) $ One b
 
   Lifecycle.Result{pending, remaining} <-
     Lifecycle.lifecycle observeDayOfMonth frn1 acquisitionDate $ date 2022 Feb 28
@@ -482,6 +479,9 @@ testFloatingRateNote = script do
     Lifecycle.lifecycle observeDayOfMonth frn1 acquisitionDate $ date 2022 Mar 10
   remaining === Zero
   pending === [Lifecycle.Pending (date 2022 Mar 10) 5.0 b]
+
+  -- The same FRN, written using `ObserveAt`
+  let frn2 = when (TimeGte paymentDate) $ scale (O.ObserveAt a fixingDate) $ One b
 
   Lifecycle.Result{pending, remaining} <-
     Lifecycle.lifecycle observeDayOfMonth frn2 acquisitionDate $ date 2022 Feb 28

--- a/src/test/daml/ContingentClaims/Test/Lifecycle.daml
+++ b/src/test/daml/ContingentClaims/Test/Lifecycle.daml
@@ -456,24 +456,43 @@ testAmericanPut = script do
   remaining === zero -- past maturity; contract is now worthless
   pending === []
 
--- | Ensure that acquisition time is propagated correctly (deterministic time)
+-- | Ensure that acquisition time is propagated correctly (deterministic time).
 testFloatingRateNote : Script ()
 testFloatingRateNote = script do
   let
     acquisitionDate = date 2022 Mar 01
-    innerFrn = Scale (O.Observe a) $ When (TimeGte $ date 2022 Mar 10) $ One b
-    frn = When (TimeGte $ date 2022 Mar 05) innerFrn
+    fixingDate = date 2022 Mar 05
+    paymentDate = date 2022 Mar 10
+
+    -- FRN written using nested `When` nodes
+    frn1 = when (TimeGte fixingDate) $ scale (O.Observe a) $ when (TimeGte paymentDate) $ one b
+
+    -- The same FRN, written using `ObserveAt`
+    frn2 = when (TimeGte paymentDate) $ scale (O.ObserveAt a fixingDate) $ One b
 
   Lifecycle.Result{pending, remaining} <-
-    Lifecycle.lifecycle observeDayOfMonth frn acquisitionDate $ date 2022 Feb 28
-  remaining === frn
+    Lifecycle.lifecycle observeDayOfMonth frn1 acquisitionDate $ date 2022 Feb 28
+  remaining === frn1
 
   Lifecycle.Result{pending, remaining} <-
-    Lifecycle.lifecycle observeDayOfMonth frn acquisitionDate $ date 2022 Mar 07
-  remaining === frn
+    Lifecycle.lifecycle observeDayOfMonth frn1 acquisitionDate $ date 2022 Mar 07
+  remaining === frn1
 
   Lifecycle.Result{pending, remaining} <-
-    Lifecycle.lifecycle observeDayOfMonth frn acquisitionDate $ date 2022 Mar 10
+    Lifecycle.lifecycle observeDayOfMonth frn1 acquisitionDate $ date 2022 Mar 10
+  remaining === Zero
+  pending === [Lifecycle.Pending (date 2022 Mar 10) 5.0 b]
+
+  Lifecycle.Result{pending, remaining} <-
+    Lifecycle.lifecycle observeDayOfMonth frn2 acquisitionDate $ date 2022 Feb 28
+  remaining === frn2
+
+  Lifecycle.Result{pending, remaining} <-
+    Lifecycle.lifecycle observeDayOfMonth frn2 acquisitionDate $ date 2022 Mar 07
+  remaining === frn2
+
+  Lifecycle.Result{pending, remaining} <-
+    Lifecycle.lifecycle observeDayOfMonth frn2 acquisitionDate $ date 2022 Mar 10
   remaining === Zero
   pending === [Lifecycle.Pending (date 2022 Mar 10) 5.0 b]
 

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Asset.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Asset.daml
@@ -84,7 +84,7 @@ run = script do
   -- performance payments.
   let
     expectedConsumedQuantities = [qty 0.001675 cashInstrument]
-    expectedProducedQuantities = [qty 0.0801561777 cashInstrument]
+    expectedProducedQuantities = [qty 0.0801561782 cashInstrument]
   Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifyPaymentEffects [publicParty]
     firstPaymentDate swapInstrument issuer [observableCid] expectedConsumedQuantities
     expectedProducedQuantities
@@ -102,7 +102,7 @@ run = script do
   -- effects for fix rate and asset performance payments.
   let
     expectedConsumedQuantities = [qty 0.0049691667 cashInstrument]
-    expectedProducedQuantities = [qty 0.0372102912 cashInstrument]
+    expectedProducedQuantities = [qty 0.0372102913 cashInstrument]
   lifecycleAndVerifyPaymentEffects [publicParty] maturityDate swapInstrumentAfterFirstPayment
     issuer [observableCid] expectedConsumedQuantities expectedProducedQuantities
 

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/CreditDefault.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/CreditDefault.daml
@@ -307,7 +307,7 @@ setupParties = do
     createParties ["Custodian", "Issuer", "Calendar Data Provider", "PublicParty"]
   pure TestParties with custodian; issuer; calendarDataProvider; publicParty
 
--- Setup holiday calendar
+-- | Setup holiday calendar.
 holidayCalendarData = HolidayCalendarData with
   id = "USD"
   weekend = [Saturday, Sunday]


### PR DESCRIPTION
Fixes https://github.com/digital-asset/daml-finance/issues/767

I had an idea around contingent claims and it turns out it could be implemented rather quickly.

The problem:
- observations within a `scale` node are evaluated at `t` = the acquisition time of the sub-contract
- this makes it cumbersome to write expressions for an observable which is observed at different points in time

Ex.1 performance-linked payoff

The Observation in this case is of the form `S(t_1) / S(t_0) - 1`

Currently we need to write this as

`when (at t_0) $ scale (Const 1.0 / Observe S) $ when (at t_1) $ scale(Observe S) payoff and when (at t_1) $ give payoff` 

This expression is rather hard to read and the `payoff` sub-claim is duplicated. 

Ex 2. rate compounding

Rate compounding is currently implemented in a fashion similar to the above (a nested sequence of `When` and `Scale` nodes).

The approach:
- Introduce an `ObserveAt` combinator in the `Observation`, allowing the user to explicitly specify the observation time `t'`

The above performance payoff would become 

`when (at t_1) $ scale( Observe S / ObserveAt S t_0 - Const 1.0) one payoff`

The compounded payoffs would contain a single `scale` node instead of nested `when` and `scale` nodes.

I feel that this expression
- is easier to read
- has a smaller footprint (`payoff` used only once)
- can be faster to lifecycle, given that we don't enter the outer `When` node for `t < t_1`
- makes it easier to apply appropriate rounding (as we can condense the to-be-rounded expression in a single `scale` node)

I need to spend some time thinking about the valuation semantics for the `ObserveAt` node, but happy to hear your thoughts!