### PR TITLE
Enable rate compounding for 2 FpML test cases

### DIFF
--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -531,7 +531,7 @@ runDualStubSampleTrade = script do
             spreadSchedule = [SpreadSchedule with initialValue = 0.005]
             finalRateRounding = None
           dayCountFraction = dayCountConvention
-          compoundingMethodEnum = None
+          compoundingMethodEnum = Some Straight
       stubCalculationPeriodAmount = Some StubCalculationPeriodAmount with
         calculationPeriodDatesReference = "floatingLegCalcPeriodDates"
         initialStub = Some $ StubValue_StubRate 0.015
@@ -595,8 +595,7 @@ runDualStubSampleTrade = script do
           rateTypeValue = RateType_Fixed FixedRateSchedule with
             initialValue = fixRate
           dayCountFraction = dayCountConvention
-          -- compoundingMethodEnum = Some Straight
-          compoundingMethodEnum = None -- https://github.com/digital-asset/daml-finance/issues/517
+          compoundingMethodEnum = None
       stubCalculationPeriodAmount = None
       principalExchanges = None
     -- CREATE_FPML_SWAP_FIX_LEG_END
@@ -2120,8 +2119,7 @@ runFpml3 = script do
             -}
             finalRateRounding = None -- https://github.com/digital-asset/daml-finance/issues/518
           dayCountFraction = Act360
-          -- compoundingMethodEnum = Some Flat
-          compoundingMethodEnum = None -- https://github.com/digital-asset/daml-finance/issues/517
+          compoundingMethodEnum = Some Flat
       stubCalculationPeriodAmount = None
       principalExchanges = None
 
@@ -2205,7 +2203,7 @@ runFpml3 = script do
   -- First payment date: Lifecycle and verify the fix and floating payments (regular 6M period)
   let
     expectedConsumedQuantities = [qty 2925000.0 cashInstrumentCid]
-    expectedProducedQuantities = [qty 3253611.11 cashInstrumentCid]
+    expectedProducedQuantities = [qty 3280064.30442675 cashInstrumentCid]
   Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     (date 2000 Nov 3) swapInstrument issuer observableCids expectedConsumedQuantities
     expectedProducedQuantities
@@ -2213,7 +2211,7 @@ runFpml3 = script do
   -- Second payment date: Lifecycle and verify the fix and floating payments (regular 6M period)
   let
     expectedConsumedQuantities = [qty 2925000.0 cashInstrumentCid]
-    expectedProducedQuantities = [qty 3436111.11 cashInstrumentCid]
+    expectedProducedQuantities = [qty 3465618.4062796481 cashInstrumentCid]
   Some swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     (date 2001 May 4) swapInstrumentAfterFirstPayment issuer observableCids
     expectedConsumedQuantities expectedProducedQuantities


### PR DESCRIPTION
- Enabled rates compounding for the official sample trade 3: the cashflows changed as expected, because 3 calculation periods are compounded in each payment period.
- Enabled rates compounding for the DualStubSampleTrade: the cashflows did not change, because there is only one calculation period in each payment period.