### PR TITLE
remove reference to white paper

### DIFF
--- a/src/main/daml/ContingentClaims/Valuation/Stochastic.daml
+++ b/src/main/daml/ContingentClaims/Valuation/Stochastic.daml
@@ -123,8 +123,8 @@ instance Traversable (ExprF t) where
   sequence (E_F fa t) = flip E_F t <$> fa
 
 -- | Converts a `Claim` into the Fundamental Asset Pricing Formula. The ϵ expressions are defined as
--- E1-E10 in the Eber/Peyton-Jones paper. If you squint you can almost see they correspond
--- one-to-one to the formulae in our whitepaper. This is still an experimental feature.
+-- E1-E10 in the Eber/Peyton-Jones paper. 
+-- This is still an experimental feature.
 fapf : (Eq a, Show a, Show o, IsIdentifier t)
      => a
        -- ^ Currency in which the value process is expressed.


### PR DESCRIPTION
Remove a sentence referring to a white paper which we do not have.