### PR TITLE
Implement payment lag for FpML swaps

### DIFF
--- a/src/main/daml/Daml/Finance/Instrument/Swap/Asset/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Asset/Instrument.daml
@@ -82,7 +82,7 @@ template Instrument
       getClaims Claim.GetClaims{actor} = do
         -- get the initial claims tree (as of the swap's acquisition time)
         let getCalendars = getHolidayCalendars actor calendarDataProvider
-        schedule <- rollSchedule getCalendars periodicSchedule holidayCalendarIds
+        (schedule, calendars) <- rollSchedule getCalendars periodicSchedule holidayCalendarIds
         let
           useAdjustedDatesForDcf = True
           notional = 1.0

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Asset/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Asset/Instrument.daml
@@ -82,7 +82,7 @@ template Instrument
       getClaims Claim.GetClaims{actor} = do
         -- get the initial claims tree (as of the swap's acquisition time)
         let getCalendars = getHolidayCalendars actor calendarDataProvider
-        (schedule, calendars) <- rollSchedule getCalendars periodicSchedule holidayCalendarIds
+        (schedule, _) <- rollSchedule getCalendars periodicSchedule holidayCalendarIds
         let
           useAdjustedDatesForDcf = True
           notional = 1.0

--- a/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault/Instrument.daml
@@ -82,7 +82,7 @@ template Instrument
       getClaims Claim.GetClaims{actor} = do
         -- get the initial claims tree (as of the swap's acquisition time)
         let getCalendars = getHolidayCalendars actor calendarDataProvider
-        schedule <- rollSchedule getCalendars periodicSchedule holidayCalendarIds
+        (schedule, calendars) <- rollSchedule getCalendars periodicSchedule holidayCalendarIds
         let
           useAdjustedDatesForDcf = True
           notional = 1.0

--- a/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault/Instrument.daml
@@ -82,7 +82,7 @@ template Instrument
       getClaims Claim.GetClaims{actor} = do
         -- get the initial claims tree (as of the swap's acquisition time)
         let getCalendars = getHolidayCalendars actor calendarDataProvider
-        (schedule, calendars) <- rollSchedule getCalendars periodicSchedule holidayCalendarIds
+        (schedule, _) <- rollSchedule getCalendars periodicSchedule holidayCalendarIds
         let
           useAdjustedDatesForDcf = True
           notional = 1.0

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Currency/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Currency/Instrument.daml
@@ -86,7 +86,7 @@ template Instrument
       getClaims Claim.GetClaims{actor} = do
         -- get the initial claims tree (as of the swap's acquisition time)
         let getCalendars = getHolidayCalendars actor calendarDataProvider
-        schedule <- rollSchedule getCalendars periodicSchedule holidayCalendarIds
+        (schedule, calendars) <- rollSchedule getCalendars periodicSchedule holidayCalendarIds
         let
           useAdjustedDatesForDcf = True
           notional = 1.0

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Currency/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Currency/Instrument.daml
@@ -86,7 +86,7 @@ template Instrument
       getClaims Claim.GetClaims{actor} = do
         -- get the initial claims tree (as of the swap's acquisition time)
         let getCalendars = getHolidayCalendars actor calendarDataProvider
-        (schedule, calendars) <- rollSchedule getCalendars periodicSchedule holidayCalendarIds
+        (schedule, _) <- rollSchedule getCalendars periodicSchedule holidayCalendarIds
         let
           useAdjustedDatesForDcf = True
           notional = 1.0

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
@@ -15,10 +15,7 @@ import Daml.Finance.Interface.Instrument.Swap.Fpml.FpmlTypes
 import Daml.Finance.Interface.Instrument.Swap.Fpml.Instrument qualified as Fpml (HasImplementation, I, View(..))
 import Daml.Finance.Interface.Instrument.Swap.Fpml.Types (Fpml(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..), InstrumentKey(..), PartiesMap)
-import Daml.Finance.Interface.Types.Date.RollConvention
-import Daml.Finance.Interface.Types.Date.Schedule (Frequency(..), PeriodicSchedule(..), SchedulePeriod(..), StubPeriodTypeEnum(..))
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
-import Daml.Finance.Util.Date.Calendar (addBusinessDays, adjustDate, merge)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 import Prelude hiding (key)
 
@@ -96,27 +93,8 @@ template Instrument
               getCalendars
               paymentPeriodicSchedule
               s.paymentDates.paymentDatesAdjustments.businessCenters
-
-            -- Adjust payment schedule according to paymentDaysOffset (if available)
-            -- TODO: Move to a separate function
-            let
-              paymentSchedule = case s.paymentDates.paymentDaysOffset of
-                Some dateOffset -> case dateOffset.dayType of
-                    Some Business -> map (\p -> SchedulePeriod with
-                        adjustedEndDate = addBusinessDays cals nDays p.adjustedEndDate
-                        adjustedStartDate = p.adjustedStartDate
-                        unadjustedEndDate = p.unadjustedEndDate
-                        unadjustedStartDate = p.unadjustedStartDate
-                        stubType = p.stubType
-                      ) paymentScheduleBase
-                        --
-                    Some Calendar -> paymentScheduleBase
-                    _ -> error "Only Business or Calendar dayType supported"
-                  where
-                    nDays = if dateOffset.period == D then dateOffset.periodMultiplier
-                      else error "Only daily offset supported"
-                    cals = merge paymentCalendars
-                None -> paymentScheduleBase
+            let paymentSchedule = applyPaymentDaysOffset paymentScheduleBase s.paymentDates
+                  paymentCalendars
 
             -- Verify the effectiveDate and the terminationDate
             effectiveDateAdjusted <- adjustDateAccordingToBusinessDayAdjustments

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
@@ -15,7 +15,10 @@ import Daml.Finance.Interface.Instrument.Swap.Fpml.FpmlTypes
 import Daml.Finance.Interface.Instrument.Swap.Fpml.Instrument qualified as Fpml (HasImplementation, I, View(..))
 import Daml.Finance.Interface.Instrument.Swap.Fpml.Types (Fpml(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..), InstrumentKey(..), PartiesMap)
+import Daml.Finance.Interface.Types.Date.RollConvention
+import Daml.Finance.Interface.Types.Date.Schedule (Frequency(..), PeriodicSchedule(..), SchedulePeriod(..), StubPeriodTypeEnum(..))
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
+import Daml.Finance.Util.Date.Calendar (addBusinessDays, adjustDate, merge)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 import Prelude hiding (key)
 
@@ -85,14 +88,35 @@ template Instrument
               s.paymentDates.payRelativeTo == CalculationPeriodEndDate
             let getCalendars = getHolidayCalendars issuer calendarDataProvider
 
-            calculationSchedule <- rollSchedule
+            (calculationSchedule, calculationCalendars) <- rollSchedule
               getCalendars
               calculationPeriodicSchedule
               s.calculationPeriodDates.calculationPeriodDatesAdjustments.businessCenters
-            paymentSchedule <- rollSchedule
+            (paymentScheduleBase, paymentCalendars) <- rollSchedule
               getCalendars
               paymentPeriodicSchedule
               s.paymentDates.paymentDatesAdjustments.businessCenters
+
+            -- Adjust payment schedule according to paymentDaysOffset (if available)
+            -- TODO: Move to a separate function
+            let
+              paymentSchedule = case s.paymentDates.paymentDaysOffset of
+                Some dateOffset -> case dateOffset.dayType of
+                    Some Business -> map (\p -> SchedulePeriod with
+                        adjustedEndDate = addBusinessDays cals nDays p.adjustedEndDate
+                        adjustedStartDate = p.adjustedStartDate
+                        unadjustedEndDate = p.unadjustedEndDate
+                        unadjustedStartDate = p.unadjustedStartDate
+                        stubType = p.stubType
+                      ) paymentScheduleBase
+                        --
+                    Some Calendar -> paymentScheduleBase
+                    _ -> error "Only Business or Calendar dayType supported"
+                  where
+                    nDays = if dateOffset.period == D then dateOffset.periodMultiplier
+                      else error "Only daily offset supported"
+                    cals = merge paymentCalendars
+                None -> paymentScheduleBase
 
             -- Verify the effectiveDate and the terminationDate
             effectiveDateAdjusted <- adjustDateAccordingToBusinessDayAdjustments

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
@@ -85,7 +85,7 @@ template Instrument
               s.paymentDates.payRelativeTo == CalculationPeriodEndDate
             let getCalendars = getHolidayCalendars issuer calendarDataProvider
 
-            (calculationSchedule, calculationCalendars) <- rollSchedule
+            (calculationSchedule, _) <- rollSchedule
               getCalendars
               calculationPeriodicSchedule
               s.calculationPeriodDates.calculationPeriodDatesAdjustments.businessCenters

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -17,7 +17,7 @@ import Daml.Finance.Interface.Instrument.Swap.Fpml.FpmlTypes
 import Daml.Finance.Interface.Types.Common.Types (Id(..))
 import Daml.Finance.Interface.Types.Date.Calendar
 import Daml.Finance.Interface.Types.Date.RollConvention
-import Daml.Finance.Interface.Types.Date.Schedule (Frequency(..), PeriodicSchedule(..), SchedulePeriod, StubPeriodTypeEnum(..))
+import Daml.Finance.Interface.Types.Date.Schedule (Frequency(..), PeriodicSchedule(..), SchedulePeriod(..), StubPeriodTypeEnum(..))
 import Daml.Finance.Util.Date.Calendar (addBusinessDays, adjustDate, merge)
 import Daml.Finance.Util.Date.DayCount (calcPeriodDcf)
 import Daml.Finance.Util.Date.RollConvention (addPeriod)
@@ -79,6 +79,35 @@ adjustDateAccordingToBusinessDayAdjustments unadjustedDate businessDayAdjustment
     case businessDayAdjustments.businessDayConvention of
       NoAdjustment -> pure $ unadjustedDate
       _ -> getCalendarsAndAdjust unadjustedDate businessDayAdjustments issuer calendarDataAgency
+
+-- Adjust payment schedule according to paymentDaysOffset (if available).
+applyPaymentDaysOffset : [SchedulePeriod] -> PaymentDates -> [HolidayCalendarData] ->
+  [SchedulePeriod]
+applyPaymentDaysOffset paymentSchedule paymentDates paymentCalendars =
+  case paymentDates.paymentDaysOffset of
+    Some dateOffset -> case dateOffset.dayType of
+      Some Business -> map (\p -> SchedulePeriod with
+          adjustedEndDate = addBusinessDays cals nDays p.adjustedEndDate
+          adjustedStartDate = p.adjustedStartDate
+          unadjustedEndDate = p.unadjustedEndDate
+          unadjustedStartDate = p.unadjustedStartDate
+          stubType = p.stubType
+        ) paymentSchedule
+      Some Calendar -> map (\p -> SchedulePeriod with
+          adjustedEndDate = adjustDate cals
+            paymentDates.paymentDatesAdjustments.businessDayConvention
+            (addDays p.adjustedEndDate nDays)
+          adjustedStartDate = p.adjustedStartDate
+          unadjustedEndDate = p.unadjustedEndDate
+          unadjustedStartDate = p.unadjustedStartDate
+          stubType = p.stubType
+        ) paymentSchedule
+      _ -> error "Only Business or Calendar day type supported"
+      where
+        nDays = if dateOffset.period == D then dateOffset.periodMultiplier
+          else error "Only daily offset supported"
+        cals = merge paymentCalendars
+    None -> paymentSchedule
 
 -- | Define observable part of claim when one specific floating rate is provided for a stub period.
 getSingleStubRate : StubFloatingRate -> Optional O
@@ -497,8 +526,6 @@ calculateClaimsFromSwapStream : SwapStream -> PeriodicSchedule -> [SchedulePerio
   Update [TaggedClaim]
 calculateClaimsFromSwapStream s periodicSchedule calculationSchedule paymentSchedule
   swapStreamNotionalRef useAdjustedDatesForDcf issuerPaysLeg currency issuer calendarDataAgency = do
-    assertMsg "Payment lag not yet supported" $
-      isNone s.paymentDates.paymentDaysOffset
     case s.calculationPeriodAmount.calculation.notionalScheduleValue of
       NotionalSchedule_FxLinked fxl -> assertMsg
         "swapStream currency does not match swap currency" $

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -86,21 +86,13 @@ applyPaymentDaysOffset : [SchedulePeriod] -> PaymentDates -> [HolidayCalendarDat
 applyPaymentDaysOffset paymentSchedule paymentDates paymentCalendars =
   case paymentDates.paymentDaysOffset of
     Some dateOffset -> case dateOffset.dayType of
-      Some Business -> map (\p -> SchedulePeriod with
+      Some Business -> map (\p -> p with
           adjustedEndDate = addBusinessDays cals nDays p.adjustedEndDate
-          adjustedStartDate = p.adjustedStartDate
-          unadjustedEndDate = p.unadjustedEndDate
-          unadjustedStartDate = p.unadjustedStartDate
-          stubType = p.stubType
         ) paymentSchedule
-      Some Calendar -> map (\p -> SchedulePeriod with
+      Some Calendar -> map (\p -> p with
           adjustedEndDate = adjustDate cals
             paymentDates.paymentDatesAdjustments.businessDayConvention
             (addDays p.adjustedEndDate nDays)
-          adjustedStartDate = p.adjustedStartDate
-          unadjustedEndDate = p.unadjustedEndDate
-          unadjustedStartDate = p.unadjustedStartDate
-          stubType = p.stubType
         ) paymentSchedule
       _ -> error "Only Business or Calendar day type supported"
       where

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -80,7 +80,7 @@ adjustDateAccordingToBusinessDayAdjustments unadjustedDate businessDayAdjustment
       NoAdjustment -> pure $ unadjustedDate
       _ -> getCalendarsAndAdjust unadjustedDate businessDayAdjustments issuer calendarDataAgency
 
--- Adjust payment schedule according to paymentDaysOffset (if available).
+-- | Adjust payment schedule according to paymentDaysOffset (if available).
 applyPaymentDaysOffset : [SchedulePeriod] -> PaymentDates -> [HolidayCalendarData] ->
   [SchedulePeriod]
 applyPaymentDaysOffset paymentSchedule paymentDates paymentCalendars =

--- a/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate/Instrument.daml
@@ -77,7 +77,7 @@ template Instrument
       getClaims Claim.GetClaims{actor} = do
         -- get the initial claims tree (as of the swap's acquisition time)
         let getCalendars = getHolidayCalendars actor calendarDataProvider
-        (schedule, calendars) <- rollSchedule getCalendars periodicSchedule holidayCalendarIds
+        (schedule, _) <- rollSchedule getCalendars periodicSchedule holidayCalendarIds
         let
           useAdjustedDatesForDcf = True
           notional = 1.0

--- a/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate/Instrument.daml
@@ -77,7 +77,7 @@ template Instrument
       getClaims Claim.GetClaims{actor} = do
         -- get the initial claims tree (as of the swap's acquisition time)
         let getCalendars = getHolidayCalendars actor calendarDataProvider
-        schedule <- rollSchedule getCalendars periodicSchedule holidayCalendarIds
+        (schedule, calendars) <- rollSchedule getCalendars periodicSchedule holidayCalendarIds
         let
           useAdjustedDatesForDcf = True
           notional = 1.0

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Util.daml
@@ -27,7 +27,8 @@ getHolidayCalendars actor provider holidayCalendarIds =
     mapA getCalendar holidayCalendarIds
 
 -- | Retrieve holiday calendar(s) from the ledger and roll out a schedule.
-rollSchedule : ([Text] -> Update [HolidayCalendarData]) -> PeriodicSchedule -> [Text] -> Update Schedule
+rollSchedule : ([Text] -> Update [HolidayCalendarData]) -> PeriodicSchedule -> [Text] ->
+  Update (Schedule, [HolidayCalendarData])
 rollSchedule getHolidayCalendars periodicSchedule holidayCalendarIds = do
   cals <- getHolidayCalendars holidayCalendarIds
-  pure $ createSchedule cals periodicSchedule
+  pure (createSchedule cals periodicSchedule, cals)

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -2100,13 +2100,10 @@ runFpml3 = script do
         firstPaymentDate = None
         lastRegularPaymentDate = None
         payRelativeTo = CalculationPeriodEndDate
-        {-
         paymentDaysOffset = Some DateOffset with
           periodMultiplier = 5
           period = D
           dayType = Some Business
-        -}
-        paymentDaysOffset = None -- https://github.com/digital-asset/daml-finance/issues/519
         paymentDatesAdjustments = BusinessDayAdjustments with
             businessDayConvention = ModifiedFollowing
             businessCenters = primaryBusinessCenters
@@ -2183,13 +2180,10 @@ runFpml3 = script do
         firstPaymentDate = None
         lastRegularPaymentDate = None
         payRelativeTo = CalculationPeriodEndDate
-        {-
         paymentDaysOffset = Some DateOffset with
           periodMultiplier = 5
           period = D
           dayType = Some Business
-        -}
-        paymentDaysOffset = None -- https://github.com/digital-asset/daml-finance/issues/519
         paymentDatesAdjustments = BusinessDayAdjustments with
             businessDayConvention = ModifiedFollowing
             businessCenters = primaryBusinessCenters
@@ -2222,6 +2216,7 @@ runFpml3 = script do
       provider = calendarDataProvider; calendar = fixingCal
       observers = M.fromList observers
 
+
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
       provider = issuer; id = Id referenceRateId; observations; observers = M.empty
@@ -2235,7 +2230,7 @@ runFpml3 = script do
     expectedConsumedQuantities = [qty 2925000.0 cashInstrumentCid]
     expectedProducedQuantities = [qty 3253611.11 cashInstrumentCid]
   Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
-    (date 2000 Oct 27) swapInstrument issuer observableCids expectedConsumedQuantities
+    (date 2000 Nov 3) swapInstrument issuer observableCids expectedConsumedQuantities
     expectedProducedQuantities
 
   -- Second payment date: Lifecycle and verify the fix and floating payments (regular 6M period)
@@ -2243,7 +2238,7 @@ runFpml3 = script do
     expectedConsumedQuantities = [qty 2925000.0 cashInstrumentCid]
     expectedProducedQuantities = [qty 3436111.11 cashInstrumentCid]
   Some swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
-    (date 2001 Apr 27) swapInstrumentAfterFirstPayment issuer observableCids
+    (date 2001 May 4) swapInstrumentAfterFirstPayment issuer observableCids
     expectedConsumedQuantities expectedProducedQuantities
 
   pure ()


### PR DESCRIPTION
- Implement logic described by the `paymentDaysOffset` FpML element
- Enable payment lag for the official FpML sample trade 3, which contains this feature.

Fixes https://github.com/digital-asset/daml-finance/issues/519