### PR TITLE
Eliminate unnecessary Remove choices and the ArchiveFungible choice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -333,7 +333,7 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 ### Daml.Finance.Interface.Lifecycle
 
-- Unecessary `Remove` choices were removed from factories.
+- Unecessary (as of SDK 2.6) `Remove` choices were removed from factories.
 
 - Dependencies update
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 ### Daml.Finance.Data
 
+- Unecessary `Remove` choice (implementations) were removed.
+
 - Dependencies update
 
 - Style changes
@@ -105,6 +107,8 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - Removed `key` from `DateClock`.
 
 ### Daml.Finance.Holding
+
+- Unecessary `Remove` choice (implementations) were removed.
 
 - Dependencies update
 
@@ -217,6 +221,8 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 ### Daml.Finance.Interface.Data
 
+- Unecessary `Remove` choices were removed from factories.
+
 - Dependencies update
 
 - Style changes
@@ -226,6 +232,10 @@ This document tracks pending changes to packages. It is facilitating the write-u
   `HasImplementation` type class)
 
 ### Daml.Finance.Interface.Holding
+
+- Unecessary `Remove` choices were removed from factories.
+
+- Removed unnecessary `ArchiveFungible` choice
 
 - Dependencies update
 
@@ -323,6 +333,8 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 ### Daml.Finance.Interface.Lifecycle
 
+- Unecessary `Remove` choices were removed from factories.
+
 - Dependencies update
 
 - Style changes
@@ -357,6 +369,8 @@ This document tracks pending changes to packages. It is facilitating the write-u
   `HasImplementation` type class was removed)
 
 ### Daml.Finance.Lifecycle
+
+- Unecessary `Remove` choice (implementations) were removed.
 
 - Dependencies update
 

--- a/src/main/daml/Daml/Finance/Account/Account.daml
+++ b/src/main/daml/Daml/Finance/Account/Account.daml
@@ -7,7 +7,7 @@ import DA.Map qualified as M (empty)
 import DA.Set qualified as S (fromList, null, singleton)
 import Daml.Finance.Interface.Account.Account qualified as Account (Controllers(..), Credit(..), Debit(..), GetCid(..), I, R, View(..), createReference, disclosureUpdateReference)
 import Daml.Finance.Interface.Account.Factory qualified as AccountFactory (Create(..), F, Remove(..), View(..))
-import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (Create(..), F, Remove(..))
+import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (Create(..), F)
 import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), Id, PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
@@ -53,8 +53,7 @@ template Account
       debit Account.Debit{holdingCid} = do
         vHolding <- view <$> fetch holdingCid
         assertMsg "accounts must match" $ vHolding.account == account
-        exercise holdingFactoryCid HoldingFactory.Remove with
-          actors = S.fromList [account.custodian, account.owner]; holdingCid
+        archive holdingCid
 
     interface instance Disclosure.I for Account where
       view = Disclosure.View with disclosureControllers = S.fromList [custodian, owner]; observers

--- a/src/main/daml/Daml/Finance/Data/Numeric/Observation.daml
+++ b/src/main/daml/Daml/Finance/Data/Numeric/Observation.daml
@@ -64,8 +64,6 @@ template Factory
         create' ObservationFactory.Create{id; observations; observers; provider} =
           toInterfaceContractId <$>
             create Observation with id; observations; observers; provider
-        remove ObservationFactory.Remove{observationCid} =
-          archive $ fromInterfaceContractId @Observation observationCid
 
     interface instance Disclosure.I for Factory where
       view = Disclosure.View with disclosureControllers = singleton provider; observers

--- a/src/main/daml/Daml/Finance/Data/Reference/HolidayCalendar.daml
+++ b/src/main/daml/Daml/Finance/Data/Reference/HolidayCalendar.daml
@@ -75,8 +75,6 @@ template Factory
         view = HolidayCalendarFactory.View with provider
         create' HolidayCalendarFactory.Create{calendar; observers; provider} =
           toInterfaceContractId <$> create HolidayCalendar with calendar; observers; provider
-        remove HolidayCalendarFactory.Remove{calendarCid} =
-          archive $ fromInterfaceContractId @HolidayCalendar calendarCid
 
     interface instance Disclosure.I for Factory where
       view = Disclosure.View with disclosureControllers = singleton provider; observers

--- a/src/main/daml/Daml/Finance/Holding/Fungible.daml
+++ b/src/main/daml/Daml/Finance/Holding/Fungible.daml
@@ -8,7 +8,7 @@ import DA.Set qualified as S (fromList, null, singleton)
 import Daml.Finance.Holding.Util (acquireImpl, mergeImpl, releaseImpl, splitImpl, transferImpl)
 import Daml.Finance.Interface.Holding.Base (getLockers)
 import Daml.Finance.Interface.Holding.Base qualified as Base (I, Lock(..), View(..))
-import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (Create(..), F, Remove(..), View(..))
+import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (Create(..), F, View(..))
 import Daml.Finance.Interface.Holding.Fungible qualified as Fungible (I, View(..))
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I, View(..))
 import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), InstrumentKey(..), PartiesMap)
@@ -81,8 +81,6 @@ template Factory
           assertMsg "amount must be positive" $ amount > 0.0
           toInterfaceContractId <$>
             create Fungible with instrument; account; amount; observers; lock = None
-        remove HoldingFactory.Remove{holdingCid} =
-          archive $ fromInterfaceContractId @Fungible holdingCid
 
     interface instance Disclosure.I for Factory where
       view = Disclosure.View with disclosureControllers = S.singleton provider; observers

--- a/src/main/daml/Daml/Finance/Holding/NonFungible.daml
+++ b/src/main/daml/Daml/Finance/Holding/NonFungible.daml
@@ -8,7 +8,7 @@ import DA.Set qualified as S (fromList, null, singleton)
 import Daml.Finance.Holding.Util (acquireImpl, releaseImpl, transferImpl)
 import Daml.Finance.Interface.Holding.Base (getLockers)
 import Daml.Finance.Interface.Holding.Base qualified as Base (I, Lock(..), View(..))
-import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (Create(..), F, Remove(..), View(..))
+import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (Create(..), F, View(..))
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I, View(..))
 import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), InstrumentKey(..), PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
@@ -75,8 +75,6 @@ template Factory
           assertMsg "amount must be positive" $ amount > 0.0
           toInterfaceContractId <$>
             create NonFungible with instrument; account; amount; observers; lock = None
-        remove HoldingFactory.Remove{holdingCid} =
-          archive $ fromInterfaceContractId @NonFungible holdingCid
 
     interface instance Disclosure.I for Factory where
       view = Disclosure.View with disclosureControllers = S.singleton provider; observers

--- a/src/main/daml/Daml/Finance/Holding/NonTransferable.daml
+++ b/src/main/daml/Daml/Finance/Holding/NonTransferable.daml
@@ -8,7 +8,7 @@ import DA.Set qualified as S (fromList, null, singleton)
 import Daml.Finance.Holding.Util (acquireImpl, releaseImpl)
 import Daml.Finance.Interface.Holding.Base (getLockers)
 import Daml.Finance.Interface.Holding.Base qualified as Base (I, Lock(), View(..))
-import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (Create(..), F, Remove(..), View(..))
+import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (Create(..), F, View(..))
 import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), InstrumentKey(..), PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
@@ -70,8 +70,6 @@ template Factory
           assertMsg "amount must be positive" $ amount > 0.0
           toInterfaceContractId <$>
             create NonTransferable with instrument; account; amount; observers; lock = None
-        remove HoldingFactory.Remove{holdingCid} =
-          archive $ fromInterfaceContractId @NonTransferable holdingCid
 
     interface instance Disclosure.I for Factory where
       view = Disclosure.View with disclosureControllers = S.singleton provider; observers

--- a/src/main/daml/Daml/Finance/Interface/Data/Numeric/Observation/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Data/Numeric/Observation/Factory.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Interface.Data.Numeric.Observation.Factory where
 
 import DA.Map (Map)
 import Daml.Finance.Interface.Data.Numeric.Observation qualified as Observation (I)
-import Daml.Finance.Interface.Types.Common.Types (Id, Parties, PartiesMap)
+import Daml.Finance.Interface.Types.Common.Types (Id, PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
 -- | Type synonym for `Factory`.
@@ -29,8 +29,6 @@ interface Factory requires Disclosure.I where
 
   create' : Create -> Update (ContractId Observation.I)
     -- ^ Implementation of `Create` choice.
-  remove : Remove -> Update ()
-    -- ^ Implementation of `Remove` choice.
 
   nonconsuming choice Create : ContractId Observation.I
     -- ^ Create an `Observation`.
@@ -46,14 +44,3 @@ interface Factory requires Disclosure.I where
     controller provider
       do
         create' this arg
-
-  nonconsuming choice Remove : ()
-    -- ^ Archive an `Observation`.
-    with
-      actors : Parties
-        -- ^ The parties authorizing the removal.
-      observationCid : ContractId Observation.I
-        -- ^ The observation to be removed.
-    controller actors
-      do
-        remove this arg

--- a/src/main/daml/Daml/Finance/Interface/Data/Reference/HolidayCalendar/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Data/Reference/HolidayCalendar/Factory.daml
@@ -27,8 +27,6 @@ interface Factory requires Disclosure.I where
 
   create' : Create -> Update (ContractId HolidayCalendar.I)
     -- ^ Implementation of `Create` choice.
-  remove : Remove -> Update ()
-    -- ^ Implementation of `Remove` choice.
 
   nonconsuming choice Create : ContractId HolidayCalendar.I
     -- ^ Create a new Holiday Calendar.
@@ -42,15 +40,3 @@ interface Factory requires Disclosure.I where
     controller provider
     do
       create' this arg
-
-  nonconsuming choice Remove : ()
-    -- ^ Archive an Holiday Calendar.
-    with
-      calendarCid : ContractId HolidayCalendar.I
-        -- ^ The calendar's contractid.
-      provider : Party
-        -- ^ The calendar's provider.
-    controller provider
-      do
-        remove this arg
-

--- a/src/main/daml/Daml/Finance/Interface/Holding/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Holding/Factory.daml
@@ -4,7 +4,7 @@
 module Daml.Finance.Interface.Holding.Factory where
 
 import Daml.Finance.Interface.Holding.Base qualified as Base (I)
-import Daml.Finance.Interface.Types.Common.Types (AccountKey, InstrumentKey, Parties, PartiesMap)
+import Daml.Finance.Interface.Types.Common.Types (AccountKey, InstrumentKey, PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
 -- | Type synonym for `Factory`.
@@ -26,8 +26,6 @@ interface Factory requires Disclosure.I where
 
   create' : Create -> Update (ContractId Base.I)
     -- ^ Implementation of `Create` choice.
-  remove : Remove -> Update ()
-    -- ^ Implementation of `Remove` choice.
 
   nonconsuming choice Create : ContractId Base.I
     -- ^ Create a holding on the instrument in the corresponding account.
@@ -43,14 +41,3 @@ interface Factory requires Disclosure.I where
     controller account.custodian, account.owner
       do
         create' this arg
-
-  nonconsuming choice Remove : ()
-    -- ^ Archive a holding.
-    with
-      actors : Parties
-        -- ^ The parties authorizing the removal.
-      holdingCid : ContractId Base.I
-        -- ^ The holding to be removed.
-    controller actors
-      do
-        remove this arg

--- a/src/main/daml/Daml/Finance/Interface/Holding/Fungible.daml
+++ b/src/main/daml/Daml/Finance/Interface/Holding/Fungible.daml
@@ -67,9 +67,3 @@ interface Fungible requires Transferable.I, Base.I, Disclosure.I where
     controller (view this).modifiers, getLockers this
     do
       merge this arg
-
-  choice ArchiveFungible : ()
-    -- ^ Archives the fungible contract.
-    controller signatory this
-    do
-      pure ()

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Election/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Election/Factory.daml
@@ -26,8 +26,6 @@ interface Factory requires Disclosure.I where
 
   create' : Create -> Update (ContractId Election.I)
     -- ^ Implementation of `Create` choice.
-  remove : Remove -> Update ()
-    -- ^ Implementation of `Remove` choice.
 
   nonconsuming choice Create : ContractId Election.I
     -- ^ Create a new Election.
@@ -59,14 +57,3 @@ interface Factory requires Disclosure.I where
     controller actors
     do
       create' this arg
-
-  nonconsuming choice Remove : ()
-    -- ^ Archive an Election.
-    with
-      actors : Parties
-        -- ^ Parties executing the `Remove` choice.
-      electionCid : ContractId Election.I
-        -- ^ The election's contract id.
-    controller actors
-      do
-        remove this arg

--- a/src/main/daml/Daml/Finance/Lifecycle/Election.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Election.daml
@@ -87,7 +87,6 @@ template Factory
         toInterfaceContractId <$> create Election with
           id; description; claim; elector; counterparty; electorIsOwner; electionTime
           observers; amount; provider; instrument
-      remove arg = archive arg.electionCid
 
     interface instance Disclosure.I for Factory where
       view = Disclosure.View with disclosureControllers = singleton provider; observers

--- a/src/test/daml/Daml/Finance/Data/Test/HolidayCalendar.daml
+++ b/src/test/daml/Daml/Finance/Data/Test/HolidayCalendar.daml
@@ -8,7 +8,7 @@ import DA.Map qualified as M (empty, fromList)
 import DA.Set (singleton)
 import Daml.Finance.Data.Reference.HolidayCalendar (Factory(..))
 import Daml.Finance.Interface.Data.Reference.HolidayCalendar (GetView(..), UpdateCalendar(..))
-import Daml.Finance.Interface.Data.Reference.HolidayCalendar.Factory qualified as Factory (Create(..), F, Remove(..))
+import Daml.Finance.Interface.Data.Reference.HolidayCalendar.Factory qualified as Factory (Create(..), F)
 import Daml.Finance.Interface.Types.Date.Calendar (HolidayCalendarData(..))
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Script
@@ -63,10 +63,8 @@ testHolidayCalendar = script do
   assertMsg "The calendars should now have different holidays"
     $ usnyCalendarView.calendar.holidays /= usnyCalendarView2.calendar.holidays
 
-  -- Archive calendar (via factory)
+  -- Archive calendar
   submit reuters do
-    exerciseCmd calendarFactoryCid Factory.Remove with
-      calendarCid = usnyCalendarCid2
-      provider = reuters
+    archiveCmd calendarFactoryCid
 
   pure ()

--- a/src/test/daml/Daml/Finance/Data/Test/Observation.daml
+++ b/src/test/daml/Daml/Finance/Data/Test/Observation.daml
@@ -10,7 +10,7 @@ import DA.Set (singleton)
 import DA.Time (time)
 import Daml.Finance.Data.Numeric.Observation (Factory(..))
 import Daml.Finance.Interface.Data.Numeric.Observation (GetView(..))
-import Daml.Finance.Interface.Data.Numeric.Observation.Factory qualified as Factory (Create(..), F, Remove(..))
+import Daml.Finance.Interface.Data.Numeric.Observation.Factory qualified as Factory (Create(..), F)
 import Daml.Finance.Interface.Lifecycle.Observable.NumericObservable qualified as NumericObservable (I, Observe(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..))
 import Daml.Finance.Test.Util.Common (createParties)
@@ -52,10 +52,8 @@ testObservation = script do
 
   o === -0.00311
 
-  -- Archive observation (via factory)
+  -- Archive observation
   submit reuters do
-    exerciseCmd observationFactoryCid Factory.Remove with
-      observationCid
-      actors = singleton reuters
+    archiveCmd observationFactoryCid
 
   pure ()


### PR DESCRIPTION
Eliminates the "Remove" choices that serve as substitutes for `archive`. 

It retains the "Remove" choices for both the `Account` and `Instrument` factories, as these essentially function as "RemoveByKey" choices, and they also conveniently obfuscate the workaround we've implemented for keying interfaces. 

The redundant `ArchiveFungible` choice was also removed.

Fixes [889](https://github.com/digital-asset/daml-finance/issues/889)