### PR TITLE
Add claim rule that compresses steps on the cash leg

### DIFF
--- a/src/main/daml/Daml/Finance/Lifecycle/Rule/ClaimWithCompression.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Rule/ClaimWithCompression.daml
@@ -1,0 +1,153 @@
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Daml.Finance.Lifecycle.Rule.ClaimWithCompression where
+
+import DA.Foldable (forA_)
+import DA.Set (member)
+import Daml.Finance.Interface.Account.Util (getCustodian, getOwner)
+import Daml.Finance.Interface.Holding.Util (getInstrument)
+import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (Calculate(..), CalculationResult(..), GetView(..))
+import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), ClaimResult(..), I, View(..))
+import Daml.Finance.Interface.Settlement.Factory qualified as Settlement (F, Instruct(..))
+import Daml.Finance.Interface.Settlement.RouteProvider qualified as RouteProvider (Discover(..), I)
+import Daml.Finance.Interface.Settlement.Types (Step(..))
+import Daml.Finance.Interface.Types.Common.Types (Parties)
+import Daml.Finance.Lifecycle.Rule.Util
+
+-- | Type synonym for `Rule`.
+type T = Rule
+
+-- | Rule contract that allows an actor to claim effects, returning settlement instructions.
+template Rule
+  with
+    providers : Parties
+      -- ^ Providers of the claim rule. Together with the actors of the `ClaimEffect` choice the
+      --   authorization requirements to upgrade the holdings being claimed have to be met.
+    claimers : Parties
+      -- ^ Any of the parties can claim an effect.
+    settlers : Parties
+      -- ^ Any of the parties can trigger settlement of the resulting batch.
+    routeProviderCid : ContractId RouteProvider.I
+      -- ^ RouteProvider used to discover settlement routes.
+    settlementFactoryCid : ContractId Settlement.F
+      -- ^ Settlement factory contract used to create a `Batch` of `Instruction`\s.
+    netInstructions : Bool
+      -- ^ Configure whether netting should be enabled for quantities having the same (instrument,
+      --   sender, receiver).
+  where
+    signatory providers
+    observer claimers
+
+    interface instance Claim.I for Rule where
+      view = Claim.View with providers; claimers; settlers; routeProviderCid; settlementFactoryCid
+      claimEffect Claim.ClaimEffect{claimer; holdingCids; effectCid; batchId} = do
+        assertMsg "Effect can only be claimed by authorized parties." $
+          claimer `member` this.claimers
+        effectView <- exercise effectCid Effect.GetView with viewer = claimer
+        holdings <- mapA fetch holdingCids
+        forA_ holdings \h ->
+          assertMsg "The provided holding does not reference the expected instrument." $
+            getInstrument h == effectView.targetInstrument
+
+        -- Calculate settlement steps
+        let
+          createSteps consume quantities holding =
+            let
+              owner = getOwner holding
+              custodian = getCustodian holding
+              sender = if consume then owner else custodian
+              receiver = if consume then custodian else owner
+            in map (\quantity -> Step with sender; receiver; quantity) quantities
+
+          calculateSteps holding holdingCid = do
+            Effect.CalculationResult{consumed; produced} <-
+              exercise effectCid Effect.Calculate with actor = claimer; holdingCid
+            let
+              (consumedNetted, producedNetted) =
+                if netInstructions
+                then splitPending . net $ mergeConsumedAndProduced consumed produced
+                else (consumed, produced)
+              consumedSteps = createSteps True consumedNetted holding
+              producedSteps = createSteps False producedNetted holding
+            pure $ consumedSteps <> producedSteps
+
+        -- Settlement steps
+        steps <- mconcat <$> sequence (zipWith calculateSteps holdings holdingCids)
+
+        -- Compress non-target-instrument legs
+        let
+          compressedSteps = uncurry (<>) $ compress <$>
+            partition (\s -> s.quantity.unit.id == effectView.targetInstrument.id) steps
+
+        -- Discover settlement routes
+        routedSteps <- exercise routeProviderCid RouteProvider.Discover with
+          discoverors = providers; contextId = None; steps = compressedSteps
+
+        -- Generate settlement instructions for other instruments
+        (batchCid, instructionCids) <- exercise settlementFactoryCid Settlement.Instruct with
+          instructors = providers
+          settlers
+          id = batchId
+          description = effectView.description
+          contextId = Some effectView.id
+          routedSteps
+          settlementTime = effectView.settlementTime
+
+        pure Claim.ClaimResult with batchCid; instructionCids
+
+-- Compress RoutedSteps by bypassing intermediaries.
+-- It only handled cycles such as A -> B, B -> A but does not handle
+-- cycles such as A -> B, B -> C, C -> A. The latter case can be handled
+-- by doing multiple passes of this function.
+compress : [Step] -> [Step]
+compress = compressRec []
+
+-- | HIDE
+-- Recursive utility for Step compression.
+-- The first argument is the list of steps for which we know that
+-- the receiver is not an intermediary.
+-- The second argument is the list of all other steps.
+-- At each stage, we
+-- - take the first element of the second list and consider the receiving party
+-- - look for steps where this party is an intermediary
+-- - if found, apply the bypass
+compressRec : [Step] -> [Step] -> [Step]
+compressRec visited [] = visited
+compressRec visited (target :: rest) =
+  let
+    (newtarget, newVisited) = foldr folder (target, []) visited
+    (newertarget, newRest)  = foldr folder (newtarget, []) rest
+    newerVisited = if (newertarget.quantity.amount == 0.0)
+      then newVisited
+      else newertarget :: newVisited
+  in
+    compressRec newerVisited newRest
+  where
+    folder elem (acc, rest) = (rest <>) <$> replace acc elem
+
+-- | HIDE
+-- Given two steps, check if they are adjacent.
+-- If they are adjacent, try to bypass the intermediary.
+-- Examples:
+-- A -- 10 --> B, C -- 10 --> D is left unchanged
+-- A -- 10 --> B, B -- 20 --> C is modified to A -- 0 --> B, B -- 10 --> C, A -- 10 --> C
+-- A -- 20 --> B, B -- 10 --> C is modified to A -- 10 --> B, A -- 10 --> C
+replace : Step -> Step -> (Step, [Step])
+replace s1 s2 | s1.receiver /= s2.sender
+              || s1.quantity.unit /= s2.quantity.unit
+              = (s1, [s2])
+replace s1 s2 =
+  let
+    mergedStep =
+      if (s1.sender == s2.receiver) then [] else [s2 with sender = s1.sender; quantity = q2]
+    leftoverStep =
+      if (q3.amount == 0.0) then [] else [s2 with quantity = q3]
+  in
+    ((s1 with quantity = q1), mergedStep <> leftoverStep)
+  where
+    a1 = s1.quantity.amount
+    a2 = s2.quantity.amount
+    q1 = s1.quantity with amount = a1 - min a1 a2 -- unconsumed amount from first step
+    q2 = s2.quantity with amount = min a1 a2      -- amount for which we bypass the intermediary
+    q3 = s2.quantity with amount = a2 - min a1 a2 -- amount for which we cannot bypass the intermediary

--- a/src/main/daml/Daml/Finance/Lifecycle/Rule/ClaimWithCompression.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Rule/ClaimWithCompression.daml
@@ -131,6 +131,7 @@ compressRec visited (target :: rest) =
 -- If they are adjacent, try to bypass the intermediary.
 -- Examples:
 -- A -- 10 --> B, C -- 10 --> D is left unchanged
+-- A -- 10 --> B, B -- 10 --> C is modified to A -- 0 --> B, A -- 10 --> C
 -- A -- 10 --> B, B -- 20 --> C is modified to A -- 0 --> B, B -- 10 --> C, A -- 10 --> C
 -- A -- 20 --> B, B -- 10 --> C is modified to A -- 10 --> B, A -- 10 --> C
 replace : Step -> Step -> (Step, [Step])

--- a/src/main/daml/Daml/Finance/Lifecycle/Rule/ClaimWithNonTargetCompression.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Rule/ClaimWithNonTargetCompression.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Daml.Finance.Lifecycle.Rule.ClaimWithCompression where
+module Daml.Finance.Lifecycle.Rule.ClaimWithNonTargetCompression where
 
 import DA.Foldable (forA_)
 import DA.Set (member)
@@ -135,15 +135,13 @@ compressRec visited (target :: rest) =
 -- A -- 10 --> B, B -- 20 --> C is modified to A -- 0 --> B, B -- 10 --> C, A -- 10 --> C
 -- A -- 20 --> B, B -- 10 --> C is modified to A -- 10 --> B, A -- 10 --> C
 replace : Step -> Step -> (Step, [Step])
-replace s1 s2 | s1.receiver /= s2.sender
-              || s1.quantity.unit /= s2.quantity.unit
-              = (s1, [s2])
+replace s1 s2 | s1.receiver /= s2.sender || s1.quantity.unit /= s2.quantity.unit = (s1, [s2])
 replace s1 s2 =
   let
     mergedStep =
-      if (s1.sender == s2.receiver) then [] else [s2 with sender = s1.sender; quantity = q2]
+      if s1.sender == s2.receiver then [] else [s2 with sender = s1.sender; quantity = q2]
     leftoverStep =
-      if (q3.amount == 0.0) then [] else [s2 with quantity = q3]
+      if q3.amount == 0.0 then [] else [s2 with quantity = q3]
   in
     ((s1 with quantity = q1), mergedStep <> leftoverStep)
   where

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCouponWithCompression.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCouponWithCompression.daml
@@ -17,7 +17,7 @@ import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..))
 import Daml.Finance.Interface.Types.Common.Types (AccountKey, Id(..), InstrumentKey, Parties)
-import Daml.Finance.Lifecycle.Rule.ClaimWithCompression qualified as Claim (Rule(..))
+import Daml.Finance.Lifecycle.Rule.ClaimWithNonTargetCompression qualified as Claim (Rule(..))
 import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.Hierarchy (Hierarchy(..))
 import Daml.Finance.Settlement.RouteProvider.IntermediatedStatic (IntermediatedStatic(..))
@@ -110,9 +110,9 @@ originateSecurityAndDefineRoute TestParties{bank, csd, investor, issuer, publicP
       expiry = addDays today 180
       bondLabel = "ABC.DE 2% " <> show expiry <> " Corp"
       claims = mapClaimToUTCTime $ andList
-        [ when (TimeGte $ today) $ scale (Const 0.02) $ one cashInstrument
-        , when (TimeGte $ expiry) $ scale (Const 0.02) $ one cashInstrument
-        , when (TimeGte $ expiry) $ scale (Const 1.0) $ one cashInstrument
+        [ when (TimeGte today) $ scale (Const 0.02) $ one cashInstrument
+        , when (TimeGte expiry) $ scale (Const 0.02) $ one cashInstrument
+        , when (TimeGte expiry) $ scale (Const 1.0) $ one cashInstrument
         ]
     -- CREATE_CC_INSTRUMENT_VARIABLES_END
     let pp = [("PublicParty", S.singleton publicParty)]

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCouponWithCompression.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCouponWithCompression.daml
@@ -1,0 +1,303 @@
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Daml.Finance.Instrument.Generic.Test.Intermediated.BondCouponWithCompression where
+
+import ContingentClaims.Core.Claim (Inequality(..), andList, one, scale, when)
+import ContingentClaims.Core.Observation (Observation(..))
+import DA.Date (addDays, toDateUTC)
+import DA.Map qualified as M (empty, fromList)
+import DA.Set qualified as S (empty, singleton, toList)
+import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
+import Daml.Finance.Instrument.Generic.Lifecycle.Rule qualified as Lifecycle (Rule(..))
+import Daml.Finance.Instrument.Generic.Test.Util (mapClaimToUTCTime, originateGeneric)
+import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), I)
+import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (Evolve(..), I)
+import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
+import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
+import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..))
+import Daml.Finance.Interface.Types.Common.Types (AccountKey, Id(..), InstrumentKey, Parties)
+import Daml.Finance.Lifecycle.Rule.ClaimWithCompression qualified as Claim (Rule(..))
+import Daml.Finance.Settlement.Factory (Factory(..))
+import Daml.Finance.Settlement.Hierarchy (Hierarchy(..))
+import Daml.Finance.Settlement.RouteProvider.IntermediatedStatic (IntermediatedStatic(..))
+import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
+import Daml.Finance.Test.Util.Common (createParties)
+import Daml.Finance.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
+import Daml.Finance.Test.Util.Instrument qualified as BaseInstrument (originate)
+import Daml.Finance.Test.Util.Time (createClockUpdateEvent)
+import Daml.Script
+
+{-
+  This script distributes a bond to investors and showcases how the bond can be lifecycled to
+  trigger (and settle) a coupon payment.
+
+  Bond (security) account structure :
+
+     Issuer
+       |
+      CSD
+       |
+    Investor
+
+  Cash account structure :
+
+      Central Bank
+        |     \
+     Issuer  Bank
+                \
+             Investor
+-}
+
+-- | Parties involved in the test script.
+data TestParties = TestParties
+  with
+    bank : Party
+      -- ^ The Bank acts as custodian of the investor's cash holdings.
+    centralBank : Party
+      -- ^ The Central Bank is the depository and the issuer of the cash instrument. It also acts
+      --   as root custodian of the cash holdings.
+    csd : Party
+      -- ^ Custodian of the bond holding (from the perspective of an investor). It also acts as
+      --   depository of the bond instrument.
+    issuer : Party
+      -- ^ Acts as issuer, as well as the root custodian, of the bond instrument. It is also the
+      --   party tasked with lifecycling the bond.
+    investor : Party
+      -- ^ Owner of the bond holding.
+    settlers : Parties
+      -- ^ Any party of the settlers triggers the settlement of fully allocated settlement
+      --   instructions.
+    publicParty : Party
+      -- ^ The public party. Every party can readAs the public party.
+
+-- | Originate USD cash instrument and define settlement route.
+originateCashAndDefineRoute : TestParties -> Time -> Script (InstrumentKey, (Text, Hierarchy))
+originateCashAndDefineRoute TestParties{bank, centralBank, csd, investor, issuer, publicParty}
+  now = do
+    let
+      pp = [("PublicParty", S.singleton publicParty)]
+      label = "USD"
+      -- CREATE_CASH_ROUTE_BEGIN
+      {-
+        Cash account structure :
+
+            Central Bank
+               |     \
+             Issuer  Bank
+                        \
+                      Investor
+      -}
+      route =
+        ( label
+        , Hierarchy with
+            rootCustodian = centralBank
+            pathsToRootCustodian = [[investor, bank], [issuer]]
+        )
+      -- CREATE_CASH_ROUTE_END
+    instrument <-
+      BaseInstrument.originate centralBank centralBank "USD" "United States Dollar" pp now
+    pure (instrument, route)
+
+-- | Originate bond instrument and define settlement route.
+originateSecurityAndDefineRoute : TestParties -> Time -> InstrumentKey ->
+  Script (InstrumentKey, (Text, Hierarchy))
+originateSecurityAndDefineRoute TestParties{bank, csd, investor, issuer, publicParty} now
+  cashInstrument = do
+    -- CREATE_CC_INSTRUMENT_VARIABLES_BEGIN
+    let
+      today = toDateUTC now
+      expiry = addDays today 180
+      bondLabel = "ABC.DE 2% " <> show expiry <> " Corp"
+      claims = mapClaimToUTCTime $ andList
+        [ when (TimeGte $ today) $ scale (Const 0.02) $ one cashInstrument
+        , when (TimeGte $ expiry) $ scale (Const 0.02) $ one cashInstrument
+        , when (TimeGte $ expiry) $ scale (Const 1.0) $ one cashInstrument
+        ]
+    -- CREATE_CC_INSTRUMENT_VARIABLES_END
+    let pp = [("PublicParty", S.singleton publicParty)]
+    -- CREATE_CC_INSTRUMENT_BEGIN
+    instrument <- originateGeneric csd issuer bondLabel "Bond" now claims pp now
+    -- CREATE_CC_INSTRUMENT_END
+    -- CREATE_BOND_ROUTE_BEGIN
+    {-
+    Bond (security) account structure :
+
+      Issuer
+        |
+        CSD
+        |
+      Investor
+    -}
+    let
+      route =
+        ( bondLabel
+        , Hierarchy with
+            rootCustodian = issuer
+            pathsToRootCustodian = [[investor, csd]]
+        )
+    -- CREATE_BOND_ROUTE_END
+    pure (instrument, route)
+
+-- | Penultimate coupon payment on a bond showing creation of new instrument version.
+-- The effect is claimed and settled atomically across the entire chain.
+runIntermediatedLifecyclingAtomic : Script ()
+runIntermediatedLifecyclingAtomic = script do
+  parties@TestParties{..} <- setupParties
+
+  -- Setup security accounts
+  [investorSecuritiesAccount] <- setupAccounts "Securities Account" csd publicParty [investor]
+  [csdAccountAtIssuer] <- setupAccounts "Securities Account" issuer publicParty [csd]
+
+  -- Setup cash accounts at central bank
+  [issuerCashAccount, bankCashAccount] <-
+    setupAccounts "Cash Account" centralBank publicParty [issuer, bank]
+
+  -- Setup investor's cash account at Bank
+  [investorCashAccount] <- setupAccounts "Cash Account" bank publicParty [investor]
+
+  -- Originate and distribute central-bank cash
+  now <- getTime
+  let today = toDateUTC now
+
+  (cashInstrument, cashRoute) <- originateCashAndDefineRoute parties now
+  issuerCashHoldingCid <- Account.credit [publicParty] cashInstrument 20_000.0 issuerCashAccount
+
+  -- Originate and distribute bond
+  (bondInstrument, bondRoute) <- originateSecurityAndDefineRoute parties now cashInstrument
+  csdBondHoldingCid <- Account.credit [publicParty] bondInstrument 1_000_000.0 csdAccountAtIssuer
+  investorBondHoldingCid <-
+    Account.credit [publicParty] bondInstrument 1_000_000.0 investorSecuritiesAccount
+
+  -- create clock update event
+  clockEventCid <- createClockUpdateEvent (S.singleton issuer) today S.empty
+
+  -- Create a lifecycle rule
+  lifecycleRuleCid <- toInterfaceContractId @Lifecycle.I <$> submit csd do
+    createCmd Lifecycle.Rule with
+      providers = S.singleton csd
+      observers= M.empty
+      lifecycler = issuer
+      id = Id "LifecycleRule"
+      description = "Rule to lifecycle a generic instrument"
+
+  -- Try to lifecycle the instrument
+  (_, [effectCid]) <- submit issuer do
+    exerciseCmd lifecycleRuleCid Lifecycle.Evolve with
+      eventCid = clockEventCid
+      observableCids = []
+      instrument = bondInstrument
+
+  -- Define settlement routes from CSD to Investor and create batch factory
+  let routes = M.fromList [cashRoute, bondRoute]
+
+  routeProviderCid <- toInterfaceContractId <$> submit csd do
+    createCmd IntermediatedStatic with
+      provider = csd; observers = S.singleton investor; paths = routes
+
+  settlementFactoryCid <- submit csd do
+    toInterfaceContractId <$> createCmd Factory with
+      provider = csd; observers = S.singleton investor
+
+  lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submit csd do
+    createCmd Claim.Rule with
+      providers = S.singleton csd
+      claimers = S.singleton csd
+      settlers
+      routeProviderCid
+      settlementFactoryCid
+      netInstructions = False
+
+  -- LIFECYCLE_BOND_ATOMIC_CLAIMEFFECT_BEGIN
+  result <- submit csd do
+    exerciseCmd lifecycleClaimRuleCid Claim.ClaimEffect with
+      claimer = csd
+      holdingCids = [csdBondHoldingCid, investorBondHoldingCid]
+      effectCid
+      batchId = Id "CouponSettlement"
+  -- LIFECYCLE_BOND_ATOMIC_CLAIMEFFECT_END
+
+  -- LIFECYCLE_BOND_ATOMIC_INSTRUCTIONS_BEGIN
+  let
+    [   csdBondInstructionCid1      -- old bond from CSD to issuer
+      , issuerBondInstructionCid    -- new bond from issuer to CSD
+      , investorBondInstructionCid  -- old bond from investor to CSD
+      , csdBondInstructionCid2      -- new bond from CSD to investor
+      , issuerCashInstructionCid    -- coupon payment from issuer to Bank
+      , bankCashInstructionCid      -- coupon payment from investor's bank to investor
+      ] = result.instructionCids
+  -- LIFECYCLE_BOND_ATOMIC_INSTRUCTIONS_END
+
+  -- Allocate instructions
+  (csdBondInstructionCid1, _) <- submit csd do
+    exerciseCmd csdBondInstructionCid1 Instruction.Allocate with
+      actors = S.singleton csd; allocation = Pledge csdBondHoldingCid
+  (issuerBondInstructionCid, _) <- submit issuer do
+    exerciseCmd issuerBondInstructionCid Instruction.Allocate with
+      actors = S.singleton issuer; allocation = CreditReceiver
+  (issuerCashInstructionCid, _) <- submit issuer do
+    exerciseCmd issuerCashInstructionCid Instruction.Allocate with
+      actors = S.singleton issuer; allocation = Pledge issuerCashHoldingCid
+  (investorBondInstructionCid, _) <- submit investor do
+    exerciseCmd investorBondInstructionCid Instruction.Allocate with
+      actors = S.singleton investor; allocation = Pledge investorBondHoldingCid
+  (csdBondInstructionCid2, _) <- submit csd do
+    exerciseCmd csdBondInstructionCid2 Instruction.Allocate with
+      actors = S.singleton csd; allocation = CreditReceiver
+  (bankCashInstructionCid, _) <- submit bank do
+    exerciseCmd bankCashInstructionCid Instruction.Allocate with
+      actors = S.singleton bank; allocation = CreditReceiver
+
+  -- Approve instructions
+  csdBondInstructionCid1 <- submit issuer do
+    exerciseCmd csdBondInstructionCid1 Instruction.Approve with
+      actors = S.singleton issuer; approval = DebitSender
+  issuerBondInstructionCid <- submit csd do
+    exerciseCmd issuerBondInstructionCid Instruction.Approve with
+      actors = S.singleton csd; approval = TakeDelivery csdAccountAtIssuer
+  issuerCashInstructionCid <- submit bank do
+    exerciseCmd issuerCashInstructionCid Instruction.Approve with
+      actors = S.singleton bank; approval = TakeDelivery bankCashAccount
+  investorBondInstructionCid <- submit csd do
+    exerciseCmd investorBondInstructionCid Instruction.Approve with
+      actors = S.singleton csd; approval = DebitSender
+  csdBondInstructionCid2 <- submit investor do
+    exerciseCmd csdBondInstructionCid2 Instruction.Approve with
+      actors = S.singleton investor; approval = TakeDelivery investorSecuritiesAccount
+  bankCashInstructionCid <- submit investor do
+    exerciseCmd bankCashInstructionCid Instruction.Approve with
+      actors = S.singleton investor; approval = TakeDelivery investorCashAccount
+
+  -- Settle batch
+  [csdBondHoldingCid, investorCashHoldingCid, bankCashHoldingCid, investorBondHoldingCid] <-
+    submitMulti (S.toList settlers) [publicParty] do
+      exerciseCmd result.batchCid Batch.Settle with actors = settlers
+
+  -- Assert state
+  Holding.verifyOwnerOfHolding
+    [ (csd, csdBondHoldingCid)
+    , (investor, investorBondHoldingCid)
+    , (bank, bankCashHoldingCid)
+    , (investor, investorCashHoldingCid)
+    ]
+
+  pure ()
+
+-- | HIDE
+setupParties : Script TestParties
+setupParties = do
+  [bank, centralBank, csd, issuer, investor, settler, publicParty] <-
+    createParties ["Bank", "CentralBank", "CSD", "Issuer", "Investor", "Settler", "PublicParty"]
+  pure TestParties with
+    bank; centralBank; csd; issuer; investor; settlers = S.singleton settler; publicParty
+
+-- | HIDE
+-- Setup a set of accounts.
+setupAccounts : Text -> Party -> Party -> [Party] -> Script [AccountKey]
+setupAccounts description custodian publicParty owners = do
+  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory custodian []
+  holdingFactoryCid <- toInterfaceContractId <$> submit custodian do
+    createCmd Fungible.Factory with
+      provider= custodian; observers = M.fromList [("PublicParty", S.singleton publicParty)]
+  forA owners $ Account.createAccount description [] accountFactoryCid holdingFactoryCid []
+    Account.Owner custodian

--- a/src/test/daml/Daml/Finance/Lifecycle/Test/Compression.daml
+++ b/src/test/daml/Daml/Finance/Lifecycle/Test/Compression.daml
@@ -1,3 +1,6 @@
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module Daml.Finance.Lifecycle.Test.Compression where
 
 import DA.Assert ((===))

--- a/src/test/daml/Daml/Finance/Lifecycle/Test/Compression.daml
+++ b/src/test/daml/Daml/Finance/Lifecycle/Test/Compression.daml
@@ -8,7 +8,7 @@ import DA.Set (fromList)
 import Daml.Finance.Interface.Settlement.Types (Step(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..), InstrumentKey(..))
 import Daml.Finance.Interface.Util.Common (qty)
-import Daml.Finance.Lifecycle.Rule.ClaimWithCompression (compress)
+import Daml.Finance.Lifecycle.Rule.ClaimWithNonTargetCompression (compress)
 import Daml.Script
 
 -- | Test for the `compress` function, which tries to eliminate intermediaries from [Step].
@@ -18,13 +18,13 @@ testCompression = do
   [a, b, c, d, e] <- mapA allocateParty ["a", "b", "c", "d", "e"]
 
   let
-    i1 = InstrumentKey with id = Id "1", issuer = a, depository = a, version = "0"
-    i2 = InstrumentKey with id = Id "1", issuer = a, depository = a, version = "1"
-    i3 = InstrumentKey with id = Id "1", issuer = a, depository = a, version = "2"
-    i4 = InstrumentKey with id = Id "1", issuer = a, depository = a, version = "3"
-    i5 = InstrumentKey with id = Id "1", issuer = a, depository = a, version = "4"
-    i6 = InstrumentKey with id = Id "1", issuer = a, depository = a, version = "5"
-    i7 = InstrumentKey with id = Id "1", issuer = a, depository = a, version = "6"
+    i1 = InstrumentKey with id = Id "1"; issuer = a; depository = a; version = "1"
+    i2 = InstrumentKey with id = Id "1"; issuer = a; depository = a; version = "2"
+    i3 = InstrumentKey with id = Id "1"; issuer = a; depository = a; version = "3"
+    i4 = InstrumentKey with id = Id "1"; issuer = a; depository = a; version = "4"
+    i5 = InstrumentKey with id = Id "1"; issuer = a; depository = a; version = "5"
+    i6 = InstrumentKey with id = Id "1"; issuer = a; depository = a; version = "6"
+    i7 = InstrumentKey with id = Id "1"; issuer = a; depository = a; version = "7"
 
     input = [
         Step a b (qty 10.0 i1) -- non-adjacent step

--- a/src/test/daml/Daml/Finance/Lifecycle/Test/Compression.daml
+++ b/src/test/daml/Daml/Finance/Lifecycle/Test/Compression.daml
@@ -1,0 +1,61 @@
+module Daml.Finance.Lifecycle.Test.Compression where
+
+import DA.Assert ((===))
+import DA.Set (fromList)
+import Daml.Finance.Interface.Settlement.Types (Step(..))
+import Daml.Finance.Interface.Types.Common.Types (Id(..), InstrumentKey(..))
+import Daml.Finance.Interface.Util.Common (qty)
+import Daml.Finance.Lifecycle.Rule.ClaimWithCompression (compress)
+import Daml.Script
+
+-- | Test for the `compress` function, which tries to eliminate intermediaries from [Step].
+testCompression : Script ()
+testCompression = do
+
+  [a, b, c, d, e] <- mapA allocateParty ["a", "b", "c", "d", "e"]
+
+  let
+    i1 = InstrumentKey with id = Id "1", issuer = a, depository = a, version = "0"
+    i2 = InstrumentKey with id = Id "1", issuer = a, depository = a, version = "1"
+    i3 = InstrumentKey with id = Id "1", issuer = a, depository = a, version = "2"
+    i4 = InstrumentKey with id = Id "1", issuer = a, depository = a, version = "3"
+    i5 = InstrumentKey with id = Id "1", issuer = a, depository = a, version = "4"
+    i6 = InstrumentKey with id = Id "1", issuer = a, depository = a, version = "5"
+    i7 = InstrumentKey with id = Id "1", issuer = a, depository = a, version = "6"
+
+    input = [
+        Step a b (qty 10.0 i1) -- non-adjacent step
+      , Step a b (qty 10.0 i2) -- cycle
+      , Step b a (qty 5.0 i2)
+      , Step a b (qty 15.0 i3) -- exact bypass
+      , Step b c (qty 15.0 i3)
+      , Step a b (qty 10.0 i4) -- incomplete bypass
+      , Step b c (qty 15.0 i4)
+      , Step a b (qty 20.0 i5) -- bypass with leftover
+      , Step b c (qty 15.0 i5)
+      , Step c d (qty 1.0 i6) -- chain
+      , Step a b (qty 1.0 i6)
+      , Step b c (qty 1.0 i6)
+      , Step a b (qty 15.0 i7) -- bifurcation
+      , Step b c (qty 10.0 i7)
+      , Step c d (qty 5.0 i7)
+      , Step c e (qty 5.0 i7)
+      ]
+
+    expected = [
+        Step a b (qty 10.0 i1) -- non-adjacent step
+      , Step a b (qty 5.0 i2) -- cycle
+      , Step a c (qty 15.0 i3) -- exact bypass
+      , Step a c (qty 10.0 i4) -- incomplete bypass
+      , Step b c (qty 5.0 i4)
+      , Step a b (qty 5.0 i5) -- bypass with leftover
+      , Step a c (qty 15.0 i5)
+      , Step a d (qty 1.0 i6) -- chain
+      , Step a b (qty 5.0 i7) -- bifurcation
+      , Step a d (qty 5.0 i7)
+      , Step a e (qty 5.0 i7)
+      ]
+
+  fromList expected === fromList (compress input)
+
+  pure ()


### PR DESCRIPTION
Merging into a side-branch for now. 

This PR adds a version of the `Claim` rule that "compresses" settlement `Steps` on the cash leg, bypassing intermediaries.

I originally applied compression directly on `RoutedSteps` (within the `RouteProvider`) but then realised that this forces the intermediaries to be in the route, which might be undesirable.

The `compress` function however works for both `Steps` and `RoutedSteps` (as they both form a set of directed graphs). If we think it is a valuable addition to the library, we can
- move it to a common place (to be defined, could be in `D.F.Settlement`)
- use a type-class to abstract graph-like structures
- have `Step` and `RoutedStep` implement such a type-class