### PR TITLE
Add daml caching to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ commands:
               --run bash \<<'EOF'
                   set -euo pipefail
 
-                  git log -n1 --format=%H daml.yaml package/*/daml/**/daml.yaml > /tmp/daml-cache-key
+                  git log -n1 --format=%H daml.yaml package/packages.yaml package/*/daml/*/daml.yaml > /tmp/daml-cache-key
             EOF
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ commands:
     description: Set up Nix
     steps:
       - run:
-          name: Generate cache key
+          name: Generate nix cache key
           command: |
             set -euo pipefail
 
@@ -79,7 +79,7 @@ commands:
               --run bash \<<'EOF'
                   set -euo pipefail
 
-                  git log -n1 --format=%H daml.yaml package/main/daml/*/daml.yaml > /tmp/daml-cache-key
+                  git log -n1 --format=%H daml.yaml package/*/daml/**/daml.yaml > /tmp/daml-cache-key
             EOF
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,30 @@ commands:
 
                   echo ${gpg_code_signing} | base64 -d | gpg --import --quiet
             EOF
+  run_daml_build:
+    description: "Run daml build"
+    steps:
+      - run:
+          name: Generate daml cache key
+          command: |
+            nix-shell \
+              --pure \
+              --run bash \<<'EOF'
+                  set -euo pipefail
+
+                  git log -n1 --format=%H daml.yaml package/main/daml/*/daml.yaml > /tmp/daml-cache-key
+            EOF
+      - restore_cache:
+          keys:
+          - daml-{{ checksum "/tmp/daml-cache-key" }}
+      - run:
+          name: Build daml source and packages
+          command:
+            make ci-build
+      - save_cache:
+          paths:
+            - .cache
+          key: daml-{{ checksum "/tmp/daml-cache-key" }}
   run_release:
     description: "GitHub Release"
     steps:
@@ -185,10 +209,7 @@ jobs:
           name: Validate package data-dependencies
           command:
             nix-shell --pure --run 'export LANG=C.UTF-8; packell data-dependencies validate'
-      - run:
-          name: Build source and packages
-          command:
-            make ci-build
+      - run_daml_build
       - run:
           name: Validate packages
           command:


### PR DESCRIPTION
Avoid downloading `dar` dependencies from GitHub for every build by the CI.

Utilises the CircleCI caching to store the `.cache` directory (which contains all the downloaded GitHub dependencies). This directory is already used locally to avoid unnecessary downloads from GitHub.