### PR TITLE
fix for fungible merge

### DIFF
--- a/src/main/daml/Daml/Finance/Holding/Fungible.daml
+++ b/src/main/daml/Daml/Finance/Holding/Fungible.daml
@@ -17,7 +17,6 @@ import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), InstrumentKey(
 import Daml.Finance.Interface.Util.Common (verify)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
-import Prelude hiding (null)
 
 -- | Type synonym for `Factory`.
 type F = Factory
@@ -47,6 +46,8 @@ template Fungible
 
     ensure amount > 0.0
 
+    let spawn = \a -> toInterfaceContractId @Fungible.I <$> create this with amount = a
+
     interface instance Disclosure.I for Fungible where
       view = Disclosure.View with
         disclosureControllers = fromList [account.owner, account.custodian]; observers
@@ -69,19 +70,21 @@ template Fungible
       asTransferable = toInterface @Transferable.I this
       view = Fungible.View with modifiers = singleton account.owner
       split Fungible.Split{amounts} = do
-        splitCids <- forA amounts \a -> toInterfaceContractId <$> create this with amount = a
+        splitCids <- forA amounts spawn
         restAmount <- getRestAmount amounts amount
-        rest <- T.forA restAmount \r -> toInterfaceContractId <$> create this with amount = r
+        rest <- T.forA restAmount spawn
         pure Fungible.SplitResult with splitCids; rest
       merge Fungible.Merge{fungibleCids} = do
+        assertMsg "list of fungibles must be non-empty" $ not $ null fungibleCids
         let
-          f a cid = do
+          aggregate a cid = do
             Some (fungibleCid, fungible) <- fetchFromInterface @Fungible cid
             assertMsg "instrument must match" $ instrument == fungible.instrument
+            assertMsg "account must match" $ account == fungible.account
             archive fungibleCid
             pure $ a + fungible.amount
-        tot <- foldlA f amount fungibleCids
-        toInterfaceContractId <$> create this with amount = tot
+        tot <- foldlA aggregate amount fungibleCids
+        spawn tot
 
 instance HoldingFactory.HasImplementation Factory
 -- | Implementation of the corresponding Holding Factory.

--- a/src/main/daml/Daml/Finance/Holding/Fungible.daml
+++ b/src/main/daml/Daml/Finance/Holding/Fungible.daml
@@ -81,6 +81,8 @@ template Fungible
             Some (fungibleCid, fungible) <- fetchFromInterface @Fungible cid
             assertMsg "instrument must match" $ instrument == fungible.instrument
             assertMsg "account must match" $ account == fungible.account
+            assertMsg "signatories must match" $
+              fromList (signatory this) == fromList (signatory fungible)
             archive fungibleCid
             pure $ a + fungible.amount
         tot <- foldlA aggregate amount fungibleCids

--- a/src/test/daml/Daml/Finance/Holding/Test/Fungible.daml
+++ b/src/test/daml/Daml/Finance/Holding/Test/Fungible.daml
@@ -140,7 +140,7 @@ run = script do
   submitMustFail issuer do
     exerciseCmd restCid Fungible.Merge with fungibleCids = []
 
-  -- Attemt to merge with an issuer@issuer holding fails
+  -- Attempt to merge with an issuer@issuer holding fails
   Some t <- queryContractId issuer $ fromInterfaceContractId @Fungible.T splitCid1
   cid <- toInterfaceContractId @Fungible.I <$> submit issuer do
     createCmd t with account = (t.account with custodian = issuer); amount = 1_000_000.0

--- a/src/test/daml/Daml/Finance/Holding/Test/Fungible.daml
+++ b/src/test/daml/Daml/Finance/Holding/Test/Fungible.daml
@@ -27,10 +27,10 @@ run = script do
 
   -- Initialize state with `Fungible.Factory`
   TestInitialState {investorAccount; issuerAccount; issuerHoldingCid} <- setupInitialState
-      tp
-      Fungible.Factory with
-        provider = custodian; observers = M.fromList [("PublicParty", S.singleton publicParty)]
-      [] Account.Owner
+    tp
+    Fungible.Factory with
+      provider = custodian; observers = M.fromList [("PublicParty", S.singleton publicParty)]
+    [] Account.Owner
 
   -- Lock asset
   baseCid <- submitMulti [issuer, locker] [] do
@@ -39,7 +39,7 @@ run = script do
         newLockers = S.singleton locker; context = "Test Lock"; lockType = Base.Semaphore
 
   -- Cannot split
-  submitMultiMustFail [issuer, investor] [] do
+  submitMustFail issuer do
     exerciseCmd (coerceInterfaceContractId @Fungible.I baseCid) Fungible.Split with
       amounts = [500.0, 250.0]
 
@@ -58,19 +58,21 @@ run = script do
     exerciseCmd baseCid Base.Release with context = "Test Lock"
 
   -- Attempt to split more than the amount available fails
-  submitMultiMustFail [issuer, investor] [] do
+  submitMustFail issuer do
     exerciseCmd fungibleCid Fungible.Split with amounts = [1_000.1]
-  submitMultiMustFail [issuer, investor] [] do
+  submitMustFail issuer do
     exerciseCmd fungibleCid Fungible.Split with amounts = [1_000.0, 0.1]
 
   -- Attempt to split negative amount fails
-  submitMultiMustFail [issuer, investor] [] do
+  submitMustFail issuer do
     exerciseCmd fungibleCid Fungible.Split with amounts = [-20.0]
-  submitMultiMustFail [issuer, investor] [] do
+  submitMustFail issuer do
     exerciseCmd fungibleCid Fungible.Split with amounts = [100.0, -20.0]
-  submitMultiMustFail [issuer, investor] [] do
+  submitMustFail issuer do
     exerciseCmd fungibleCid Fungible.Split with amounts = [0.0]
-  submitMultiMustFail [issuer, investor] [] do
+
+  -- Attempt to split with empty list fails
+  submitMustFail issuer do
     exerciseCmd fungibleCid Fungible.Split with amounts = []
 
   -- Fungible (before split)
@@ -79,7 +81,7 @@ run = script do
 
   -- Split fungible
   Fungible.SplitResult [splitCid1, splitCid2] (Some restCid) <-
-    submitMulti [issuer, investor] [] do
+    submit issuer do
       exerciseCmd fungibleCid Fungible.Split with amounts = [500.0, 250.0]
 
   -- Fungibles (after split)
@@ -134,8 +136,18 @@ run = script do
     "Fungible::verifySplit - Amounts must be non-empty, strictly positive, and not exceed " <>
     "current amount. amounts=[], splitAmountSum=0.0, currentAmount=-1.0"
 
+  -- Attempt to merge with empty list fails
+  submitMustFail issuer do
+    exerciseCmd restCid Fungible.Merge with fungibleCids = []
+
+  -- Attemt to merge with an issuer@issuer holding fails
+  Some t <- queryContractId issuer $ fromInterfaceContractId @Fungible.T splitCid1
+  cid <- toInterfaceContractId @Fungible.I <$> submit issuer do
+    createCmd t with account = (t.account with custodian = issuer); amount = 1_000_000.0
+  submitMustFail issuer do exerciseCmd restCid Fungible.Merge with fungibleCids = [cid]
+
   -- Merge fungibles
-  fungibleCid <- submitMulti [issuer, investor] [] do
+  fungibleCid <- submit issuer do
     exerciseCmd restCid Fungible.Merge with fungibleCids = [splitCid1, splitCid2]
 
   -- Fungibles (after merge)

--- a/src/test/daml/Daml/Finance/Holding/Test/Fungible.daml
+++ b/src/test/daml/Daml/Finance/Holding/Test/Fungible.daml
@@ -34,7 +34,7 @@ run = script do
 
   -- Lock asset
   baseCid <- submitMulti [issuer, locker] [] do
-    exerciseCmd (coerceInterfaceContractId @Base.I issuerHoldingCid)
+    exerciseCmd (toInterfaceContractId @Base.I issuerHoldingCid)
       Base.Acquire with
         newLockers = S.singleton locker; context = "Test Lock"; lockType = Base.Semaphore
 
@@ -51,7 +51,7 @@ run = script do
 
   -- Cannot debit
   Account.submitMustFailExerciseInterfaceByKeyCmd @Account.I [custodian, issuer] [] issuerAccount $
-    Account.Debit with holdingCid = toInterfaceContractId baseCid
+    Account.Debit with holdingCid = baseCid
 
   -- Unlock asset
   fungibleCid <- coerceInterfaceContractId @Fungible.I <$> submit locker do
@@ -76,7 +76,7 @@ run = script do
     exerciseCmd fungibleCid Fungible.Split with amounts = []
 
   -- Fungible (before split)
-  fungible <- fmap (\o -> toInterface @Fungible.I $ fromSome o) <$>
+  fungible <- fmap (toInterface @Fungible.I . fromSome) <$>
     queryContractId @Fungible.T issuer $ fromInterfaceContractId fungibleCid
 
   -- Split fungible
@@ -85,10 +85,11 @@ run = script do
       exerciseCmd fungibleCid Fungible.Split with amounts = [500.0, 250.0]
 
   -- Fungibles (after split)
-  [fungible1, fungible2, rest] <- fmap (\f -> toInterface @Fungible.I $ fromSome f) <$>
-    mapA
-      (\cid -> queryContractId @Fungible.T issuer $ fromInterfaceContractId cid)
-      [splitCid1, splitCid2, restCid]
+  [fungible1, fungible2, rest] <- forA
+    [splitCid1, splitCid2, restCid]
+    \cid -> do
+      Some fungible <- queryContractId @Fungible.T issuer $ fromInterfaceContractId cid
+      pure $ toInterface @Fungible.I fungible
 
   -- Test utility function `verifyAmountPreserving`
   verifyAmountPreserving [] []
@@ -151,13 +152,13 @@ run = script do
     exerciseCmd restCid Fungible.Merge with fungibleCids = [splitCid1, splitCid2]
 
   -- Fungibles (after merge)
-  fungible' <- fmap (\o -> toInterface @Fungible.I $ fromSome o) <$>
+  fungible' <- fmap (toInterface @Fungible.I . fromSome) <$>
     queryContractId @Fungible.T issuer $ fromInterfaceContractId fungibleCid
   verifyAmountPreserving [fungible] [fungible']
 
   -- Transfer
   transferableCid <- submitMulti [issuer, investor] [publicParty] do
-    exerciseCmd (coerceInterfaceContractId @Transferable.I fungibleCid)
+    exerciseCmd (toInterfaceContractId @Transferable.I fungibleCid)
       Transferable.Transfer with
         actors = S.fromList [issuer, investor]; newOwnerAccount = investorAccount
 


### PR DESCRIPTION
this PR adds the following checks to the merge choice **implementation**:

1. list of fungibles to merge is non-empty
2. the account key of merged fungibles are the same
3. signatories of merged fungibles are the same 

and corresponding tests