### PR TITLE
Backport #669

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ doc-code: doc-code-json
 		--template=docs/code-documentation-templates/base-rst-template.rst \
 		--index-template=docs/code-documentation-templates/base-rst-index-template.rst \
 		--hoogle-template=docs/code-documentation-templates/base-hoogle-template.txt \
-		--base-url=https://docs.daml.com/daml/daml-finance \
+		--base-url=https://docs.daml.com/daml-finance/reference/code-documentation/daml-finance-rst \
 		--input-anchor=$(DAML_ROOT)/sdk/$(SDK_VERSION)/damlc/resources/daml-base-anchors.json \
 		docs/build/daml-finance.json
 

--- a/daml.yaml
+++ b/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.5.0
 name: daml-finance
 source: src/test/daml
-version: 1.1.4
+version: 1.1.5
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/docs/scripts/build-assembly.sh
+++ b/docs/scripts/build-assembly.sh
@@ -19,8 +19,8 @@ mkdir ${docs_dir}/.assembly
 cp -r ${root_dir}/src ${docs_dir}/.assembly
 
 # Copy doc build output into assembly file structure
-mkdir ${docs_dir}/.assembly/reference
-cp -r ${docs_dir}/build/daml-finance-rst ${docs_dir}/.assembly/reference/code-documentation
+mkdir -p ${docs_dir}/.assembly/reference/code-documentation
+cp -r ${docs_dir}/build/daml-finance-rst ${docs_dir}/.assembly/reference/code-documentation/daml-finance-rst
 cp ${docs_dir}/build/daml-finance-hoogle.txt ${docs_dir}/.assembly/reference/daml-finance-hoogle.txt
 
 # Update the directory paths in the RST files as per the assembly structure


### PR DESCRIPTION
https://github.com/digital-asset/daml-finance/pull/669

This also bumps assembly to `1.1.5`