### PR TITLE
Bump `Daml.Finance.Util` to 2.0.0

### DIFF
--- a/package/main/daml/Daml.Finance.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Account/daml.yaml
@@ -13,7 +13,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Holding/1.0.0/daml-finance-interface-holding-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.0/daml-finance-interface-types-common-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.0/daml-finance-interface-util-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/1.0.1/daml-finance-util-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/2.0.0/daml-finance-util-2.0.0.dar
 build-options:
   - --target=1.15
 

--- a/package/main/daml/Daml.Finance.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Claims/daml.yaml
@@ -18,7 +18,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.0/daml-finance-interface-types-date-2.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.0/daml-finance-interface-util-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/1.0.1/daml-finance-lifecycle-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/1.0.1/daml-finance-util-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/2.0.0/daml-finance-util-2.0.0.dar
 build-options:
   - --target=1.15
 

--- a/package/main/daml/Daml.Finance.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Data/daml.yaml
@@ -14,7 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.0/daml-finance-interface-types-common-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.0/daml-finance-interface-types-date-2.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.0/daml-finance-interface-util-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/1.0.1/daml-finance-util-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/2.0.0/daml-finance-util-2.0.0.dar
 build-options:
   - --target=1.15
 

--- a/package/main/daml/Daml.Finance.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Holding/daml.yaml
@@ -13,7 +13,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Holding/1.0.0/daml-finance-interface-holding-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.0/daml-finance-interface-types-common-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.0/daml-finance-interface-util-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/1.0.1/daml-finance-util-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/2.0.0/daml-finance-util-2.0.0.dar
 build-options:
   - --target=1.15
 

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -18,7 +18,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.0/daml-finance-interface-types-common-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.0/daml-finance-interface-types-date-2.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.0/daml-finance-interface-util-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/1.0.1/daml-finance-util-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/2.0.0/daml-finance-util-2.0.0.dar
 build-options:
   - --target=1.15
 

--- a/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
@@ -14,7 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.0/daml-finance-interface-types-common-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.0/daml-finance-interface-util-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/1.0.1/daml-finance-lifecycle-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/1.0.1/daml-finance-util-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/2.0.0/daml-finance-util-2.0.0.dar
 build-options:
   - --target=1.15
 

--- a/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
@@ -17,7 +17,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.0/daml-finance-interface-types-common-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.0/daml-finance-interface-util-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/1.0.1/daml-finance-lifecycle-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/1.0.1/daml-finance-util-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/2.0.0/daml-finance-util-2.0.0.dar
 build-options:
   - --target=1.15
 

--- a/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
@@ -18,7 +18,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.0/daml-finance-interface-types-common-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.0/daml-finance-interface-types-date-2.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.0/daml-finance-interface-util-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/1.0.1/daml-finance-util-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/2.0.0/daml-finance-util-2.0.0.dar
 build-options:
   - --target=1.15
 

--- a/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
@@ -13,7 +13,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/1.0.0/daml-finance-interface-instrument-token-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.0/daml-finance-interface-types-common-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.0/daml-finance-interface-util-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/1.0.1/daml-finance-util-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/2.0.0/daml-finance-util-2.0.0.dar
 build-options:
   - --target=1.15
 

--- a/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
@@ -15,7 +15,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Settlement/1.0.0/daml-finance-interface-settlement-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.0/daml-finance-interface-types-common-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.0/daml-finance-interface-util-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/1.0.1/daml-finance-util-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/2.0.0/daml-finance-util-2.0.0.dar
 build-options:
   - --target=1.15
 

--- a/package/main/daml/Daml.Finance.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Settlement/daml.yaml
@@ -14,7 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Settlement/1.0.0/daml-finance-interface-settlement-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.0/daml-finance-interface-types-common-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.0/daml-finance-interface-util-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/1.0.1/daml-finance-util-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/2.0.0/daml-finance-util-2.0.0.dar
 build-options:
   - --target=1.15
 

--- a/package/main/daml/Daml.Finance.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Util/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.5.0
 name: daml-finance-util
 source: daml
-version: 1.0.1
+version: 2.0.0
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/test/daml/Daml.Finance.Util.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Util.Test/daml.yaml
@@ -14,7 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.0/daml-finance-interface-types-date-2.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.0/daml-finance-interface-util-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/1.0.1/daml-finance-util-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/2.0.0/daml-finance-util-2.0.0.dar
 build-options:
   - --target=1.15
 


### PR DESCRIPTION
The previous PR from @markus-da introduced a breaking changes to the package, hence the bump.