### PR TITLE
improve token instrument description

### DIFF
--- a/src/main/daml/Daml/Finance/Instrument/Token/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Token/Instrument.daml
@@ -14,8 +14,8 @@ import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setO
 -- | Type synonym for `Instrument`.
 type T = Instrument
 
--- | Implementation of a *Token* Instrument, which is a simple instrument that does not define
--- any lifecycling logic.
+-- | Implementation of a Token Instrument, which is a simple instrument whose economic terms
+-- on the ledger are represented by an `id` and a textual `description`.
 template Instrument
   with
     depository : Party
@@ -23,7 +23,7 @@ template Instrument
     issuer : Party
       -- ^ The instrument's issuer.
     id : Id
-      -- ^ The intrument's versioned identifier.
+      -- ^ The intrument's identifier.
     version : Text
       -- ^ A textual instrument version.
     description : Text

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Base/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Base/Instrument.daml
@@ -32,7 +32,7 @@ data View = View
     depository : Party
       -- ^ The instrument's depository.
     id : Id
-      -- ^ A versioned instrument identifier.
+      -- ^ The instrument's identifier.
     version : Text
       -- ^ A textual instrument version.
     description : Text

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Token/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Token/Instrument.daml
@@ -17,10 +17,11 @@ type V = View
 data View = View
   with
     token : Token
-      -- ^ Attributes of a token.
+      -- ^ Attributes of a Token Instrument.
   deriving (Eq, Show)
 
--- | Interface for simple token instruments which do not define any lifecycling logic.
+-- | Interface for a Token, an instrument whose economic terms on the ledger are represented
+-- by an `id` and a textual `description`.
 interface Instrument requires BaseInstrument.I, Disclosure.I where
   viewtype V
 

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Token/Types.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Token/Types.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Interface.Instrument.Token.Types where
 
 import Daml.Finance.Interface.Types.Common.Types (InstrumentKey)
 
--- | Describes the attributes of an Token.
+-- | Describes the attributes of a Token Instrument.
 data Token = Token
   with
     instrument : InstrumentKey


### PR DESCRIPTION
We shouldn't characterise the `Token` instrument as not defining any lifecycling logic. This is because we can process e.g. `Distribution` events for a Token, and we do so in the getting started lifecycling tutorial