### PR TITLE
Add features to generic callable bond

### DIFF
--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
@@ -57,15 +57,17 @@ data TestParties = TestParties
     publicParty : Party
       -- ^ The public party. Every party can readAs the public party.
 
--- | Creates the claim for a callable bond and the corresponding elections
-bootstrapBond : Date -> Date -> Decimal -> Decimal -> Deliverable -> C
-bootstrapBond intermediateDate maturity couponAmount principalAmount ccy =
+-- | Creates the claim for a callable bond (with 2 coupons) and the corresponding elections
+bootstrapBond : Date -> Date -> Date -> Decimal -> Decimal -> Decimal -> Deliverable -> C
+bootstrapBond cpn1Date cpn2Date maturity couponAmount principalAmount callPrincipalAmount ccy =
   let
     coupon = scale (Const couponAmount) $ one ccy
     principal = scale (Const principalAmount) $ one ccy
-    called = ("CALLED",) $ give principal
-    notCalled = ("NOT CALLED",) $ when (at maturity) $ give principal
-    callableBond = when (at intermediateDate) $ and coupon $ give $ or called notCalled
+    callPrincipal = scale (Const callPrincipalAmount) $ one ccy
+    called = ("CALLED",) $ give callPrincipal
+    notCalledFinal = ("NOT CALLED",) $ when (at maturity) $ give principal
+    notCalled = ("NOT CALLED",) $ when (at cpn2Date) $ and coupon $ give $ or called notCalledFinal
+    callableBond = when (at cpn1Date) $ and coupon $ give $ or called notCalled
   in mapClaimToUTCTime callableBond
 
 run : Script ()
@@ -93,12 +95,14 @@ run = script do
   -- Create and distribute a generic derivative
   let
     acquisitionTime = time (D.date 2022 Jul 01) 0 0 0
-    intermediateDate = D.date 2022 Jul 07
-    maturityDate = D.date 2023 Jul 07
+    coupon1Date = D.date 2022 Jul 07
+    coupon2Date = D.date 2023 Jul 07
+    maturityDate = D.date 2024 Jul 07
     couponAmount = 1_000.0
     principalAmount = 100_000.0
-    bond = bootstrapBond intermediateDate maturityDate couponAmount principalAmount
-      cashInstrument
+    callPrincipalAmount = 101_000.0
+    bond = bootstrapBond coupon1Date coupon2Date maturityDate couponAmount principalAmount
+      callPrincipalAmount cashInstrument
   genericInstrument <- originateGeneric bank issuer "ABC.DE 1% 07/07/23 Corp" "Callable Bond"
     acquisitionTime bond pp now
   investorGenericHoldingCid <- Account.credit [publicParty] genericInstrument 1.0 investorAccount
@@ -127,7 +131,7 @@ run = script do
   submitMultiMustFail [bank] [publicParty] do
     exerciseCmd callElectionFactoryCid CreateElectionCandidate with
       elector = bank
-      electionTime = dateToDateClockTime intermediateDate
+      electionTime = dateToDateClockTime coupon1Date
       holdingCid = investorGenericHoldingCid
       amount = 5000.0
 
@@ -135,11 +139,11 @@ run = script do
   electionProposalCid <- submitMulti [bank] [publicParty] do
     exerciseCmd callElectionFactoryCid CreateElectionCandidate with
       elector = bank
-      electionTime = dateToDateClockTime intermediateDate
+      electionTime = dateToDateClockTime coupon1Date
       holdingCid = fromInterfaceContractId investorGenericHoldingCid
       amount = 1.0
 
-  currentTimeCid <- createDateClock (S.singleton issuer) intermediateDate S.empty
+  currentTimeCid <- createDateClock (S.singleton issuer) coupon1Date S.empty
 
   electionCid <- submit issuer do
     exerciseCmd electionProposalCid ValidateElectionCandidate with
@@ -212,7 +216,7 @@ run = script do
   Some investorCouponAndPrincipal <-
     queryContractId investor $ fromInterfaceContractId @Fungible.T
       investorCashHoldingCouponAndPrincipalCid
-  getAmount investorCouponAndPrincipal === couponAmount + principalAmount
+  getAmount investorCouponAndPrincipal === couponAmount + callPrincipalAmount
   getOwner investorCouponAndPrincipal === investor
 
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
@@ -61,13 +61,13 @@ data TestParties = TestParties
 bootstrapBond : Date -> Date -> Date -> Decimal -> Decimal -> Decimal -> Deliverable -> C
 bootstrapBond cpn1Date cpn2Date maturity couponAmount principalAmount callPrincipalAmount ccy =
   let
-    coupon = scale (Const couponAmount) $ one ccy
-    principal = scale (Const principalAmount) $ one ccy
-    callPrincipal = scale (Const callPrincipalAmount) $ one ccy
-    called = ("CALLED",) $ give callPrincipal
-    notCalledFinal = ("NOT CALLED",) $ when (at maturity) $ give principal
-    notCalled = ("NOT CALLED",) $ when (at cpn2Date) $ and coupon $ give $ or called notCalledFinal
-    callableBond = when (at cpn1Date) $ and coupon $ give $ or called notCalled
+    coupon = give $ scale (Const couponAmount) $ one ccy
+    principal = give $ scale (Const principalAmount) $ one ccy
+    callPrincipal = give $ scale (Const callPrincipalAmount) $ one ccy
+    called = ("CALLED",) callPrincipal
+    notCalledFinal = ("NOT CALLED",) $ when (at maturity) $ principal
+    notCalled = ("NOT CALLED",) $ when (at cpn2Date) $ and coupon $ or called notCalledFinal
+    callableBond = when (at cpn1Date) $ give $ and coupon $ or called notCalled
   in mapClaimToUTCTime callableBond
 
 run : Script ()
@@ -105,13 +105,29 @@ run = script do
       callPrincipalAmount cashInstrument
   genericInstrument <- originateGeneric bank issuer "ABC.DE 1% 07/07/23 Corp" "Callable Bond"
     acquisitionTime bond pp now
-  investorGenericHoldingCid <- Account.credit [publicParty] genericInstrument 1.0 investorAccount
 
   -- Create election offer to allow the custodian to create elections
   electionFactoryCid <- submit issuer do
     toInterfaceContractId <$> createCmd Election.Factory with
       provider = issuer
       observers = M.fromList [("Custodian", S.singleton bank)]
+
+  currentTimeCid <- createDateClock (S.singleton issuer) coupon1Date S.empty
+
+  -- Create a lifecycle rule
+  lifecycleRuleCid <- toInterfaceContractId <$> submit bank do
+    createCmd Lifecycle.Rule with
+      providers = S.singleton bank
+      observers= M.empty
+      lifecycler = issuer
+      id = Id "LifecycleRule"
+      description = "Rule to lifecycle a generic instrument"
+
+  ---------------------------------
+  -- 1. ELECTION : CALL THE BOND --
+  ---------------------------------
+
+  investorGenericHoldingCid <- Account.credit [publicParty] genericInstrument 1.0 investorAccount
 
   callElectionFactoryCid <- submit issuer do
     createCmd ElectionOffer with
@@ -122,10 +138,6 @@ run = script do
       observers = S.singleton publicParty
       instrument = genericInstrument
       factoryCid = electionFactoryCid
-
-  ---------------------------------
-  -- 2. ELECTION : CALL THE BOND --
-  ---------------------------------
 
   -- One cannot exercise for more units than they own
   submitMultiMustFail [bank] [publicParty] do
@@ -143,21 +155,11 @@ run = script do
       holdingCid = fromInterfaceContractId investorGenericHoldingCid
       amount = 1.0
 
-  currentTimeCid <- createDateClock (S.singleton issuer) coupon1Date S.empty
-
   electionCid <- submit issuer do
     exerciseCmd electionProposalCid ValidateElectionCandidate with
       currentTimeCid
 
   -- Apply election to generate new instrument version + effects
-  lifecycleRuleCid <- toInterfaceContractId <$> submit bank do
-    createCmd Lifecycle.Rule with
-      providers = S.singleton bank
-      observers= M.empty
-      lifecycler = issuer
-      id = Id "LifecycleRule"
-      description = "Rule to lifecycle a generic instrument"
-
   (_, [effectCid]) <- submit issuer do
     exerciseCmd electionCid Election.Apply with
       observableCids = []
@@ -218,6 +220,93 @@ run = script do
       investorCashHoldingCouponAndPrincipalCid
   getAmount investorCouponAndPrincipal === couponAmount + callPrincipalAmount
   getOwner investorCouponAndPrincipal === investor
+
+  ----------------------------------------
+  -- 2. ELECTION : DO NOT CALL THE BOND --
+  ----------------------------------------
+
+  investorGenericHoldingCid <- Account.credit [publicParty] genericInstrument 1.0 investorAccount
+
+  dontCallElectionFactoryCid <- submit issuer do
+    createCmd ElectionOffer with
+      provider = issuer
+      id = Id "bondDontCall1"
+      description = "Bond - Do not Call"
+      claim = "NOT CALLED"
+      observers = S.singleton publicParty
+      instrument = genericInstrument
+      factoryCid = electionFactoryCid
+
+  -- Create election
+  electionProposalCid <- submitMulti [bank] [publicParty] do
+    exerciseCmd dontCallElectionFactoryCid CreateElectionCandidate with
+      elector = bank
+      electionTime = dateToDateClockTime coupon1Date
+      holdingCid = fromInterfaceContractId investorGenericHoldingCid
+      amount = 1.0
+
+  electionCid <- submit issuer do
+    exerciseCmd electionProposalCid ValidateElectionCandidate with
+      currentTimeCid
+
+  -- Apply election to generate new instrument version + effects
+  (_, [effectCid]) <- submit issuer do
+    exerciseCmd electionCid Election.Apply with
+      observableCids = []
+      exercisableCid = lifecycleRuleCid
+
+  -- Claim effect
+  result <- submitMulti [bank] [publicParty] do
+    exerciseCmd lifecycleClaimRuleCid Claim.ClaimEffect with
+      claimer = bank
+      holdingCids = [investorGenericHoldingCid]
+      effectCid
+      batchId = Id "BondDontCallSettlement"
+
+  let
+    [investorInstrumentInstructionCid, bankInstrumentInstructionCid,
+      bankCashInstructionCouponAndPrincipalCid] = result.instructionCids
+
+  -- Allocate instructions
+  (investorInstrumentInstructionCid, _) <- submit investor do
+    exerciseCmd investorInstrumentInstructionCid Instruction.Allocate with
+      actors = S.singleton investor; allocation = Pledge investorGenericHoldingCid
+  (bankInstrumentInstructionCid, _) <- submit bank do
+    exerciseCmd bankInstrumentInstructionCid Instruction.Allocate with
+      actors = S.singleton bank; allocation = CreditReceiver
+  (bankCashInstructionCouponAndPrincipalCid, _) <- submit bank do
+    exerciseCmd bankCashInstructionCouponAndPrincipalCid Instruction.Allocate with
+      actors = S.singleton bank; allocation = CreditReceiver
+
+  -- Approve instructions
+  investorInstrumentInstructionCid <- submit bank do
+    exerciseCmd investorInstrumentInstructionCid Instruction.Approve with
+      actors = S.singleton bank; approval = DebitSender
+  bankInstrumentInstructionCid <- submit investor do
+    exerciseCmd bankInstrumentInstructionCid Instruction.Approve with
+      actors = S.singleton investor; approval = TakeDelivery investorAccount
+  bankCashInstructionCouponAndPrincipalCid <- submit investor do
+    exerciseCmd bankCashInstructionCouponAndPrincipalCid Instruction.Approve with
+      actors = S.singleton investor; approval = TakeDelivery investorAccount
+
+
+  -- Settle batch
+  [investorInstrumentAfterCouponHoldingCid, investorCashHoldingCouponAndPrincipalCid]
+     <- submitMulti (S.toList settlers) [publicParty] do
+        exerciseCmd result.batchCid Batch.Settle with actors = settlers
+
+  -- Assert state
+  Some investorCouponAndPrincipal <-
+    queryContractId investor $ fromInterfaceContractId @Fungible.T
+      investorCashHoldingCouponAndPrincipalCid
+  getAmount investorCouponAndPrincipal === couponAmount
+  getOwner investorCouponAndPrincipal === investor
+
+  Some investorBondAfterCoupon <-
+    queryContractId investor $ fromInterfaceContractId @Fungible.T
+      investorInstrumentAfterCouponHoldingCid
+  getAmount investorBondAfterCoupon === 1.0
+  getOwner investorBondAfterCoupon === investor
 
   pure ()
 

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
@@ -57,7 +57,7 @@ data TestParties = TestParties
     publicParty : Party
       -- ^ The public party. Every party can readAs the public party.
 
--- | Creates the claim for a callable bond (with 2 coupons) and the corresponding elections
+-- | Creates the claim for a callable bond (with 2 coupons) and the corresponding elections.
 bootstrapBond : Date -> Date -> Date -> Decimal -> Decimal -> Decimal -> Deliverable -> C
 bootstrapBond cpn1Date cpn2Date maturity couponAmount principalAmount callPrincipalAmount ccy =
   let


### PR DESCRIPTION
Currently, the generic callable bond example only contains one coupon, so it does not show any nesting of claims. I have added a 2nd coupon to make the example a bit more realistic and to show claims nesting. 

I also added a separate principal amount in case of a call, to make it possible to add a call premium if desired.