### PR TITLE
Add FpML sample trade 5 and enhance stub period logic

### DIFF
--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
@@ -67,9 +67,14 @@ template Instrument
         -- get the initial claims tree (as of the swap's acquisition time)
         let
           calculateSwapStreamClaims (s, ccy) = do
+            debug s.calculationPeriodDates
             let
               calculationPeriodicSchedule = createCalculationPeriodicSchedule s.calculationPeriodDates
+            debug calculationPeriodicSchedule
+            let
               paymentPeriodicSchedule = createPaymentPeriodicSchedule s
+            debug paymentPeriodicSchedule
+            let
               useAdjustedDatesForDcf = True
               issuerPaysLeg = if s.payerPartyReference == s.receiverPartyReference
                               then error "payer and receiver must be different counterparties"

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
@@ -4,7 +4,6 @@
 module Daml.Finance.Instrument.Swap.Fpml.Instrument where
 
 import DA.Date (daysSinceEpochToDate)
-import DA.List (head)
 import DA.Set (singleton)
 import Daml.Finance.Instrument.Swap.Fpml.Util
 import Daml.Finance.Instrument.Swap.Util
@@ -94,22 +93,13 @@ template Instrument
               getCalendars
               calculationPeriodicSchedule
               s.calculationPeriodDates.calculationPeriodDatesAdjustments.businessCenters
+            debug calculationSchedule
             (paymentScheduleBase, paymentCalendars) <- rollSchedule
               getCalendars
               paymentPeriodicSchedule
               s.paymentDates.paymentDatesAdjustments.businessCenters
             let paymentSchedule = applyPaymentDaysOffset paymentScheduleBase s.paymentDates
                   paymentCalendars
-
-            -- Verify the effectiveDate (not the terminationDate, because it can differ from the
-            -- last date of the calculationSchedule, as seen in the official FpML sample trade 4).
-            effectiveDateAdjusted <- adjustDateAccordingToBusinessDayAdjustments
-              e.unadjustedDate e.dateAdjustments issuer calendarDataProvider
-            terminationDateAdjusted <- adjustDateAccordingToBusinessDayAdjustments
-              t.unadjustedDate t.dateAdjustments issuer calendarDataProvider
-            let h = head calculationSchedule
-            assertMsg ("The adjusted effectiveDate must match the adjusted start date of the " <>
-              "first period") $ h.adjustedStartDate == effectiveDateAdjusted
 
             -- If there is an fxLinkedNotionalSchedule, look up which swap leg contains
             -- the base notional

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
@@ -66,20 +66,13 @@ template Instrument
         -- get the initial claims tree (as of the swap's acquisition time)
         let
           calculateSwapStreamClaims (s, ccy) = do
-            debug s.calculationPeriodDates
             let
               calculationPeriodicSchedule = createCalculationPeriodicSchedule s.calculationPeriodDates
-            debug calculationPeriodicSchedule
-            let
               paymentPeriodicSchedule = createPaymentPeriodicSchedule s
-            debug paymentPeriodicSchedule
-            let
               useAdjustedDatesForDcf = True
               issuerPaysLeg = if s.payerPartyReference == s.receiverPartyReference
                               then error "payer and receiver must be different counterparties"
                               else (s.payerPartyReference == issuerPartyRef)
-              e = s.calculationPeriodDates.effectiveDate
-              t = s.calculationPeriodDates.terminationDate
 
             -- Verify the payment schedule
             assertMsg ("The payment schedule must refer to the calculationPeriodDates of the " <>
@@ -93,7 +86,6 @@ template Instrument
               getCalendars
               calculationPeriodicSchedule
               s.calculationPeriodDates.calculationPeriodDatesAdjustments.businessCenters
-            debug calculationSchedule
             (paymentScheduleBase, paymentCalendars) <- rollSchedule
               getCalendars
               paymentPeriodicSchedule

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -65,7 +65,9 @@ createCalculationPeriodicSchedule c =
       rollConvention = c.calculationPeriodFrequency.rollConvention
       period = c.calculationPeriodFrequency.period
       periodMultiplier = c.calculationPeriodFrequency.periodMultiplier
-    effectiveDate = c.effectiveDate.unadjustedDate
+    effectiveDate = case c.firstPeriodStartDate of
+      Some fp -> fp
+      None -> c.effectiveDate.unadjustedDate
     firstRegularPeriodStartDate = c.firstRegularPeriodStartDate
     lastRegularPeriodEndDate = c.lastRegularPeriodEndDate
     stubPeriodType = None

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -67,6 +67,7 @@ createCalculationPeriodicSchedule c =
       periodMultiplier = c.calculationPeriodFrequency.periodMultiplier
     effectiveDate = case c.firstPeriodStartDate of
       Some fp -> fp
+      --Some fp -> c.effectiveDate.unadjustedDate
       None -> c.effectiveDate.unadjustedDate
     firstRegularPeriodStartDate = c.firstRegularPeriodStartDate
     lastRegularPeriodEndDate = c.lastRegularPeriodEndDate
@@ -454,7 +455,8 @@ calculateNotionalAndFixings p s
   where
     paymentPeriodStaticDataFiltered = filter (\c ->
       c.calculationPeriod.unadjustedEndDate <= p.unadjustedEndDate &&
-      c.calculationPeriod.unadjustedStartDate >= p.unadjustedStartDate)
+      --c.calculationPeriod.unadjustedStartDate >= p.unadjustedStartDate)
+      c.calculationPeriod.unadjustedEndDate > p.unadjustedStartDate)
       paymentPeriodStaticData
 
     -- Ensure that all notionals and fxAdjRequireds are the same for each paymentPeriod

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -66,8 +66,7 @@ createCalculationPeriodicSchedule c =
       period = c.calculationPeriodFrequency.period
       periodMultiplier = c.calculationPeriodFrequency.periodMultiplier
     effectiveDate = case c.firstPeriodStartDate of
-      Some fp -> fp
-      --Some fp -> c.effectiveDate.unadjustedDate
+      Some fp -> fp.unadjustedDate
       None -> c.effectiveDate.unadjustedDate
     firstRegularPeriodStartDate = c.firstRegularPeriodStartDate
     lastRegularPeriodEndDate = c.lastRegularPeriodEndDate

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -454,7 +454,6 @@ calculateNotionalAndFixings p s
   where
     paymentPeriodStaticDataFiltered = filter (\c ->
       c.calculationPeriod.unadjustedEndDate <= p.unadjustedEndDate &&
-      --c.calculationPeriod.unadjustedStartDate >= p.unadjustedStartDate)
       c.calculationPeriod.unadjustedEndDate > p.unadjustedStartDate)
       paymentPeriodStaticData
 

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Fpml/FpmlTypes.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Fpml/FpmlTypes.daml
@@ -42,7 +42,7 @@ data CalculationPeriodDates = CalculationPeriodDates
     effectiveDate : AdjustableDate
     terminationDate : AdjustableDate
     calculationPeriodDatesAdjustments : CalculationPeriodDatesAdjustments
-    firstPeriodStartDate : Optional Date
+    firstPeriodStartDate : Optional AdjustableDate
     firstRegularPeriodStartDate : Optional Date
     lastRegularPeriodEndDate : Optional Date
     calculationPeriodFrequency : CalculationPeriodFrequency

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Fpml/FpmlTypes.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Fpml/FpmlTypes.daml
@@ -42,6 +42,7 @@ data CalculationPeriodDates = CalculationPeriodDates
     effectiveDate : AdjustableDate
     terminationDate : AdjustableDate
     calculationPeriodDatesAdjustments : CalculationPeriodDatesAdjustments
+    firstPeriodStartDate : Optional Date
     firstRegularPeriodStartDate : Optional Date
     lastRegularPeriodEndDate : Optional Date
     calculationPeriodFrequency : CalculationPeriodFrequency

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -85,6 +85,7 @@ run = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
           businessCenters = holidayCalendarId
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = Some firstPaymentDate
         lastRegularPeriodEndDate = None
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -156,6 +157,7 @@ run = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
           businessCenters = holidayCalendarId
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = Some firstPaymentDate
         lastRegularPeriodEndDate = None
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -310,6 +312,7 @@ runStubRateInterpolation = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
           businessCenters = holidayCalendarId
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = Some firstRegularPeriodDate
         lastRegularPeriodEndDate = Some lastRegularPeriodDate
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -483,6 +486,7 @@ runDualStubSampleTrade = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
           businessCenters = holidayCalendarId
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = Some firstRegularPeriodDate
         lastRegularPeriodEndDate = Some lastRegularPeriodDate
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -566,6 +570,7 @@ runDualStubSampleTrade = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
           businessCenters = holidayCalendarId
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = Some firstRegularPeriodDateFixLeg
         lastRegularPeriodEndDate = Some lastRegularPeriodDateFixLeg
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -739,6 +744,7 @@ runSeparatePaymentFrequencySampleTrade = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
           businessCenters = holidayCalendarId
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = Some firstRegularPeriodDate
         lastRegularPeriodEndDate = None
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -820,6 +826,7 @@ runSeparatePaymentFrequencySampleTrade = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
           businessCenters = holidayCalendarId
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = Some firstRegularPeriodDate
         lastRegularPeriodEndDate = None
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -1012,6 +1019,7 @@ runCurrencySwapSampleTrade = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
           businessCenters = holidayCalendarId
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = None
         lastRegularPeriodEndDate = None
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -1086,6 +1094,7 @@ runCurrencySwapSampleTrade = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
           businessCenters = holidayCalendarId
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = None
         lastRegularPeriodEndDate = None
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -1303,6 +1312,7 @@ runAmortizingNotionalSampleTrade = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
           businessCenters = holidayCalendarId
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = Some firstRegularPeriodDateFixLeg
         lastRegularPeriodEndDate = Some lastRegularPeriodDateFixLeg
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -1369,6 +1379,7 @@ runAmortizingNotionalSampleTrade = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
           businessCenters = holidayCalendarId
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = Some firstRegularPeriodDate
         lastRegularPeriodEndDate = Some lastRegularPeriodDate
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -1585,6 +1596,7 @@ runFpml1 = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
           businessCenters = primaryBusinessCenters
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = None
         lastRegularPeriodEndDate = None
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -1656,6 +1668,7 @@ runFpml1 = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
           businessCenters = primaryBusinessCenters
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = None
         lastRegularPeriodEndDate = None
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -1808,6 +1821,7 @@ runFpml2 = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
           businessCenters = primaryBusinessCenters
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = Some firstRegularDateFloat
         lastRegularPeriodEndDate = None
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -1894,6 +1908,7 @@ runFpml2 = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
           businessCenters = primaryBusinessCenters
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = Some firstRegularDateFixed
         lastRegularPeriodEndDate = None
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -2068,6 +2083,7 @@ runFpml3 = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
           businessCenters = primaryBusinessCenters
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = None
         lastRegularPeriodEndDate = None
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -2147,6 +2163,7 @@ runFpml3 = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
           businessCenters = primaryBusinessCenters
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = None
         lastRegularPeriodEndDate = None
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -2309,6 +2326,7 @@ runCompounding = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
           businessCenters = primaryBusinessCenters
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = None
         lastRegularPeriodEndDate = None
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -2458,6 +2476,7 @@ runCompoundingFlat = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
           businessCenters = primaryBusinessCenters
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = None
         lastRegularPeriodEndDate = None
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -2608,6 +2627,7 @@ runCompoundingSpreadSimple = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
           businessCenters = primaryBusinessCenters
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = None
         lastRegularPeriodEndDate = None
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -2761,6 +2781,7 @@ runFpml4 = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
           businessCenters = primaryBusinessCenters
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = None
         lastRegularPeriodEndDate = None
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -2832,6 +2853,7 @@ runFpml4 = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = NoAdjustment
           businessCenters = primaryBusinessCenters
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = None
         lastRegularPeriodEndDate = None
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -3007,6 +3029,7 @@ runFpml4a = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = ModifiedFollowing
           businessCenters = primaryBusinessCenters
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = None
         lastRegularPeriodEndDate = None
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -3081,6 +3104,7 @@ runFpml4a = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = NoAdjustment
           businessCenters = primaryBusinessCenters
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = None
         lastRegularPeriodEndDate = None
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -3210,7 +3234,7 @@ runFpml5 = script do
     calcPeriodMultiplierFloat = 6
     businessDayConvention = Following
     observations = M.fromList
-      [ (dateToDateClockTime (date 2000 Jul 25), 0.063)
+      [ (dateToDateClockTime (date 2000 Oct 03), 0.063)
       , (dateToDateClockTime (date 2000 Oct 25), 0.065)
       , (dateToDateClockTime (date 2001 Jan 25), 0.067)
       , (dateToDateClockTime (date 2001 Apr 25), 0.069)
@@ -3255,6 +3279,7 @@ runFpml5 = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = businessDayConvention
           businessCenters = primaryBusinessCenters
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = Some firstRegularPeriodStartDate
         lastRegularPeriodEndDate = Some lastRegularPeriodEndDate
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -3308,7 +3333,7 @@ runFpml5 = script do
           dayCountFraction = Act360
           compoundingMethodEnum = None
       stubCalculationPeriodAmount = Some StubCalculationPeriodAmount with
-        calculationPeriodDatesReference = "floatingLegCalcPeriodDates"
+        calculationPeriodDatesReference = "floatingCalcPeriodDates"
         initialStub = Some $ StubValue_StubRate 0.05125
         finalStub = Some $ StubValue_FloatingRate
           [ StubFloatingRate with
@@ -3335,6 +3360,7 @@ runFpml5 = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = businessDayConvention
           businessCenters = primaryBusinessCenters
+        firstPeriodStartDate = None
         firstRegularPeriodStartDate = Some firstRegularPeriodStartDate
         lastRegularPeriodEndDate = Some lastRegularPeriodEndDate
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -3373,7 +3399,6 @@ runFpml5 = script do
       principalExchanges = None
 
     --swapStreams = [swapStreamFloatingLeg, swapStreamFixedLeg]
-    --swapStreams = [swapStreamFloatingLeg]
     swapStreams = [swapStreamFixedLeg]
     currencies = [cashInstrumentCid, cashInstrumentCid]
 
@@ -3395,53 +3420,28 @@ runFpml5 = script do
   swapInstrument <- originateFpmlSwap custodian issuer "SwapTest1" "Interest rate swap" observers
     now swapStreams calendarDataProvider currencies issuerPartyRef
 
-  -- First payment date: Lifecycle and verify a floating payment (regular 3M period)
+  -- First regular payment date: 6M initial stub
   let
-    expectedConsumedQuantities = []
-    expectedProducedQuantities = [qty 1592500.0 cashInstrumentCid]
+    expectedConsumedQuantities = [qty 1968750.0 cashInstrumentCid]
+    expectedProducedQuantities = []
   Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     firstRegularPeriodStartDate swapInstrument issuer observableCids expectedConsumedQuantities
     expectedProducedQuantities
 
-  -- Second payment date: Lifecycle and verify the fix (6M) and floating payments (3M)
+  -- Fast-forward to the last regular payment date: lifecycle 4 years of fixed & floating payments
   let
-    expectedConsumedQuantities = [qty 3000000.0 cashInstrumentCid]
-    expectedProducedQuantities = [qty 1661111.11 cashInstrumentCid]
+    expectedConsumedQuantities = [qty 15750000.0075 cashInstrumentCid]
+    expectedProducedQuantities = []
   Some swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
-    (date 2000 Oct 27) swapInstrumentAfterFirstPayment issuer observableCids
+    lastRegularPeriodEndDate swapInstrumentAfterFirstPayment issuer observableCids
     expectedConsumedQuantities expectedProducedQuantities
 
-  -- Third payment date: Lifecycle and verify a floating payment (regular 3M period)
+  -- Maturity date: 3M final stub
   let
-    expectedConsumedQuantities = []
-    expectedProducedQuantities = [qty 1749444.44 cashInstrumentCid]
+    expectedConsumedQuantities = [qty 984375.0 cashInstrumentCid]
+    expectedProducedQuantities = []
   Some swapInstrumentAfterThirdPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
-    (date 2001 Jan 29) swapInstrumentAfterSecondPayment issuer observableCids
-    expectedConsumedQuantities expectedProducedQuantities
-
-  -- Fourth payment date: Lifecycle and verify the fix (6M) and floating payments (3M)
-  let
-    expectedConsumedQuantities = [qty 3000000.0 cashInstrumentCid]
-    expectedProducedQuantities = [qty 1686666.67 cashInstrumentCid]
-  Some swapInstrumentAfterFourthPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
-    (date 2001 Apr 27) swapInstrumentAfterThirdPayment issuer observableCids
-    expectedConsumedQuantities expectedProducedQuantities
-
-  -- Fifth payment date: Lifecycle and verify a floating payment (regular 3M period)
-  let
-    expectedConsumedQuantities = []
-    expectedProducedQuantities = [qty 1794722.22 cashInstrumentCid]
-  Some swapInstrumentAfterFifthPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
-    (date 2001 Jul 29) swapInstrumentAfterFourthPayment issuer observableCids
-    expectedConsumedQuantities expectedProducedQuantities
-
-  -- Sixth payment date: Lifecycle and verify the fix (6M) and floating payments (3M)
-  -- The fix rate is now higher, as configured in the step-up FpML element
-  let
-    expectedConsumedQuantities = [qty 3250000.0 cashInstrumentCid]
-    expectedProducedQuantities = [qty 1906111.11 cashInstrumentCid]
-  Some swapInstrumentAfterSixthPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
-    (date 2001 Oct 29) swapInstrumentAfterFifthPayment issuer observableCids
+    maturityDate swapInstrumentAfterSecondPayment issuer observableCids
     expectedConsumedQuantities expectedProducedQuantities
 
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -3219,6 +3219,7 @@ runFpml5 = script do
   -- Create swap
   let
     rollDay = 5
+    firstPeriodStartDate = date 2000 Mar rollDay
     issueDate = date 2000 Apr rollDay
     maturityDate = date 2005 Jan rollDay
     firstRegularPeriodStartDate = date 2000 Oct rollDay
@@ -3281,7 +3282,7 @@ runFpml5 = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = businessDayConvention
           businessCenters = primaryBusinessCenters
-        firstPeriodStartDate = None
+        firstPeriodStartDate = Some firstPeriodStartDate
         firstRegularPeriodStartDate = Some firstRegularPeriodStartDate
         lastRegularPeriodEndDate = Some lastRegularPeriodEndDate
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -3362,7 +3363,7 @@ runFpml5 = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = businessDayConvention
           businessCenters = primaryBusinessCenters
-        firstPeriodStartDate = None
+        firstPeriodStartDate = Some firstPeriodStartDate
         firstRegularPeriodStartDate = Some firstRegularPeriodStartDate
         lastRegularPeriodEndDate = Some lastRegularPeriodEndDate
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -3422,6 +3423,9 @@ runFpml5 = script do
   swapInstrument <- originateFpmlSwap custodian issuer "SwapTest1" "Interest rate swap" observers
     now swapStreams calendarDataProvider currencies issuerPartyRef
 
+  verifyNoLifecycleEffects [publicParty] (subtractDays firstRegularPeriodStartDate 1) swapInstrument issuer
+    [observableCid]
+{-
   -- First regular payment date: 6M initial stub
   let
     expectedConsumedQuantities = [qty 1968750.0 cashInstrumentCid]
@@ -3445,5 +3449,5 @@ runFpml5 = script do
   swapInstrumentAfterThirdPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     maturityDate swapInstrumentAfterSecondPayment issuer observableCids
     expectedConsumedQuantities expectedProducedQuantities
-
+ -}
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -3243,17 +3243,9 @@ runFpml5 = script do
       , (dateToDateClockTime (date 2003 Apr 03), 0.075)
       , (dateToDateClockTime (date 2003 Oct 02), 0.075)
       , (dateToDateClockTime (date 2004 Apr 01), 0.075)
-      , (dateToDateClockTime (date 2004 Oct 01), 0.075)
       ]
     stubObservations = M.fromList
-      [ (dateToDateClockTime (date 2000 Jul 25), 0.063)
-      , (dateToDateClockTime (date 2000 Oct 25), 0.065)
-      , (dateToDateClockTime (date 2001 Jan 25), 0.067)
-      , (dateToDateClockTime (date 2001 Apr 25), 0.069)
-      , (dateToDateClockTime (date 2001 Jul 25), 0.071)
-      , (dateToDateClockTime (date 2001 Oct 25), 0.073)
-      , (dateToDateClockTime (date 2002 Jan 25), 0.075)
-      ]
+      [ (dateToDateClockTime (date 2004 Oct 01), 0.077) ]
     primaryBusinessCenters = ["EUTA"]
     cal =
       HolidayCalendarData with
@@ -3344,7 +3336,7 @@ runFpml5 = script do
         initialStub = Some $ StubValue_StubRate 0.05125
         finalStub = Some $ StubValue_FloatingRate
           [ StubFloatingRate with
-              floatingRateIndex = referenceRateId
+              floatingRateIndex = stubReferenceRateId
               indexTenor = Some (Period with period = M; periodMultiplier = 3)
           ]
       principalExchanges = None
@@ -3449,7 +3441,7 @@ runFpml5 = script do
   -- Maturity date: 3M short final stub
   let
     expectedConsumedQuantities = [qty 984375.0 cashInstrumentCid]
-    expectedProducedQuantities = [qty 1437500.0025 cashInstrumentCid]
+    expectedProducedQuantities = [qty 1475833.335 cashInstrumentCid]
   swapInstrumentAfterThirdPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     maturityDate swapInstrumentAfterSecondPayment issuer observableCids
     expectedConsumedQuantities expectedProducedQuantities

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -3235,12 +3235,14 @@ runFpml5 = script do
     businessDayConvention = Following
     observations = M.fromList
       [ (dateToDateClockTime (date 2000 Oct 03), 0.063)
-      , (dateToDateClockTime (date 2000 Oct 25), 0.065)
-      , (dateToDateClockTime (date 2001 Jan 25), 0.067)
-      , (dateToDateClockTime (date 2001 Apr 25), 0.069)
-      , (dateToDateClockTime (date 2001 Jul 25), 0.071)
-      , (dateToDateClockTime (date 2001 Oct 25), 0.073)
-      , (dateToDateClockTime (date 2002 Jan 25), 0.075)
+      , (dateToDateClockTime (date 2001 Apr 03), 0.069)
+      , (dateToDateClockTime (date 2001 Oct 03), 0.073)
+      , (dateToDateClockTime (date 2002 Apr 03), 0.075)
+      , (dateToDateClockTime (date 2002 Oct 03), 0.075)
+      , (dateToDateClockTime (date 2003 Apr 03), 0.075)
+      , (dateToDateClockTime (date 2003 Oct 02), 0.075)
+      , (dateToDateClockTime (date 2004 Apr 01), 0.075)
+      , (dateToDateClockTime (date 2004 Oct 01), 0.075)
       ]
     stubObservations = M.fromList
       [ (dateToDateClockTime (date 2000 Jul 25), 0.063)
@@ -3398,8 +3400,8 @@ runFpml5 = script do
       stubCalculationPeriodAmount = None
       principalExchanges = None
 
-    --swapStreams = [swapStreamFloatingLeg, swapStreamFixedLeg]
-    swapStreams = [swapStreamFixedLeg]
+    swapStreams = [swapStreamFloatingLeg, swapStreamFixedLeg]
+    --swapStreams = [swapStreamFixedLeg]
     currencies = [cashInstrumentCid, cashInstrumentCid]
 
   -- A reference data provider publishes the holiday calendars on the ledger
@@ -3423,7 +3425,7 @@ runFpml5 = script do
   -- First regular payment date: 6M initial stub
   let
     expectedConsumedQuantities = [qty 1968750.0 cashInstrumentCid]
-    expectedProducedQuantities = []
+    expectedProducedQuantities = [qty 1953906.2475 cashInstrumentCid]
   Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     firstRegularPeriodStartDate swapInstrument issuer observableCids expectedConsumedQuantities
     expectedProducedQuantities
@@ -3431,7 +3433,7 @@ runFpml5 = script do
   -- Fast-forward to the last regular payment date: lifecycle 4 years of fixed & floating payments
   let
     expectedConsumedQuantities = [qty 15750000.0075 cashInstrumentCid]
-    expectedProducedQuantities = []
+    expectedProducedQuantities = [qty 22372916.6625 cashInstrumentCid]
   Some swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     lastRegularPeriodEndDate swapInstrumentAfterFirstPayment issuer observableCids
     expectedConsumedQuantities expectedProducedQuantities
@@ -3439,8 +3441,8 @@ runFpml5 = script do
   -- Maturity date: 3M final stub
   let
     expectedConsumedQuantities = [qty 984375.0 cashInstrumentCid]
-    expectedProducedQuantities = []
-  Some swapInstrumentAfterThirdPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
+    expectedProducedQuantities = [qty 1437500.0025 cashInstrumentCid]
+  swapInstrumentAfterThirdPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     maturityDate swapInstrumentAfterSecondPayment issuer observableCids
     expectedConsumedQuantities expectedProducedQuantities
 

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -3425,11 +3425,11 @@ runFpml5 = script do
 
   verifyNoLifecycleEffects [publicParty] (subtractDays firstRegularPeriodStartDate 1) swapInstrument issuer
     [observableCid]
-{-
-  -- First regular payment date: 6M initial stub
+
+  -- First regular payment date: 7M long initial stub
   let
-    expectedConsumedQuantities = [qty 1968750.0 cashInstrumentCid]
-    expectedProducedQuantities = [qty 1953906.2475 cashInstrumentCid]
+    expectedConsumedQuantities = [qty 2285937.5025 cashInstrumentCid]
+    expectedProducedQuantities = [qty 2274218.7525 cashInstrumentCid]
   Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     firstRegularPeriodStartDate swapInstrument issuer observableCids expectedConsumedQuantities
     expectedProducedQuantities
@@ -3442,12 +3442,12 @@ runFpml5 = script do
     lastRegularPeriodEndDate swapInstrumentAfterFirstPayment issuer observableCids
     expectedConsumedQuantities expectedProducedQuantities
 
-  -- Maturity date: 3M final stub
+  -- Maturity date: 3M short final stub
   let
     expectedConsumedQuantities = [qty 984375.0 cashInstrumentCid]
     expectedProducedQuantities = [qty 1437500.0025 cashInstrumentCid]
   swapInstrumentAfterThirdPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
     maturityDate swapInstrumentAfterSecondPayment issuer observableCids
     expectedConsumedQuantities expectedProducedQuantities
- -}
+
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -3282,7 +3282,11 @@ runFpml5 = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = businessDayConvention
           businessCenters = primaryBusinessCenters
-        firstPeriodStartDate = Some firstPeriodStartDate
+        firstPeriodStartDate = Some AdjustableDate with
+          unadjustedDate = firstPeriodStartDate
+          dateAdjustments = BusinessDayAdjustments with
+            businessDayConvention = NoAdjustment
+            businessCenters = []
         firstRegularPeriodStartDate = Some firstRegularPeriodStartDate
         lastRegularPeriodEndDate = Some lastRegularPeriodEndDate
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -3363,7 +3367,11 @@ runFpml5 = script do
         calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
           businessDayConvention = businessDayConvention
           businessCenters = primaryBusinessCenters
-        firstPeriodStartDate = Some firstPeriodStartDate
+        firstPeriodStartDate = Some AdjustableDate with
+          unadjustedDate = firstPeriodStartDate
+          dateAdjustments = BusinessDayAdjustments with
+            businessDayConvention = NoAdjustment
+            businessCenters = []
         firstRegularPeriodStartDate = Some firstRegularPeriodStartDate
         lastRegularPeriodEndDate = Some lastRegularPeriodEndDate
         calculationPeriodFrequency = CalculationPeriodFrequency with
@@ -3402,7 +3410,6 @@ runFpml5 = script do
       principalExchanges = None
 
     swapStreams = [swapStreamFloatingLeg, swapStreamFixedLeg]
-    --swapStreams = [swapStreamFixedLeg]
     currencies = [cashInstrumentCid, cashInstrumentCid]
 
   -- A reference data provider publishes the holiday calendars on the ledger
@@ -3422,9 +3429,6 @@ runFpml5 = script do
 
   swapInstrument <- originateFpmlSwap custodian issuer "SwapTest1" "Interest rate swap" observers
     now swapStreams calendarDataProvider currencies issuerPartyRef
-
-  verifyNoLifecycleEffects [publicParty] (subtractDays firstRegularPeriodStartDate 1) swapInstrument issuer
-    [observableCid]
 
   -- First regular payment date: 7M long initial stub
   let

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -3178,3 +3178,270 @@ runFpml4a = script do
     expectedConsumedQuantities expectedProducedQuantities
 
   pure ()
+
+-- fpml.org Example 5 - Fixed/Floating Single Currency Interest Rate Swap with Long Initial Stub and
+-- Short Final Stub
+-- https://www.fpml.org/spec/fpml-5-11-7-rec-1/html/confirmation/fpml-5-11-examples.html#s2
+runFpml5 : Script ()
+runFpml5 = script do
+  [custodian, issuer, calendarDataProvider, publicParty] <-
+    createParties ["Custodian", "Issuer", "Calendar Data Provider", "PublicParty"]
+
+  -- Create commercial-bank cash
+  now <- getTime
+  let observers = [("PublicParty", singleton publicParty)]
+  cashInstrumentCid <- Instrument.originate custodian issuer "EUR" "Euro" observers now
+
+  -- Create swap
+  let
+    rollDay = 5
+    issueDate = date 2000 Apr rollDay
+    maturityDate = date 2005 Jan rollDay
+    firstRegularPeriodStartDate = date 2000 Oct rollDay
+    lastRegularPeriodEndDate = date 2004 Oct rollDay
+    referenceRateId = "EUR-EURIBOR-Telerate-6M"
+    stubReferenceRateId = "EUR-EURIBOR-Telerate-3M"
+    notional = 75000000.0
+    ccy = "EUR"
+    fixRate = 0.0525
+    calcPeriodFix = Y
+    calcPeriodMultiplierFix = 1
+    calcPeriodFloat = M
+    calcPeriodMultiplierFloat = 6
+    businessDayConvention = Following
+    observations = M.fromList
+      [ (dateToDateClockTime (date 2000 Jul 25), 0.063)
+      , (dateToDateClockTime (date 2000 Oct 25), 0.065)
+      , (dateToDateClockTime (date 2001 Jan 25), 0.067)
+      , (dateToDateClockTime (date 2001 Apr 25), 0.069)
+      , (dateToDateClockTime (date 2001 Jul 25), 0.071)
+      , (dateToDateClockTime (date 2001 Oct 25), 0.073)
+      , (dateToDateClockTime (date 2002 Jan 25), 0.075)
+      ]
+    stubObservations = M.fromList
+      [ (dateToDateClockTime (date 2000 Jul 25), 0.063)
+      , (dateToDateClockTime (date 2000 Oct 25), 0.065)
+      , (dateToDateClockTime (date 2001 Jan 25), 0.067)
+      , (dateToDateClockTime (date 2001 Apr 25), 0.069)
+      , (dateToDateClockTime (date 2001 Jul 25), 0.071)
+      , (dateToDateClockTime (date 2001 Oct 25), 0.073)
+      , (dateToDateClockTime (date 2002 Jan 25), 0.075)
+      ]
+    primaryBusinessCenters = ["EUTA"]
+    cal =
+      HolidayCalendarData with
+        id = "EUTA"
+        weekend = [Saturday, Sunday]
+        holidays = []
+
+    issuerPartyRef = "party1"
+    clientPartyRef = "party2"
+
+    swapStreamFloatingLeg = SwapStream with
+      payerPartyReference = issuerPartyRef
+      receiverPartyReference = clientPartyRef
+      calculationPeriodDates = CalculationPeriodDates with
+        id = "floatingCalcPeriodDates"
+        effectiveDate = AdjustableDate with
+          unadjustedDate = issueDate
+          dateAdjustments = BusinessDayAdjustments with
+            businessDayConvention = NoAdjustment
+            businessCenters = []
+        terminationDate = AdjustableDate with
+          unadjustedDate = maturityDate
+          dateAdjustments = BusinessDayAdjustments with
+            businessDayConvention = businessDayConvention
+            businessCenters = primaryBusinessCenters
+        calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
+          businessDayConvention = businessDayConvention
+          businessCenters = primaryBusinessCenters
+        firstRegularPeriodStartDate = Some firstRegularPeriodStartDate
+        lastRegularPeriodEndDate = Some lastRegularPeriodEndDate
+        calculationPeriodFrequency = CalculationPeriodFrequency with
+          periodMultiplier = calcPeriodMultiplierFloat
+          period = calcPeriodFloat
+          rollConvention = DOM rollDay
+      paymentDates = PaymentDates with
+        calculationPeriodDatesReference = "floatingCalcPeriodDates"
+        paymentFrequency = PaymentFrequency with
+          periodMultiplier = calcPeriodMultiplierFloat
+          period = calcPeriodFloat
+        firstPaymentDate = Some firstRegularPeriodStartDate
+        -- lastRegularPaymentDate is not provided in the original sample trade, but required
+        -- according to the FpML schema in order to define a final stub.
+        lastRegularPaymentDate = Some lastRegularPeriodEndDate
+        payRelativeTo = CalculationPeriodEndDate
+        paymentDaysOffset = None
+        paymentDatesAdjustments = BusinessDayAdjustments with
+            businessDayConvention = businessDayConvention
+            businessCenters = primaryBusinessCenters
+      resetDates = Some ResetDates with
+        calculationPeriodDatesReference = "floatingCalcPeriodDates"
+        resetRelativeTo = CalculationPeriodStartDate
+        fixingDates = FixingDates with
+          periodMultiplier = -2
+          period = D
+          dayType = Business
+          businessDayConvention = NoAdjustment
+          businessCenters = primaryBusinessCenters
+        resetFrequency = ResetFrequency with
+          periodMultiplier = calcPeriodMultiplierFloat
+          period = calcPeriodFloat
+        resetDatesAdjustments = ResetDatesAdjustments with
+          businessDayConvention = businessDayConvention
+          businessCenters = primaryBusinessCenters
+      calculationPeriodAmount = CalculationPeriodAmount with
+        calculation = Calculation with
+          notionalScheduleValue = NotionalSchedule_Regular NotionalSchedule with
+            id = "floatingLegNotionalSchedule"
+            notionalStepSchedule = NotionalStepSchedule with
+              initialValue = notional
+              step = []
+              currency = ccy
+          rateTypeValue = RateType_Floating FloatingRateCalculation with
+            floatingRateIndex = referenceRateId
+            indexTenor = Some Period with
+              periodMultiplier = calcPeriodMultiplierFloat
+              period = calcPeriodFloat
+            spreadSchedule = [SpreadSchedule with initialValue = 0.001]
+            finalRateRounding = None
+          dayCountFraction = Act360
+          compoundingMethodEnum = None
+      stubCalculationPeriodAmount = Some StubCalculationPeriodAmount with
+        calculationPeriodDatesReference = "floatingLegCalcPeriodDates"
+        initialStub = Some $ StubValue_StubRate 0.05125
+        finalStub = Some $ StubValue_FloatingRate
+          [ StubFloatingRate with
+              floatingRateIndex = referenceRateId
+              indexTenor = Some (Period with period = M; periodMultiplier = 3)
+          ]
+      principalExchanges = None
+
+    swapStreamFixedLeg = SwapStream with
+      payerPartyReference = clientPartyRef
+      receiverPartyReference = issuerPartyRef
+      calculationPeriodDates = CalculationPeriodDates with
+        id = "fixedCalcPeriodDates"
+        effectiveDate = AdjustableDate with
+          unadjustedDate = issueDate
+          dateAdjustments = BusinessDayAdjustments with
+            businessDayConvention = NoAdjustment
+            businessCenters = []
+        terminationDate = AdjustableDate with
+          unadjustedDate = maturityDate
+          dateAdjustments = BusinessDayAdjustments with
+            businessDayConvention = businessDayConvention
+            businessCenters = primaryBusinessCenters
+        calculationPeriodDatesAdjustments = CalculationPeriodDatesAdjustments with
+          businessDayConvention = businessDayConvention
+          businessCenters = primaryBusinessCenters
+        firstRegularPeriodStartDate = Some firstRegularPeriodStartDate
+        lastRegularPeriodEndDate = Some lastRegularPeriodEndDate
+        calculationPeriodFrequency = CalculationPeriodFrequency with
+          periodMultiplier = calcPeriodMultiplierFix
+          period = calcPeriodFix
+          rollConvention = DOM rollDay
+      paymentDates = PaymentDates with
+        calculationPeriodDatesReference = "fixedCalcPeriodDates"
+        paymentFrequency = PaymentFrequency with
+          periodMultiplier = calcPeriodMultiplierFix
+          period = calcPeriodFix
+        firstPaymentDate = Some firstRegularPeriodStartDate
+        -- lastRegularPaymentDate is not provided in the original sample trade, but required
+        -- according to the FpML schema in order to define a final stub.
+        lastRegularPaymentDate = Some lastRegularPeriodEndDate
+        payRelativeTo = CalculationPeriodEndDate
+        paymentDaysOffset = None
+        paymentDatesAdjustments = BusinessDayAdjustments with
+            businessDayConvention = businessDayConvention
+            businessCenters = primaryBusinessCenters
+      resetDates = None
+      calculationPeriodAmount = CalculationPeriodAmount with
+        calculation = Calculation with
+          notionalScheduleValue = NotionalSchedule_Regular NotionalSchedule with
+            id = "fixedLegNotionalSchedule"
+            notionalStepSchedule = NotionalStepSchedule with
+              initialValue = notional
+              step = []
+              currency = ccy
+          rateTypeValue = RateType_Fixed FixedRateSchedule with
+            initialValue = fixRate
+            step = []
+          dayCountFraction = Basis30360
+          compoundingMethodEnum = None
+      stubCalculationPeriodAmount = None
+      principalExchanges = None
+
+    --swapStreams = [swapStreamFloatingLeg, swapStreamFixedLeg]
+    --swapStreams = [swapStreamFloatingLeg]
+    swapStreams = [swapStreamFixedLeg]
+    currencies = [cashInstrumentCid, cashInstrumentCid]
+
+  -- A reference data provider publishes the holiday calendars on the ledger
+  calendarCid <- submit calendarDataProvider do
+    createCmd HolidayCalendar with
+      provider = calendarDataProvider; calendar = cal
+      observers = M.fromList observers
+
+  observableCid <- toInterfaceContractId <$> submit issuer do
+    createCmd Observation with
+      provider = issuer; id = Id referenceRateId; observations; observers = M.empty
+  stubObservableCid <- toInterfaceContractId <$> submit issuer do
+    createCmd Observation with
+      provider = issuer; id = Id stubReferenceRateId; observations = stubObservations;
+        observers = M.empty
+  let observableCids = [observableCid, stubObservableCid]
+
+  swapInstrument <- originateFpmlSwap custodian issuer "SwapTest1" "Interest rate swap" observers
+    now swapStreams calendarDataProvider currencies issuerPartyRef
+
+  -- First payment date: Lifecycle and verify a floating payment (regular 3M period)
+  let
+    expectedConsumedQuantities = []
+    expectedProducedQuantities = [qty 1592500.0 cashInstrumentCid]
+  Some swapInstrumentAfterFirstPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
+    firstRegularPeriodStartDate swapInstrument issuer observableCids expectedConsumedQuantities
+    expectedProducedQuantities
+
+  -- Second payment date: Lifecycle and verify the fix (6M) and floating payments (3M)
+  let
+    expectedConsumedQuantities = [qty 3000000.0 cashInstrumentCid]
+    expectedProducedQuantities = [qty 1661111.11 cashInstrumentCid]
+  Some swapInstrumentAfterSecondPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
+    (date 2000 Oct 27) swapInstrumentAfterFirstPayment issuer observableCids
+    expectedConsumedQuantities expectedProducedQuantities
+
+  -- Third payment date: Lifecycle and verify a floating payment (regular 3M period)
+  let
+    expectedConsumedQuantities = []
+    expectedProducedQuantities = [qty 1749444.44 cashInstrumentCid]
+  Some swapInstrumentAfterThirdPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
+    (date 2001 Jan 29) swapInstrumentAfterSecondPayment issuer observableCids
+    expectedConsumedQuantities expectedProducedQuantities
+
+  -- Fourth payment date: Lifecycle and verify the fix (6M) and floating payments (3M)
+  let
+    expectedConsumedQuantities = [qty 3000000.0 cashInstrumentCid]
+    expectedProducedQuantities = [qty 1686666.67 cashInstrumentCid]
+  Some swapInstrumentAfterFourthPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
+    (date 2001 Apr 27) swapInstrumentAfterThirdPayment issuer observableCids
+    expectedConsumedQuantities expectedProducedQuantities
+
+  -- Fifth payment date: Lifecycle and verify a floating payment (regular 3M period)
+  let
+    expectedConsumedQuantities = []
+    expectedProducedQuantities = [qty 1794722.22 cashInstrumentCid]
+  Some swapInstrumentAfterFifthPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
+    (date 2001 Jul 29) swapInstrumentAfterFourthPayment issuer observableCids
+    expectedConsumedQuantities expectedProducedQuantities
+
+  -- Sixth payment date: Lifecycle and verify the fix (6M) and floating payments (3M)
+  -- The fix rate is now higher, as configured in the step-up FpML element
+  let
+    expectedConsumedQuantities = [qty 3250000.0 cashInstrumentCid]
+    expectedProducedQuantities = [qty 1906111.11 cashInstrumentCid]
+  Some swapInstrumentAfterSixthPayment <- lifecycleAndVerifySwapPaymentEffects [publicParty]
+    (date 2001 Oct 29) swapInstrumentAfterFifthPayment issuer observableCids
+    expectedConsumedQuantities expectedProducedQuantities
+
+  pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -220,11 +220,6 @@ lifecycleAndVerifySwapPaymentEffects readAs today swapInstrument issuer
     effectView <- submit issuer do
       exerciseCmd effectCid Effect.GetView with viewer = issuer
 
-    debug expectedConsumedQuantities
-    debug effectView.otherConsumed
-    debug expectedProducedQuantities
-    debug effectView.otherProduced
-
     -- Verify that the consumed/produced quantities match the expected ones
     assertMsg "The consumed quantities do not match the expected ones" $
       sort expectedConsumedQuantities == sort effectView.otherConsumed

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -220,6 +220,11 @@ lifecycleAndVerifySwapPaymentEffects readAs today swapInstrument issuer
     effectView <- submit issuer do
       exerciseCmd effectCid Effect.GetView with viewer = issuer
 
+    debug expectedConsumedQuantities
+    debug effectView.otherConsumed
+    debug expectedProducedQuantities
+    debug effectView.otherProduced
+
     -- Verify that the consumed/produced quantities match the expected ones
     assertMsg "The consumed quantities do not match the expected ones" $
       sort expectedConsumedQuantities == sort effectView.otherConsumed


### PR DESCRIPTION
- Implement official sample trade 5
- Add support for initial stub period that starts before the issue date of the swap
- Modify filtering and sanity checks of calculation periods to account for this