### PR TITLE
`DateClock` key violation on `nonconsuming` `Advance` and `Rewind` interface choices.

### DIFF
--- a/src/main/daml/Daml/Finance/Data/Time/DateClock.daml
+++ b/src/main/daml/Daml/Finance/Data/Time/DateClock.daml
@@ -44,12 +44,13 @@ template DateClock
     maintainer key._1
 
     let
-      moveClock : Id -> Text -> Int -> Update (ContractId Time.I, ContractId TimeEvent.I)
-      moveClock eventId eventDescription offset = do
+      moveClock : ContractId Time.I -> Id -> Text -> Int -> Update (ContractId Time.I, ContractId TimeEvent.I)
+      moveClock self eventId eventDescription offset = do
         let
           Unit currentDate = date
           newDate = addDays currentDate offset
           clock = this with date = Unit newDate
+        archive $ fromInterfaceContractId @DateClock self
         clockCid <- toInterfaceContractId <$> create clock
         eventCid <- toInterfaceContractId <$> create DateClockUpdateEvent with
           providers
@@ -69,8 +70,8 @@ template DateClock
     interface instance Time.I for DateClock where
       view = Time.View with providers; id
       asTimeObservable = toInterface @TimeObservable.I this
-      advance Time.Advance{eventId; eventDescription} = moveClock eventId eventDescription 1
-      rewind Time.Rewind{eventId; eventDescription} = moveClock eventId eventDescription (-1)
+      advance self Time.Advance{eventId; eventDescription} = moveClock self eventId eventDescription 1
+      rewind self Time.Rewind{eventId; eventDescription} = moveClock self eventId eventDescription (-1)
 
 instance HasUTCTimeConversion DateClock where
   toUTCTime clock = toUTCTime clock.date

--- a/src/main/daml/Daml/Finance/Interface/Data/Reference/Time.daml
+++ b/src/main/daml/Daml/Finance/Interface/Data/Reference/Time.daml
@@ -49,7 +49,7 @@ interface Time where
     do
       pure $ view this
 
-  nonconsuming choice Advance : (ContractId Time, ContractId Time.Event)
+  choice Advance : (ContractId Time, ContractId Time.Event)
     -- ^ Advance time to its next state.
     with
       eventId : Id
@@ -60,7 +60,7 @@ interface Time where
     do
       advance this arg
 
-  nonconsuming choice Rewind : (ContractId Time, ContractId Time.Event)
+  choice Rewind : (ContractId Time, ContractId Time.Event)
     -- ^ Rewind time to its previous state.
     with
       eventId : Id

--- a/src/main/daml/Daml/Finance/Interface/Data/Reference/Time.daml
+++ b/src/main/daml/Daml/Finance/Interface/Data/Reference/Time.daml
@@ -35,9 +35,9 @@ interface Time where
 
   asTimeObservable : TimeObservable.I
     -- Conversion to `TimeObservable` interface.
-  advance : Advance -> Update (ContractId Time, ContractId Time.Event)
+  advance : ContractId Time -> Advance -> Update (ContractId Time, ContractId Time.Event)
     -- ^ Implementation of the `Advance` choice.
-  rewind : Rewind -> Update (ContractId Time, ContractId Time.Event)
+  rewind : ContractId Time -> Rewind -> Update (ContractId Time, ContractId Time.Event)
     -- ^ Implementation of the `Rewind` choice.
 
   nonconsuming choice GetView : View
@@ -49,7 +49,7 @@ interface Time where
     do
       pure $ view this
 
-  choice Advance : (ContractId Time, ContractId Time.Event)
+  nonconsuming choice Advance : (ContractId Time, ContractId Time.Event)
     -- ^ Advance time to its next state.
     with
       eventId : Id
@@ -58,9 +58,9 @@ interface Time where
         -- ^ Event description.
     controller (view this).providers
     do
-      advance this arg
+      advance this self arg
 
-  choice Rewind : (ContractId Time, ContractId Time.Event)
+  nonconsuming choice Rewind : (ContractId Time, ContractId Time.Event)
     -- ^ Rewind time to its previous state.
     with
       eventId : Id
@@ -69,7 +69,7 @@ interface Time where
         -- ^ Event description.
     controller (view this).providers
     do
-      rewind this arg
+      rewind this self arg
 
 -- | Type constraint for requiring templates to implement `Time`.
 type Implementation t = (HasToInterface t Time, TimeObservable.Implementation t)

--- a/src/test/daml/Daml/Finance/Data/Test/DateClock.daml
+++ b/src/test/daml/Daml/Finance/Data/Test/DateClock.daml
@@ -1,0 +1,63 @@
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Daml.Finance.Data.Test.DateClock where
+
+import Daml.Finance.Interface.Data.Reference.Time qualified as Time (Advance(..), I, Rewind(..))
+import Daml.Finance.Interface.Types.Common.Types (Id(..))
+
+import Daml.Finance.Data.Time.DateClock qualified as DateClock (DateClock(..), T)
+import Daml.Finance.Data.Time.DateClock.Types (Unit(..))
+
+import DA.Set qualified as S
+import DA.Assert ((===))
+import DA.Date (addDays, toDateUTC)
+import Daml.Script
+
+
+testDateClock : Script ()
+testDateClock = script do
+    bank <- listKnownParties
+        >>= flip getOrAllocatePartyWithSameHint "Bank"
+    now <- getTime
+
+    let dateNow = toDateUTC now
+        dateClock = DateClock.DateClock with
+            providers = S.singleton bank
+            date = Unit dateNow
+            id = Id "CLOCK"
+            description = "Clock"
+            observers = mempty
+
+    -- test advance
+    dateClockCid <- submit bank
+        . widenCid @Time.I
+        $ createCmd dateClock
+    (dateClockCid, _) <- submit bank $
+        exerciseCmd dateClockCid Time.Advance with
+            eventId = Id "T1"
+            eventDescription = "Time advance"
+
+    Some dateClock <- queryContractId bank $
+        fromInterfaceContractId @DateClock.T dateClockCid
+    dateClock.date === Unit (dateNow `addDays` 1)
+
+    -- test rewind
+    (dateClockCid, _) <- submit bank $
+        exerciseCmd dateClockCid Time.Rewind with
+            eventId = Id "T2"
+            eventDescription = "Time rewind"
+
+    Some dateClock <- queryContractId bank $
+        fromInterfaceContractId @DateClock.T dateClockCid
+    dateClock.date === Unit dateNow
+  where
+    allocatePartyWithSameHint = allocatePartyWithHint <*> PartyIdHint
+    getOrAllocatePartyWithSameHint parties hint =
+        optional (allocatePartyWithSameHint hint) (pure . party)
+        . find ((== Some hint) . displayName)
+        $ parties
+    
+widenCid  :   forall super a f. (Functor f, HasToInterface a super)
+          =>  f (ContractId a) -> f (ContractId super)
+widenCid  =   fmap toInterfaceContractId

--- a/src/test/daml/Daml/Finance/Data/Test/DateClock.daml
+++ b/src/test/daml/Daml/Finance/Data/Test/DateClock.daml
@@ -15,8 +15,7 @@ import Daml.Script
 
 testDateClock : Script ()
 testDateClock = script do
-  bank <- listKnownParties
-    >>= flip getOrAllocatePartyWithSameHint "Bank"
+  bank <- allocatePartyWithHint <*> PartyIdHint $ "Bank"
   now <- getTime
 
   let
@@ -29,9 +28,8 @@ testDateClock = script do
       observers = mempty
 
   -- test advance
-  dateClockCid <- submit bank
-    . widenCid @Time.I
-    $ createCmd dateClock
+  dateClockCid <- toInterfaceContractId @Time.I <$> submit bank do
+    createCmd dateClock
   (dateClockCid, _) <- submit bank $
     exerciseCmd dateClockCid Time.Advance with
       eventId = Id "T1"
@@ -50,14 +48,3 @@ testDateClock = script do
   Some dateClock <- queryContractId bank $
     fromInterfaceContractId @DateClock.T dateClockCid
   dateClock.date === Unit dateNow
-  where
-  allocatePartyWithSameHint = allocatePartyWithHint <*> PartyIdHint
-  getOrAllocatePartyWithSameHint parties hint =
-    optional (allocatePartyWithSameHint hint) (pure . party)
-    . find ((== Some hint) . displayName)
-    $ parties
-    
-widenCid
-  : forall super a f. (Functor f, HasToInterface a super)
-  => f (ContractId a) -> f (ContractId super)
-widenCid = fmap toInterfaceContractId

--- a/src/test/daml/Daml/Finance/Data/Test/DateClock.daml
+++ b/src/test/daml/Daml/Finance/Data/Test/DateClock.daml
@@ -3,61 +3,61 @@
 
 module Daml.Finance.Data.Test.DateClock where
 
-import Daml.Finance.Interface.Data.Reference.Time qualified as Time (Advance(..), I, Rewind(..))
-import Daml.Finance.Interface.Types.Common.Types (Id(..))
-
-import Daml.Finance.Data.Time.DateClock qualified as DateClock (DateClock(..), T)
-import Daml.Finance.Data.Time.DateClock.Types (Unit(..))
-
-import DA.Set qualified as S
 import DA.Assert ((===))
 import DA.Date (addDays, toDateUTC)
+import DA.Set qualified as S (singleton)
+import Daml.Finance.Data.Time.DateClock qualified as DateClock (DateClock(..), T)
+import Daml.Finance.Data.Time.DateClock.Types (Unit(..))
+import Daml.Finance.Interface.Data.Reference.Time qualified as Time (Advance(..), I, Rewind(..))
+import Daml.Finance.Interface.Types.Common.Types (Id(..))
 import Daml.Script
 
 
 testDateClock : Script ()
 testDateClock = script do
-    bank <- listKnownParties
-        >>= flip getOrAllocatePartyWithSameHint "Bank"
-    now <- getTime
+  bank <- listKnownParties
+    >>= flip getOrAllocatePartyWithSameHint "Bank"
+  now <- getTime
 
-    let dateNow = toDateUTC now
-        dateClock = DateClock.DateClock with
-            providers = S.singleton bank
-            date = Unit dateNow
-            id = Id "CLOCK"
-            description = "Clock"
-            observers = mempty
+  let
+    dateNow = toDateUTC now
+    dateClock = DateClock.DateClock with
+      providers = S.singleton bank
+      date = Unit dateNow
+      id = Id "CLOCK"
+      description = "Clock"
+      observers = mempty
 
-    -- test advance
-    dateClockCid <- submit bank
-        . widenCid @Time.I
-        $ createCmd dateClock
-    (dateClockCid, _) <- submit bank $
-        exerciseCmd dateClockCid Time.Advance with
-            eventId = Id "T1"
-            eventDescription = "Time advance"
+  -- test advance
+  dateClockCid <- submit bank
+    . widenCid @Time.I
+    $ createCmd dateClock
+  (dateClockCid, _) <- submit bank $
+    exerciseCmd dateClockCid Time.Advance with
+      eventId = Id "T1"
+      eventDescription = "Time advance"
 
-    Some dateClock <- queryContractId bank $
-        fromInterfaceContractId @DateClock.T dateClockCid
-    dateClock.date === Unit (dateNow `addDays` 1)
+  Some dateClock <- queryContractId bank $
+    fromInterfaceContractId @DateClock.T dateClockCid
+  dateClock.date === Unit (dateNow `addDays` 1)
 
-    -- test rewind
-    (dateClockCid, _) <- submit bank $
-        exerciseCmd dateClockCid Time.Rewind with
-            eventId = Id "T2"
-            eventDescription = "Time rewind"
+  -- test rewind
+  (dateClockCid, _) <- submit bank $
+    exerciseCmd dateClockCid Time.Rewind with
+      eventId = Id "T2"
+      eventDescription = "Time rewind"
 
-    Some dateClock <- queryContractId bank $
-        fromInterfaceContractId @DateClock.T dateClockCid
-    dateClock.date === Unit dateNow
+  Some dateClock <- queryContractId bank $
+    fromInterfaceContractId @DateClock.T dateClockCid
+  dateClock.date === Unit dateNow
   where
-    allocatePartyWithSameHint = allocatePartyWithHint <*> PartyIdHint
-    getOrAllocatePartyWithSameHint parties hint =
-        optional (allocatePartyWithSameHint hint) (pure . party)
-        . find ((== Some hint) . displayName)
-        $ parties
+  allocatePartyWithSameHint = allocatePartyWithHint <*> PartyIdHint
+  getOrAllocatePartyWithSameHint parties hint =
+    optional (allocatePartyWithSameHint hint) (pure . party)
+    . find ((== Some hint) . displayName)
+    $ parties
     
-widenCid  :   forall super a f. (Functor f, HasToInterface a super)
-          =>  f (ContractId a) -> f (ContractId super)
-widenCid  =   fmap toInterfaceContractId
+widenCid
+  : forall super a f. (Functor f, HasToInterface a super)
+  => f (ContractId a) -> f (ContractId super)
+widenCid = fmap toInterfaceContractId


### PR DESCRIPTION
Reopening of #631.

This PR proposes making Advance and Rewind of the Time interface consuming. Alternatively, if choices are required to be nonconsuming at the interface level, then archival can be push to the implementation level in DateClock instead.