### PR TITLE
Improve parsing of notionalStepSchedule for FpML swaps

### DIFF
--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -610,10 +610,11 @@ calculateClaimsFromSwapStream s periodicSchedule calculationSchedule paymentSche
           _ -> error ""
 
       -- Find the notional of a calculation period in the notional step list
-      findNotional fxAdjustmentRequired notionalSteps c =
+      findNotional notionalSteps fxAdjustmentRequired calculationPeriod =
         (notionalValue, fxAdjustmentRequired)
         where
-          notionalStepsFiltered = filter (\n -> n.stepDate <= c.unadjustedStartDate) notionalSteps
+          notionalStepsFiltered = filter (\n -> n.stepDate <= calculationPeriod.unadjustedStartDate)
+            notionalSteps
           lastMatching = last $ sortOn (.stepDate) notionalStepsFiltered
           notionalValue = lastMatching.stepValue
 
@@ -621,12 +622,11 @@ calculateClaimsFromSwapStream s periodicSchedule calculationSchedule paymentSche
         stepDate = (.unadjustedStartDate) $ head calculationSchedule
         stepValue = n.notionalStepSchedule.initialValue
       notionalStepScheduleInclInitial = initialStep :: n.notionalStepSchedule.step
-      notionalBase = map (findNotional fxAdjustmentRequired notionalStepScheduleInclInitial) calculationSchedule
-
+      notionalBase = map (findNotional notionalStepScheduleInclInitial fxAdjustmentRequired)
+        calculationSchedule
       notionals = case fxLinkedNotionalInitialValue of
         None -> notionalBase
         Some iv -> (iv, False) :: (drop 1 notionalBase)
-
     assertMsg "notionals list must be of same length as calculationSchedule" $
       length notionals == length calculationSchedule
     paymentScheduleAligned <- alignPaymentSchedule calculationSchedule paymentSchedule

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -8,7 +8,7 @@ import ContingentClaims.Core.Observation (Observation(..))
 import DA.BigNumeric qualified as BN
 import DA.Date
 import DA.Foldable (foldMap)
-import DA.List (dedup, head, init, last, tail)
+import DA.List (dedup, head, init, last, sortOn, tail)
 import DA.Optional (fromOptional, fromSome, isNone, isSome, whenSome)
 import Daml.Finance.Claims.Util.Builders (prepareAndTagClaims)
 import Daml.Finance.Instrument.Swap.Util
@@ -608,23 +608,25 @@ calculateClaimsFromSwapStream s periodicSchedule calculationSchedule paymentSche
         _ -> case s.calculationPeriodAmount.calculation.notionalScheduleValue of
           NotionalSchedule_Regular nr -> nr
           _ -> error ""
-      notionalSteps = n.notionalStepSchedule.step
-      notionalBase
-        | length notionalSteps == length calculationSchedule
-            = if
-                any (\(n, p) -> n.stepDate /= p.unadjustedStartDate) $
-                  zip notionalSteps calculationSchedule
-              then error "notional step schedule does not match calculationSchedule"
-              else map (\e -> (e.stepValue, fxAdjustmentRequired)) notionalSteps
-        | null notionalSteps
-            = replicate (length calculationSchedule)
-                (n.notionalStepSchedule.initialValue, fxAdjustmentRequired)
-        | otherwise
-            = error ("number of notional steps do not match the number of calculationSchedule " <>
-                "periods")
+
+      -- Find the notional of a calculation period in the notional step list
+      findNotional fxAdjustmentRequired notionalSteps c =
+        (notionalValue, fxAdjustmentRequired)
+        where
+          notionalStepsFiltered = filter (\n -> n.stepDate <= c.unadjustedStartDate) notionalSteps
+          lastMatching = last $ sortOn (.stepDate) notionalStepsFiltered
+          notionalValue = lastMatching.stepValue
+
+      initialStep = Step with
+        stepDate = (.unadjustedStartDate) $ head calculationSchedule
+        stepValue = n.notionalStepSchedule.initialValue
+      notionalStepScheduleInclInitial = initialStep :: n.notionalStepSchedule.step
+      notionalBase = map (findNotional fxAdjustmentRequired notionalStepScheduleInclInitial) calculationSchedule
+
       notionals = case fxLinkedNotionalInitialValue of
         None -> notionalBase
         Some iv -> (iv, False) :: (drop 1 notionalBase)
+
     assertMsg "notionals list must be of same length as calculationSchedule" $
       length notionals == length calculationSchedule
     paymentScheduleAligned <- alignPaymentSchedule calculationSchedule paymentSchedule

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -607,7 +607,7 @@ calculateClaimsFromSwapStream s periodicSchedule calculationSchedule paymentSche
           NotionalSchedule_Regular nr -> nr
         _ -> case s.calculationPeriodAmount.calculation.notionalScheduleValue of
           NotionalSchedule_Regular nr -> nr
-          _ -> error ""
+          _ -> error "Regular notional schedule required if no swapStream notional ref provided."
 
       -- Find the notional of a calculation period in the notional step list
       findNotional notionalSteps fxAdjustmentRequired calculationPeriod =

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -1843,25 +1843,11 @@ runFpml2 = script do
             id = "floatingLegNotionalSchedule"
             notionalStepSchedule = NotionalStepSchedule with
               initialValue = notional
-              {-
               step =
                 [ Step with stepDate = date 1995 Dec 14; stepValue = 40000000.0
                 , Step with stepDate = date 1996 Dec 14; stepValue = 30000000.0
                 , Step with stepDate = date 1997 Dec 14; stepValue = 20000000.0
                 , Step with stepDate = date 1998 Dec 14; stepValue = 10000000.0
-                ] -- https://github.com/digital-asset/daml-finance/issues/520
-              -}
-              step =
-                [ Step with stepDate = date 1995 Jan 16; stepValue = 50000000.0
-                , Step with stepDate = date 1995 Jun 14; stepValue = 50000000.0
-                , Step with stepDate = date 1995 Dec 14; stepValue = 40000000.0
-                , Step with stepDate = date 1996 Jun 14; stepValue = 40000000.0
-                , Step with stepDate = date 1996 Dec 14; stepValue = 30000000.0
-                , Step with stepDate = date 1997 Jun 14; stepValue = 30000000.0
-                , Step with stepDate = date 1997 Dec 14; stepValue = 20000000.0
-                , Step with stepDate = date 1998 Jun 14; stepValue = 20000000.0
-                , Step with stepDate = date 1998 Dec 14; stepValue = 10000000.0
-                , Step with stepDate = date 1999 Jun 14; stepValue = 10000000.0
                 ]
               currency = ccy
           rateTypeValue = RateType_Floating FloatingRateCalculation with
@@ -1929,17 +1915,8 @@ runFpml2 = script do
             id = "fixedLegNotionalSchedule"
             notionalStepSchedule = NotionalStepSchedule with
               initialValue = notional
-              {-
               step =
                 [ Step with stepDate = date 1995 Dec 14; stepValue = 40000000.0
-                , Step with stepDate = date 1996 Dec 14; stepValue = 30000000.0
-                , Step with stepDate = date 1997 Dec 14; stepValue = 20000000.0
-                , Step with stepDate = date 1998 Dec 14; stepValue = 10000000.0
-                ] -- https://github.com/digital-asset/daml-finance/issues/520
-              -}
-              step =
-                [ Step with stepDate = date 1995 Jan 16; stepValue = 50000000.0
-                , Step with stepDate = date 1995 Dec 14; stepValue = 40000000.0
                 , Step with stepDate = date 1996 Dec 14; stepValue = 30000000.0
                 , Step with stepDate = date 1997 Dec 14; stepValue = 20000000.0
                 , Step with stepDate = date 1998 Dec 14; stepValue = 10000000.0


### PR DESCRIPTION
- Support when the initialStep is not included in the steps list
- Support when not each calculationStep has a corresponding notional step.
- Enable the simpler way of specifying notional steps for the official FpML sample trade 2.

Fixes https://github.com/digital-asset/daml-finance/issues/520