### PR TITLE
`DateClock` key violation on `nonconsuming` `Advance` and `Rewind` interface choices.

### DIFF
--- a/src/main/daml/Daml/Finance/Interface/Data/Reference/Time.daml
+++ b/src/main/daml/Daml/Finance/Interface/Data/Reference/Time.daml
@@ -49,7 +49,7 @@ interface Time where
     do
       pure $ view this
 
-  nonconsuming choice Advance : (ContractId Time, ContractId Time.Event)
+  choice Advance : (ContractId Time, ContractId Time.Event)
     -- ^ Advance time to its next state.
     with
       eventId : Id
@@ -60,7 +60,7 @@ interface Time where
     do
       advance this arg
 
-  nonconsuming choice Rewind : (ContractId Time, ContractId Time.Event)
+  choice Rewind : (ContractId Time, ContractId Time.Event)
     -- ^ Rewind time to its previous state.
     with
       eventId : Id

--- a/src/test/daml/Daml/Finance/Data/Test/DateClock.daml
+++ b/src/test/daml/Daml/Finance/Data/Test/DateClock.daml
@@ -1,0 +1,63 @@
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Daml.Finance.Data.Test.DateClock where
+
+import Daml.Finance.Interface.Data.Reference.Time qualified as Time (Advance(..), I, Rewind(..))
+import Daml.Finance.Interface.Types.Common.Types (Id(..))
+
+import Daml.Finance.Data.Time.DateClock qualified as DateClock (DateClock(..), T)
+import Daml.Finance.Data.Time.DateClock.Types (Unit(..))
+
+import DA.Set qualified as S
+import DA.Assert ((===))
+import DA.Date (addDays, toDateUTC)
+import Daml.Script
+
+
+testDateClock : Script ()
+testDateClock = script do
+    bank <- listKnownParties
+        >>= flip getOrAllocatePartyWithSameHint "Bank"
+    now <- getTime
+
+    let dateNow = toDateUTC now
+        dateClock = DateClock.DateClock with
+            providers = S.singleton bank
+            date = Unit dateNow
+            id = Id "CLOCK"
+            description = "Clock"
+            observers = mempty
+
+    -- test advance
+    dateClockCid <- submit bank
+        . widenCid @Time.I
+        $ createCmd dateClock
+    (dateClockCid, _) <- submit bank $
+        exerciseCmd dateClockCid Time.Advance with
+            eventId = Id "T1"
+            eventDescription = "Time advance"
+
+    Some dateClock <- queryContractId bank $
+        fromInterfaceContractId @DateClock.T dateClockCid
+    dateClock.date === Unit (dateNow `addDays` 1)
+
+    -- test rewind
+    (dateClockCid, _) <- submit bank $
+        exerciseCmd dateClockCid Time.Rewind with
+            eventId = Id "T2"
+            eventDescription = "Time rewind"
+
+    Some dateClock <- queryContractId bank $
+        fromInterfaceContractId @DateClock.T dateClockCid
+    dateClock.date === Unit dateNow
+  where
+    allocatePartyWithSameHint = allocatePartyWithHint <*> PartyIdHint
+    getOrAllocatePartyWithSameHint parties hint =
+        optional (allocatePartyWithSameHint hint) (pure . party)
+        . find ((== Some hint) . displayName)
+        $ parties
+    
+widenCid  :   forall super a f. (Functor f, HasToInterface a super)
+          =>  f (ContractId a) -> f (ContractId super)
+widenCid  =   fmap toInterfaceContractId


### PR DESCRIPTION
This PR proposes making  `Advance` and `Rewind`  of the `Time` interface consuming. Alternatively, if choices are required to be `nonconsuming` at the interface level, then archival can be push to the implementation level in `DateClock` instead.