### PR TITLE
Cleanup of `main` branch after release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,13 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 | Package                                    | Released version   | Target version |
 |--------------------------------------------|--------------------|----------------|
-| ContingentClaims.Core                      | 1.0.0              | 1.0.1          |
-| ContingentClaims.Lifecycle                 | 1.0.0              | 1.0.1          |
+| ContingentClaims.Core                      | 1.0.0              | 2.0.0          |
+| ContingentClaims.Lifecycle                 | 1.0.0              | 2.0.0          |
 | Daml.Finance.Account                       | 1.0.1              | 2.0.0          |
-| Daml.Finance.Claims                        | 1.0.1              | 1.0.2          |
+| Daml.Finance.Claims                        | 1.0.1              | 2.0.0          |
 | Daml.Finance.Data                          | 1.0.1              | 2.0.0          |
 | Daml.Finance.Holding                       | 1.0.2              | 2.0.0          |
+| Daml.Finance.Instrument.Bond               | 0.2.1              | 1.0.0          |
 | Daml.Finance.Instrument.Generic            | 1.0.1              | 2.0.0          |
 | Daml.Finance.Instrument.Token              | 1.0.1              | 2.0.0          |
 | Daml.Finance.Interface.Account             | 1.0.0              | 2.0.0          |
@@ -19,28 +20,27 @@ This document tracks pending changes to packages. It is facilitating the write-u
 | Daml.Finance.Interface.Data                | 2.0.0              | 3.0.0          |
 | Daml.Finance.Interface.Holding             | 1.0.0              | 2.0.0          |
 | Daml.Finance.Interface.Instrument.Base     | 1.0.0              | 2.0.0          |
+| Daml.Finance.Interface.Instrument.Bond     | 0.2.1              | 1.0.0          |
 | Daml.Finance.Interface.Instrument.Generic  | 1.0.0              | 2.0.0          |
 | Daml.Finance.Interface.Instrument.Token    | 1.0.0              | 2.0.0          |
 | Daml.Finance.Interface.Lifecycle           | 1.0.0              | 2.0.0          |
 | Daml.Finance.Interface.Settlement          | 1.0.0              | 2.0.0          |
 | Daml.Finance.Interface.Types.Common        | 1.0.0              | 1.0.1          |
 | Daml.Finance.Interface.Types.Date          | 2.0.0              | 2.0.1          |
-| Daml.Finance.Interface.Util                | 1.0.0              | 1.0.1          |
+| Daml.Finance.Interface.Util                | 1.0.0              | 2.0.0          |
 | Daml.Finance.Lifecycle                     | 1.0.1              | 2.0.0          |
 | Daml.Finance.Settlement                    | 1.0.2              | 2.0.0          |
-| Daml.Finance.Util                          | 2.0.0              | 2.0.1          |
+| Daml.Finance.Util                          | 2.0.0              | 3.0.0          |
 
 ## Early Access Packages
 
 | Package                                             | Released version   | Target version |
 |-----------------------------------------------------|--------------------|----------------|
 | ContingentClaims.Valuation                          | 0.2.0              | 0.2.1          |
-| Daml.Finance.Instrument.Bond                        | 0.2.1              | 0.3.0          |
 | Daml.Finance.Instrument.Equity                      | 0.2.1              | 0.3.0          |
 | Daml.Finance.Instrument.Option                      | 0.1.0              | 0.2.0          |
 | Daml.Finance.Instrument.StructuredProduct           |                    | 0.1.0          |
 | Daml.Finance.Instrument.Swap                        | 0.2.1              | 0.3.0          |
-| Daml.Finance.Interface.Instrument.Bond              | 0.2.1              | 0.3.0          |
 | Daml.Finance.Interface.Instrument.Equity            | 0.2.0              | 0.3.0          |
 | Daml.Finance.Interface.Instrument.Option            | 0.1.0              | 0.2.0          |
 | Daml.Finance.Interface.Instrument.StructuredProduct |                    | 0.1.0          |
@@ -50,87 +50,28 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 ### ContingentClaims.Core
 
-- Dependencies update
-
-- Style changes
-
-- Add smart constructors: orList & andList
-
-- Add `ObserveAt` observation builder
-
 ### ContingentClaims.Lifecycle
-
-- Dependencies update
-
-- Style changes
 
 ### ContingentClaims.Valuation
 
-- Dependencies update
-
-- Style changes
-
 ### Daml.Finance.Account
+
+- Dependencies update
 
 - Let the `Account` implement the `Lockable` interface with `custodian` as required authorizer (for
   exercising the `Acquire` choice).
 
-- Dependencies update
-
-- Makes use of `requires` to enforce the interface hierarchy (in particular the `asDisclosure`
-  implementation was removed as well as redundant `HasImplementation` instances)
-
-- Uses `ensure` to ensure that the set of outgoing controllers is non-empty.
-
-- Adds a check that locked holdings can't be debited.
-
 ### Daml.Finance.Claims
-
-- Dependencies update
-
-- Style changes
-
-- Add support for hybrid (election & time-based) instruments
-
-- Create version consisting of more than hash of remaining claims: it now includes
-  `lastEventTimestamp` as well.
-
-- Create instruments even if they have a Zero claim
 
 ### Daml.Finance.Data
 
-- Unecessary `Remove` choice (implementations) were removed.
-
-- Dependencies update
-
-- Style changes
-
-- Makes use of `requires` to enforce the interface hierarchy (in particular the `asDisclosure`,
-  `asNumericObservable`, `asTimeObservable`, and `asEvent` implementations were removed as well as
-  redundant `HasImplementation` instances)
-
-- Removed `key` from `DateClock`.
-
 ### Daml.Finance.Holding
 
-- Unecessary `Remove` choice (implementations) were removed.
+- Dependencies update
 
 - As the locking logic from the `Holding.Base` interface was factored out to a separate interface
   called `Lockable` of the `Daml.Finance.Interface.Util` package, the `acquireImpl` and
   `releaseImpl` moved to the `Lockable` module in the `Daml.Finance.Util` implementation package.
-
-- Dependencies update
-
-- Added default `splitImpl` and `mergeImpl` for `Fungible` to `Util.daml` (also generalized the
-  `acquireImpl` and `releaseImpl` to not rely on an attribute called "lock")
-
-- Makes use of `requires` to enforce the interface hierarchy (in particular the `asDisclosure`,
-  `asBase`, and `asTransferable` implementations were removed as well as redundant
-  `HasImplementation` instances)
-
-- Added the new owner as observer of the `Transfer` choice of the `Transferable` interface.
-
-- Fix for locking (don't allow an empty `lockers` set).
 
 - Prohibits the `Transfer`, `Split`, `Merge`, and `Debit` actions on holdings that are in a locked
   state, requiring them to be unlocked first. Adjustments have been made in the corresponding
@@ -140,292 +81,64 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 ### Daml.Finance.Instrument.Bond
 
-- The factory create choices return the corresponding interface (instead of the base interface).
-
-- Dependencies update
-
-- Style changes
-
-- Makes use of `requires` to enforce the interface hierarchy (in particular the `asDisclosure` and
-  `asBaseInstrument` implementations were removed as well as redundant `HasImplementation`
-  instances)
-
-- Add callable bond instrument
-
-- Make notional configurable on the instrument
-
 ### Daml.Finance.Instrument.Equity
-
-- The factory create choices return the corresponding interface (instead of the base interface).
-
-- Dependencies update
-
-- Makes use of `requires` to enforce the interface hierarchy (in particular the `asDisclosure` and
-  `asBaseInstrument` implementations were removed as well as redundant `HasImplementation`
-  instances)
-
-- Rename `DeclareDividend` to `DeclareDistribution`
 
 ### Daml.Finance.Instrument.Generic
 
-- The factory create choices return the corresponding interface (instead of the base interface).
-
-- Dependencies update
-
-- Style changes
-
-- Move Election logic from Generic to Lifecycle (to facilitate code reuse)
-
-- Makes use of `requires` to enforce the interface hierarchy (in particular the `asDisclosure`,
-  `asBaseInstrument`, and `asClaim` implementations were removed as well as redundant
-  `HasImplementation` instances)
-
-- During lifeycling: create a new instrument also in case of a Zero claim (breaking change).
-
 ### Daml.Finance.Instrument.Option
-
-- The factory create choices return the corresponding interface (instead of the base interface).
-
-- Dependencies update
-
-- Style changes
-
-- Add physically settled European options (EuropeanPhysical)
-
-- Renamed cash-settled European options (European -> EuropeanCash)
-
-- Add dividend options
-
-- Makes use of `requires` to enforce the interface hierarchy (in particular the `asDisclosure` and
-  `asBaseInstrument` implementations were removed as well as redundant `HasImplementation`
-  instances)
-
-- Add barrier options
 
 ### Daml.Finance.Instrument.StructuredProduct
 
-- The factory create choices return the corresponding interface (instead of the base interface).
-
-- Add Barrier Reverse Convertible instrument
-
 ### Daml.Finance.Instrument.Swap
-
-- The factory create choices return the corresponding interface (instead of the base interface).
-
-- Dependencies update
-
-- Style changes
-
-- Makes use of `requires` to enforce the interface hierarchy (in particular the `asDisclosure` and
-  `asBaseInstrument` implementations were removed as well as redundant `HasImplementation`
-  instances)
-
-- Refactor using `ObserveAt`
 
 ### Daml.Finance.Instrument.Token
 
-- The factory create choices return the corresponding interface (instead of the base interface).
+### Daml.Finance.Interface.Account
 
 - Dependencies update
-
-- Makes use of `requires` to enforce the interface hierarchy (in the particular `asDisclosure` and
-  `asBaseInstrument` implementations were removed as well as redundant `HasImplementation`
-  instances)
-
-### Daml.Finance.Interface.Account
 
 - Let the `Account` require the `Lockable` interface, effectively allowing to freeze an account.
 
-- Dependencies update
-
-- Removed `type K = AccountKey`
-
-- Makes use of `requires` to enforce the interface hierarchy (in particular the `asDisclosure`
-  method was removed as well as the redundant `HasImplementation` type class)
-
 ### Daml.Finance.Interface.Claims
-
-- Dependencies update
-
-- Makes use of `requires` to enforce the interface hierarchy (in particular the `asBaseInstrument`
-  method was removed as well as the redundant `HasImplementation` type class)
 
 ### Daml.Finance.Interface.Data
 
-- Unecessary `Remove` choices were removed from factories.
-
-- Dependencies update
-
-- Style changes
-
-- Makes use of `requires` to enforce the interface hierarchy (in particular the `asDisclosure`,
-  `asNumericObservable`, and `asTimeObservable` methods were removed as well as the redundant
-  `HasImplementation` type class)
-
 ### Daml.Finance.Interface.Holding
-
-- Unecessary `Remove` choices were removed from factories.
-
-- Removed unnecessary `ArchiveFungible` choice
 
 - Factored out the locking logic from the `Holding.Base` interface to a separate interface called
   `Lockable` of the `Daml.Finance.Interface.Util` package.
 
-- Dependencies update
-
-- Style changes
-
-- Makes use of `requires` to enforce the interface hierarchy (in particular the `asDisclosure`,
-  `asBase`, and `asTransferable` methods were removed as well as the redundant `HasImplementation`
-  type class)
-
-- Fix to signature of `disclose` (removed the `actor` argument).
-
-- The `lockers` have been removed as controllers of the `Transfer`, `Split`, and `Merge` choices.
-  Any `Holding` in a locked state must first be unlocked before any modifications can be made to it.
-
 ### Daml.Finance.Interface.Instrument.Base
-
-- Dependencies update
-
-- Style changes
-
-- Removed `type K = InstrumentKey`
-
-- Makes use of `requires` to enforce the interface hierarchy (in particular the `asDisclosure`
-  method was removed as well as the redundant `HasImplementation` type class)
 
 ### Daml.Finance.Interface.Instrument.Bond
 
-- The factory create choices return the corresponding interface (instead of the base interface).
-
-- Dependencies update
-
-- Added `GetView` to all instruments
-
-- Makes use of `requires` to enforce the interface hierarchy (in particular the `asDisclosure` and
-  `asBaseInstrument` methods were removed as well as the redundant `HasImplementation` type
-  classes)
-
-- Add callable bond instrument
-
-- Make notional configurable on the instrument
-
 ### Daml.Finance.Interface.Instrument.Equity
-
-- The factory create choices return the corresponding interface (instead of the base interface).
-
-- Dependencies update
-
-- Makes use of `requires` to enforce the interface hierarchy (in particular the `asDisclosure` and
-  `asBaseInstrument` methods were removed as well as the redundant `HasImplementation` type class)
-
-- Rename `DeclareDividend` to `DeclareDistribution`
 
 ### Daml.Finance.Interface.Instrument.Generic
 
-- The factory create choices return the corresponding interface (instead of the base interface).
-
-- Dependencies update
-
-- Move Election logic from Generic to Lifecycle (to facilitate code reuse)
-
-- Makes use of `requires` to enforce the interface hierarchy (in particular the `asDisclosure`,
-  `asBaseInstrument`, and `asClaim` methods were removed as well as the redundant
-  `HasImplementation` type class)
-
 ### Daml.Finance.Interface.Instrument.Option
-
-- The factory create choices return the corresponding interface (instead of the base interface).
-
-- Dependencies update
-
-- Add physically settled European options (EuropeanPhysical)
-
-- Renamed cash-settled European options (European -> EuropeanCash)
-
-- Added `GetView` to all instruments
-
-- Add dividend options
-
-- Makes use of `requires` to enforce the interface hierarchy (in particular the `asDisclosure`,
-  `asBaseInstrument`, and `asEvent` methods were removed as well as the redundant
-  `HasImplementation` type class)
-
-- Add barrier options
 
 ### Daml.Finance.Interface.Instrument.StructuredProduct
 
-- The factory create choices return the corresponding interface (instead of the base interface).
-
-- Add Barrier Reverse Convertible instrument
-
 ### Daml.Finance.Interface.Instrument.Swap
 
-- The factory create choices return the corresponding interface (instead of the base interface).
-
-- Dependencies update
-
-- Style changes
-
-- Added `GetView` to all instruments
-
-- Makes use of `requires` to enforce the interface hierarchy (in particular the `asDisclosure` and
-  `asBaseInstrument` methods were removed as well as the redundant `HasImplementation` type class)
-
 ### Daml.Finance.Interface.Instrument.Token
-
-- The factory create choices return the corresponding interface (instead of the base interface).
-
-- Dependencies update
-
-- Makes use of `requires` to enforce the interface hierarchy (in particular the `asDisclosure` and
-  `asBaseInstrument` methods were removed as well as the redundant `HasImplementation` type class)
 
 ### Daml.Finance.Interface.Lifecycle
 
 - Changed the `Calculate` choice of the `Effect.I` to take a quantity as argument instead of a
   `ContractId Holding` (in order to not leak information about the holding to the effect provider).
 
-- Unecessary (as of SDK 2.6) `Remove` choices were removed from factories.
-
-- Dependencies update
-
-- Style changes
-
-- Move Election logic from Generic to Lifecycle (to facilitate code reuse)
-
-- Makes use of `requires` to enforce the interface hierarchy (in particular the `asDisclosure` and
-  `asEvent` methods were removed as well as the redundant `HasImplementation` type class)
-
 ### Daml.Finance.Interface.Settlement
-
-- Dependencies update
-
-- Style changes
-
-- Makes use of `requires` to enforce the interface hierarchy (in particular the `asDisclosure` was
-  removed as well as the redundant `HasImplementation` type class)
 
 ### Daml.Finance.Interface.Types.Common
 
-- Dependencies update
-
 ### Daml.Finance.Interface.Types.Date
-
-- Dependencies update
 
 ### Daml.Finance.Interface.Util
 
-- Removed `mapWithIndex` as it only was used once, and applied the index in a reverse order.
-
 - Added a `Lockable` module containing the interface for locking (the `Acquire` and `Release`
   choices used to be part of the `Holding.Base` interface).
-
-- Dependencies update
-
-- Makes use of `requires` to enforce the interface hierarchy (in particular the redundant
-  `HasImplementation` type class was removed)
 
 ### Daml.Finance.Lifecycle
 
@@ -433,63 +146,9 @@ This document tracks pending changes to packages. It is facilitating the write-u
   to reflect the change in the `Effect.I` interface. The implementation of the `ClaimEffect` choice
   body of `Daml.Finance.Lifecycle.Rule.Claim` also changed accordingly.
 
-- Unecessary `Remove` choice (implementations) were removed.
-
-- Dependencies update
-
-- Style changes
-
-- Move Election logic from Generic to Lifecycle (to facilitate code reuse)
-
-- Makes use of `requires` to enforce the interface hierarchy (in particular the `asDisclosure` and
-  `asEvent` implementations were removed as well as redundant `HasImplementation` instances)
-
-- Let `Election` and `ElectionEffect` implement the `Disclosure` interface.
-
-- Add check that instruments exist for `Distribution` and `Replacement`
-
 ### Daml.Finance.Settlement
-
-- In the `Batch`, the order of the `settledCids` were changed to match the initial order of the
-  instructions in the batch.
-
-- In the settlement `Factory`, the id values used for the `Instruction`s were modified to accurately
-  reflect their order within the `Batch`.
-
-- Fix for `Instruction` and `IntermediatedStatic`, replaced `groupOn` by `sortAndGroupOn`.
-
-- Dependencies update
-
-- Style changes
-
-- Added locking to the `Instruction` (pledge is locked to requestors and the outgoing controllers of
-  the sending account)
-
-- Makes use of `requires` to enforce the interface hierarchy (in particular the `asDisclosure`
-  implementation was removed as well as redundant `HasImplementation` instances)
-
-- When an `Allocation` (`Approval`) takes place, a check has been added to ensure that either the
-  `sender` or the `custodian` (`receiver` or the `custodian`) is among the authorizers.
-
-- When reallocation (re-approval) occurs, it is required that the `signedSenders`
-  (`signedReceivers`) of the `Instruction` are part of the authorizing set.
-
-- We have improved the pass-through allocation/approval process by adding additional checks. These
-  checks detect settlement failures during the allocation/approval stage, rather than waiting until
-  settlement occurs. Specifically, we now verify that the specified pass-through `Instruction` is
-  actually part of the `Batch`.
-
-- Removed the `key` from the `Batch` implementation.
 
 ### Daml.Finance.Util
 
-- Added test for `sortAndGroupOn`.
-
-- Removed the custom `groupBy` as it was not being used anywhere.
-
 - Added a `Lockable` module containing the `aquireImpl` and `releaseImpl` locking utitlity
   functions.
-
-- Dependencies update
-
-- Style changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,45 +6,45 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 | Package                                    | Released version   | Target version |
 |--------------------------------------------|--------------------|----------------|
-| ContingentClaims.Core                      | 1.0.0              | 2.0.0          |
-| ContingentClaims.Lifecycle                 | 1.0.0              | 2.0.0          |
-| Daml.Finance.Account                       | 1.0.1              | 2.0.0          |
-| Daml.Finance.Claims                        | 1.0.1              | 2.0.0          |
-| Daml.Finance.Data                          | 1.0.1              | 2.0.0          |
-| Daml.Finance.Holding                       | 1.0.2              | 2.0.0          |
-| Daml.Finance.Instrument.Bond               | 0.2.1              | 1.0.0          |
-| Daml.Finance.Instrument.Generic            | 1.0.1              | 2.0.0          |
-| Daml.Finance.Instrument.Token              | 1.0.1              | 2.0.0          |
-| Daml.Finance.Interface.Account             | 1.0.0              | 2.0.0          |
-| Daml.Finance.Interface.Claims              | 1.0.0              | 2.0.0          |
-| Daml.Finance.Interface.Data                | 2.0.0              | 3.0.0          |
-| Daml.Finance.Interface.Holding             | 1.0.0              | 2.0.0          |
-| Daml.Finance.Interface.Instrument.Base     | 1.0.0              | 2.0.0          |
-| Daml.Finance.Interface.Instrument.Bond     | 0.2.1              | 1.0.0          |
-| Daml.Finance.Interface.Instrument.Generic  | 1.0.0              | 2.0.0          |
-| Daml.Finance.Interface.Instrument.Token    | 1.0.0              | 2.0.0          |
-| Daml.Finance.Interface.Lifecycle           | 1.0.0              | 2.0.0          |
-| Daml.Finance.Interface.Settlement          | 1.0.0              | 2.0.0          |
-| Daml.Finance.Interface.Types.Common        | 1.0.0              | 1.0.1          |
-| Daml.Finance.Interface.Types.Date          | 2.0.0              | 2.0.1          |
-| Daml.Finance.Interface.Util                | 1.0.0              | 2.0.0          |
-| Daml.Finance.Lifecycle                     | 1.0.1              | 2.0.0          |
-| Daml.Finance.Settlement                    | 1.0.2              | 2.0.0          |
-| Daml.Finance.Util                          | 2.0.0              | 3.0.0          |
+| ContingentClaims.Core                      | 2.0.0              | 2.0.0          |
+| ContingentClaims.Lifecycle                 | 2.0.0              | 2.0.0          |
+| Daml.Finance.Account                       | 2.0.0              | 2.0.0          |
+| Daml.Finance.Claims                        | 2.0.0              | 2.0.0          |
+| Daml.Finance.Data                          | 2.0.0              | 2.0.0          |
+| Daml.Finance.Holding                       | 2.0.0              | 2.0.0          |
+| Daml.Finance.Instrument.Bond               | 1.0.0              | 1.0.0          |
+| Daml.Finance.Instrument.Generic            | 2.0.0              | 2.0.0          |
+| Daml.Finance.Instrument.Token              | 2.0.0              | 2.0.0          |
+| Daml.Finance.Interface.Account             | 2.0.0              | 2.0.0          |
+| Daml.Finance.Interface.Claims              | 2.0.0              | 2.0.0          |
+| Daml.Finance.Interface.Data                | 3.0.0              | 3.0.0          |
+| Daml.Finance.Interface.Holding             | 2.0.0              | 2.0.0          |
+| Daml.Finance.Interface.Instrument.Base     | 2.0.0              | 2.0.0          |
+| Daml.Finance.Interface.Instrument.Bond     | 1.0.0              | 1.0.0          |
+| Daml.Finance.Interface.Instrument.Generic  | 2.0.0              | 2.0.0          |
+| Daml.Finance.Interface.Instrument.Token    | 2.0.0              | 2.0.0          |
+| Daml.Finance.Interface.Lifecycle           | 2.0.0              | 2.0.0          |
+| Daml.Finance.Interface.Settlement          | 2.0.0              | 2.0.0          |
+| Daml.Finance.Interface.Types.Common        | 1.0.1              | 1.0.1          |
+| Daml.Finance.Interface.Types.Date          | 2.0.1              | 2.0.1          |
+| Daml.Finance.Interface.Util                | 2.0.0              | 2.0.0          |
+| Daml.Finance.Lifecycle                     | 2.0.0              | 2.0.0          |
+| Daml.Finance.Settlement                    | 2.0.0              | 2.0.0          |
+| Daml.Finance.Util                          | 3.0.0              | 3.0.0          |
 
 ## Early Access Packages
 
 | Package                                             | Released version   | Target version |
 |-----------------------------------------------------|--------------------|----------------|
-| ContingentClaims.Valuation                          | 0.2.0              | 0.2.1          |
-| Daml.Finance.Instrument.Equity                      | 0.2.1              | 0.3.0          |
-| Daml.Finance.Instrument.Option                      | 0.1.0              | 0.2.0          |
+| ContingentClaims.Valuation                          | 0.2.1              | 0.2.1          |
+| Daml.Finance.Instrument.Equity                      | 0.3.0              | 0.3.0          |
+| Daml.Finance.Instrument.Option                      | 0.2.0              | 0.2.0          |
 | Daml.Finance.Instrument.StructuredProduct           |                    | 0.1.0          |
-| Daml.Finance.Instrument.Swap                        | 0.2.1              | 0.3.0          |
-| Daml.Finance.Interface.Instrument.Equity            | 0.2.0              | 0.3.0          |
-| Daml.Finance.Interface.Instrument.Option            | 0.1.0              | 0.2.0          |
+| Daml.Finance.Instrument.Swap                        | 0.3.0              | 0.3.0          |
+| Daml.Finance.Interface.Instrument.Equity            | 0.3.0              | 0.3.0          |
+| Daml.Finance.Interface.Instrument.Option            | 0.2.0              | 0.2.0          |
 | Daml.Finance.Interface.Instrument.StructuredProduct |                    | 0.1.0          |
-| Daml.Finance.Interface.Instrument.Swap              | 0.2.1              | 0.3.0          |
+| Daml.Finance.Interface.Instrument.Swap              | 0.3.0              | 0.3.0          |
 
 ## Pending changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,45 +6,45 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 | Package                                    | Released version   | Target version |
 |--------------------------------------------|--------------------|----------------|
-| ContingentClaims.Core                      | 2.0.0              | 2.0.0          |
-| ContingentClaims.Lifecycle                 | 2.0.0              | 2.0.0          |
-| Daml.Finance.Account                       | 2.0.0              | 2.0.0          |
-| Daml.Finance.Claims                        | 2.0.0              | 2.0.0          |
-| Daml.Finance.Data                          | 2.0.0              | 2.0.0          |
-| Daml.Finance.Holding                       | 2.0.0              | 2.0.0          |
-| Daml.Finance.Instrument.Bond               | 1.0.0              | 1.0.0          |
-| Daml.Finance.Instrument.Generic            | 2.0.0              | 2.0.0          |
-| Daml.Finance.Instrument.Token              | 2.0.0              | 2.0.0          |
-| Daml.Finance.Interface.Account             | 2.0.0              | 2.0.0          |
-| Daml.Finance.Interface.Claims              | 2.0.0              | 2.0.0          |
-| Daml.Finance.Interface.Data                | 3.0.0              | 3.0.0          |
-| Daml.Finance.Interface.Holding             | 2.0.0              | 2.0.0          |
-| Daml.Finance.Interface.Instrument.Base     | 2.0.0              | 2.0.0          |
-| Daml.Finance.Interface.Instrument.Bond     | 1.0.0              | 1.0.0          |
-| Daml.Finance.Interface.Instrument.Generic  | 2.0.0              | 2.0.0          |
-| Daml.Finance.Interface.Instrument.Token    | 2.0.0              | 2.0.0          |
-| Daml.Finance.Interface.Lifecycle           | 2.0.0              | 2.0.0          |
-| Daml.Finance.Interface.Settlement          | 2.0.0              | 2.0.0          |
-| Daml.Finance.Interface.Types.Common        | 1.0.1              | 1.0.1          |
-| Daml.Finance.Interface.Types.Date          | 2.0.1              | 2.0.1          |
-| Daml.Finance.Interface.Util                | 2.0.0              | 2.0.0          |
-| Daml.Finance.Lifecycle                     | 2.0.0              | 2.0.0          |
-| Daml.Finance.Settlement                    | 2.0.0              | 2.0.0          |
-| Daml.Finance.Util                          | 3.0.0              | 3.0.0          |
+| ContingentClaims.Core                      | 2.0.0              | TBD            |
+| ContingentClaims.Lifecycle                 | 2.0.0              | TBD            |
+| Daml.Finance.Account                       | 2.0.0              | TBD            |
+| Daml.Finance.Claims                        | 2.0.0              | TBD            |
+| Daml.Finance.Data                          | 2.0.0              | TBD            |
+| Daml.Finance.Holding                       | 2.0.0              | TBD            |
+| Daml.Finance.Instrument.Bond               | 1.0.0              | TBD            |
+| Daml.Finance.Instrument.Generic            | 2.0.0              | TBD            |
+| Daml.Finance.Instrument.Token              | 2.0.0              | TBD            |
+| Daml.Finance.Interface.Account             | 2.0.0              | TBD            |
+| Daml.Finance.Interface.Claims              | 2.0.0              | TBD            |
+| Daml.Finance.Interface.Data                | 3.0.0              | TBD            |
+| Daml.Finance.Interface.Holding             | 2.0.0              | TBD            |
+| Daml.Finance.Interface.Instrument.Base     | 2.0.0              | TBD            |
+| Daml.Finance.Interface.Instrument.Bond     | 1.0.0              | TBD            |
+| Daml.Finance.Interface.Instrument.Generic  | 2.0.0              | TBD            |
+| Daml.Finance.Interface.Instrument.Token    | 2.0.0              | TBD            |
+| Daml.Finance.Interface.Lifecycle           | 2.0.0              | TBD            |
+| Daml.Finance.Interface.Settlement          | 2.0.0              | TBD            |
+| Daml.Finance.Interface.Types.Common        | 1.0.1              | TBD            |
+| Daml.Finance.Interface.Types.Date          | 2.0.1              | TBD            |
+| Daml.Finance.Interface.Util                | 2.0.0              | TBD            |
+| Daml.Finance.Lifecycle                     | 2.0.0              | TBD            |
+| Daml.Finance.Settlement                    | 2.0.0              | TBD            |
+| Daml.Finance.Util                          | 3.0.0              | TBD            |
 
 ## Early Access Packages
 
 | Package                                             | Released version   | Target version |
 |-----------------------------------------------------|--------------------|----------------|
-| ContingentClaims.Valuation                          | 0.2.1              | 0.2.1          |
-| Daml.Finance.Instrument.Equity                      | 0.3.0              | 0.3.0          |
-| Daml.Finance.Instrument.Option                      | 0.2.0              | 0.2.0          |
-| Daml.Finance.Instrument.StructuredProduct           |                    | 0.1.0          |
-| Daml.Finance.Instrument.Swap                        | 0.3.0              | 0.3.0          |
-| Daml.Finance.Interface.Instrument.Equity            | 0.3.0              | 0.3.0          |
-| Daml.Finance.Interface.Instrument.Option            | 0.2.0              | 0.2.0          |
-| Daml.Finance.Interface.Instrument.StructuredProduct |                    | 0.1.0          |
-| Daml.Finance.Interface.Instrument.Swap              | 0.3.0              | 0.3.0          |
+| ContingentClaims.Valuation                          | 0.2.1              | TBD            |
+| Daml.Finance.Instrument.Equity                      | 0.3.0              | TBD            |
+| Daml.Finance.Instrument.Option                      | 0.2.0              | TBD            |
+| Daml.Finance.Instrument.StructuredProduct           |                    | TBD            |
+| Daml.Finance.Instrument.Swap                        | 0.3.0              | TBD            |
+| Daml.Finance.Interface.Instrument.Equity            | 0.3.0              | TBD            |
+| Daml.Finance.Interface.Instrument.Option            | 0.2.0              | TBD            |
+| Daml.Finance.Interface.Instrument.StructuredProduct |                    | TBD            |
+| Daml.Finance.Interface.Instrument.Swap              | 0.3.0              | TBD            |
 
 ## Pending changes
 
@@ -63,7 +63,11 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 ### Daml.Finance.Claims
 
+- Dependencies update
+
 ### Daml.Finance.Data
+
+- Dependencies update
 
 ### Daml.Finance.Holding
 
@@ -81,17 +85,31 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 ### Daml.Finance.Instrument.Bond
 
+- Dependencies update
+
 ### Daml.Finance.Instrument.Equity
+
+- Dependencies update
 
 ### Daml.Finance.Instrument.Generic
 
+- Dependencies update
+
 ### Daml.Finance.Instrument.Option
+
+- Dependencies update
 
 ### Daml.Finance.Instrument.StructuredProduct
 
+- First Release
+
 ### Daml.Finance.Instrument.Swap
 
+- Dependencies update
+
 ### Daml.Finance.Instrument.Token
+
+- Dependencies update
 
 ### Daml.Finance.Interface.Account
 
@@ -101,28 +119,50 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 ### Daml.Finance.Interface.Claims
 
+- Dependencies update
+
 ### Daml.Finance.Interface.Data
 
+- Dependencies update
+
 ### Daml.Finance.Interface.Holding
+
+- Dependencies update
 
 - Factored out the locking logic from the `Holding.Base` interface to a separate interface called
   `Lockable` of the `Daml.Finance.Interface.Util` package.
 
 ### Daml.Finance.Interface.Instrument.Base
 
+- Dependencies update
+
 ### Daml.Finance.Interface.Instrument.Bond
+
+- Dependencies update
 
 ### Daml.Finance.Interface.Instrument.Equity
 
+- Dependencies update
+
 ### Daml.Finance.Interface.Instrument.Generic
+
+- Dependencies update
 
 ### Daml.Finance.Interface.Instrument.Option
 
+- Dependencies update
+
 ### Daml.Finance.Interface.Instrument.StructuredProduct
+
+- First release
 
 ### Daml.Finance.Interface.Instrument.Swap
 
+- Dependencies update
+
 ### Daml.Finance.Interface.Instrument.Token
+
+- Dependencies update
 
 ### Daml.Finance.Interface.Lifecycle
 
@@ -130,6 +170,8 @@ This document tracks pending changes to packages. It is facilitating the write-u
   `ContractId Holding` (in order to not leak information about the holding to the effect provider).
 
 ### Daml.Finance.Interface.Settlement
+
+- Dependencies update
 
 ### Daml.Finance.Interface.Types.Common
 
@@ -142,11 +184,15 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 ### Daml.Finance.Lifecycle
 
+- Dependencies update
+
 - The `Calculate` choice of the `Effect` and `ElectionEffect` now takes a quantity as argument
   to reflect the change in the `Effect.I` interface. The implementation of the `ClaimEffect` choice
   body of `Daml.Finance.Lifecycle.Rule.Claim` also changed accordingly.
 
 ### Daml.Finance.Settlement
+
+- Dependencies update
 
 ### Daml.Finance.Util
 

--- a/daml.yaml
+++ b/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.7.0
 name: daml-finance
 source: src/test/daml
-version: 1.2.17
+version: 1.3.0
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/daml.yaml
+++ b/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance
 source: src/test/daml
 version: 1.2.17

--- a/docs/code-samples/getting-started/daml.yaml
+++ b/docs/code-samples/getting-started/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: quickstart-finance
 source: daml
 init-script: Scripts.Transfer:runTransfer

--- a/docs/code-samples/lifecycling/daml.yaml
+++ b/docs/code-samples/lifecycling/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: finance-lifecycling
 source: daml
 init-script: Scripts.FixedRateBond:runFixedRateBond

--- a/docs/code-samples/payoff-modeling/daml.yaml
+++ b/docs/code-samples/payoff-modeling/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: finance-payoff-modeling
 source: daml
 init-script: PayoffBuilder:runCreateAndLifecycle

--- a/docs/code-samples/settlement/daml.yaml
+++ b/docs/code-samples/settlement/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: finance-settlement
 source: daml
 init-script: Scripts.Transfer:runDualControlTransfer

--- a/package/main/daml/ContingentClaims.Core/daml.yaml
+++ b/package/main/daml/ContingentClaims.Core/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.6.0
 name: contingent-claims-core
 source: daml
-version: 1.0.1
+version: 2.0.0
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/main/daml/ContingentClaims.Core/daml.yaml
+++ b/package/main/daml/ContingentClaims.Core/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: contingent-claims-core
 source: daml
 version: 2.0.0

--- a/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
+++ b/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
@@ -10,5 +10,6 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-ctl/v2.3.0/daml-ctl-2.3.0.dar
-  - .lib/daml-finance/ContingentClaims.Core/1.0.1/contingent-claims-core-1.0.1.dar
+  - .lib/daml-finance/ContingentClaims.Core/2.0.0/contingent-claims-core-2.0.0.dar
+build-options: null
 

--- a/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
+++ b/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: contingent-claims-lifecycle
 source: daml
 version: 2.0.0

--- a/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
+++ b/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.6.0
 name: contingent-claims-lifecycle
 source: daml
-version: 1.0.1
+version: 2.0.0
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/main/daml/ContingentClaims.Valuation/daml.yaml
+++ b/package/main/daml/ContingentClaims.Valuation/daml.yaml
@@ -10,5 +10,6 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-ctl/v2.3.0/daml-ctl-2.3.0.dar
-  - .lib/daml-finance/ContingentClaims.Core/1.0.1/contingent-claims-core-1.0.1.dar
+  - .lib/daml-finance/ContingentClaims.Core/2.0.0/contingent-claims-core-2.0.0.dar
+build-options: null
 

--- a/package/main/daml/ContingentClaims.Valuation/daml.yaml
+++ b/package/main/daml/ContingentClaims.Valuation/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: contingent-claims-valuation
 source: daml
 version: 0.2.1

--- a/package/main/daml/Daml.Finance.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Account/daml.yaml
@@ -4,14 +4,15 @@
 sdk-version: 2.7.0
 name: daml-finance-account
 source: daml
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.0/daml-finance-interface-account-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.0/daml-finance-interface-holding-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.1/daml-finance-interface-account-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.1/daml-finance-interface-holding-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/2.0.1/daml-finance-util-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar
+build-options: null
 

--- a/package/main/daml/Daml.Finance.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Account/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-account
 source: daml
 version: 2.0.0

--- a/package/main/daml/Daml.Finance.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Claims/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.6.0
 name: daml-finance-claims
 source: daml
-version: 1.0.2
+version: 2.0.0
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/main/daml/Daml.Finance.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Claims/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-claims
 source: daml
 version: 2.0.0

--- a/package/main/daml/Daml.Finance.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Claims/daml.yaml
@@ -4,18 +4,20 @@
 sdk-version: 2.7.0
 name: daml-finance-claims
 source: daml
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/ContingentClaims.Core/1.0.1/contingent-claims-core-1.0.1.dar
-  - .lib/daml-finance/ContingentClaims.Lifecycle/1.0.1/contingent-claims-lifecycle-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.0/daml-finance-interface-claims-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.0/daml-finance-interface-instrument-base-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.0/daml-finance-interface-lifecycle-2.0.0.dar
+  - .lib/daml-finance/ContingentClaims.Core/2.0.0/contingent-claims-core-2.0.0.dar
+  - .lib/daml-finance/ContingentClaims.Lifecycle/2.0.0/contingent-claims-lifecycle-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.1/daml-finance-interface-claims-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.1/daml-finance-interface-lifecycle-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.1/daml-finance-interface-types-date-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/2.0.0/daml-finance-lifecycle-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/2.0.1/daml-finance-util-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/2.0.1/daml-finance-lifecycle-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar
+build-options: null
+

--- a/package/main/daml/Daml.Finance.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Data/daml.yaml
@@ -4,16 +4,16 @@
 sdk-version: 2.7.0
 name: daml-finance-data
 source: daml
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Data/3.0.0/daml-finance-interface-data-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.0/daml-finance-interface-lifecycle-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/3.0.1/daml-finance-interface-data-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.1/daml-finance-interface-lifecycle-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.1/daml-finance-interface-types-date-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/2.0.1/daml-finance-util-2.0.1.dar
-
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar
+build-options: null
 

--- a/package/main/daml/Daml.Finance.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Data/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-data
 source: daml
 version: 2.0.0

--- a/package/main/daml/Daml.Finance.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Holding/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-holding
 source: daml
 version: 2.0.0

--- a/package/main/daml/Daml.Finance.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Holding/daml.yaml
@@ -4,15 +4,15 @@
 sdk-version: 2.7.0
 name: daml-finance-holding
 source: daml
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.0/daml-finance-interface-account-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.0/daml-finance-interface-holding-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.1/daml-finance-interface-account-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.1/daml-finance-interface-holding-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/2.0.1/daml-finance-util-2.0.1.dar
-
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar
+build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.6.0
 name: daml-finance-instrument-bond
 source: daml
-version: 0.3.0
+version: 1.0.0
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -4,18 +4,20 @@
 sdk-version: 2.7.0
 name: daml-finance-instrument-bond
 source: daml
-version: 1.0.0
+version: 1.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/ContingentClaims.Core/1.0.1/contingent-claims-core-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Claims/1.0.2/daml-finance-claims-1.0.2.dar
-  - .lib/daml-finance/Daml.Finance.Data/2.0.0/daml-finance-data-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.0/daml-finance-interface-claims-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.0/daml-finance-interface-instrument-base-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/0.3.0/daml-finance-interface-instrument-bond-0.3.0.dar
+  - .lib/daml-finance/ContingentClaims.Core/2.0.0/contingent-claims-core-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Claims/2.0.1/daml-finance-claims-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.1/daml-finance-interface-claims-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/1.0.1/daml-finance-interface-instrument-bond-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.1/daml-finance-interface-types-date-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/2.0.1/daml-finance-util-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar
+build-options: null
+

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-instrument-bond
 source: daml
 version: 1.0.0

--- a/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-instrument-equity
 source: daml
 version: 0.3.0

--- a/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
@@ -4,16 +4,16 @@
 sdk-version: 2.7.0
 name: daml-finance-instrument-equity
 source: daml
-version: 0.3.0
+version: 0.3.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.0/daml-finance-interface-instrument-base-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.3.0/daml-finance-interface-instrument-equity-0.3.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.3.1/daml-finance-interface-instrument-equity-0.3.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/2.0.0/daml-finance-lifecycle-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/2.0.1/daml-finance-util-2.0.1.dar
-
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/2.0.1/daml-finance-lifecycle-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar
+build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-instrument-generic
 source: daml
 version: 2.0.0

--- a/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
@@ -4,19 +4,19 @@
 sdk-version: 2.7.0
 name: daml-finance-instrument-generic
 source: daml
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Claims/1.0.2/daml-finance-claims-1.0.2.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.0/daml-finance-interface-claims-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.0/daml-finance-interface-instrument-base-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/2.0.0/daml-finance-interface-instrument-generic-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.0/daml-finance-interface-lifecycle-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Claims/2.0.1/daml-finance-claims-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.1/daml-finance-interface-claims-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/2.0.1/daml-finance-interface-instrument-generic-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.1/daml-finance-interface-lifecycle-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/2.0.0/daml-finance-lifecycle-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/2.0.1/daml-finance-util-2.0.1.dar
-
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/2.0.1/daml-finance-lifecycle-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar
+build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-instrument-option
 source: daml
 version: 0.2.0

--- a/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
@@ -4,17 +4,19 @@
 sdk-version: 2.7.0
 name: daml-finance-instrument-option
 source: daml
-version: 0.2.0
+version: 0.2.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Claims/1.0.2/daml-finance-claims-1.0.2.dar
-  - .lib/daml-finance/Daml.Finance.Data/2.0.0/daml-finance-data-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.0/daml-finance-interface-claims-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.0/daml-finance-interface-instrument-base-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.2.0/daml-finance-interface-instrument-option-0.2.0.dar
+  - .lib/daml-finance/Daml.Finance.Claims/2.0.1/daml-finance-claims-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.1/daml-finance-interface-claims-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.2.1/daml-finance-interface-instrument-option-0.2.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/2.0.0/daml-finance-lifecycle-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/2.0.1/daml-finance-util-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/2.0.1/daml-finance-lifecycle-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar
+build-options: null
+

--- a/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-instrument-structuredproduct
 source: daml
 version: 0.1.0

--- a/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
@@ -9,15 +9,15 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Claims/1.0.2/daml-finance-claims-1.0.2.dar
-  - .lib/daml-finance/Daml.Finance.Data/2.0.0/daml-finance-data-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.0/daml-finance-interface-claims-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.0/daml-finance-interface-instrument-base-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.2.0/daml-finance-interface-instrument-option-0.2.0.dar
+  - .lib/daml-finance/Daml.Finance.Claims/2.0.1/daml-finance-claims-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.1/daml-finance-interface-claims-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.2.1/daml-finance-interface-instrument-option-0.2.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.StructuredProduct/0.1.0/daml-finance-interface-instrument-structuredproduct-0.1.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.1/daml-finance-interface-types-date-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/2.0.1/daml-finance-util-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-instrument-swap
 source: daml
 version: 0.3.0

--- a/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
@@ -4,18 +4,20 @@
 sdk-version: 2.7.0
 name: daml-finance-instrument-swap
 source: daml
-version: 0.3.0
+version: 0.3.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/ContingentClaims.Core/1.0.1/contingent-claims-core-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Claims/1.0.2/daml-finance-claims-1.0.2.dar
-  - .lib/daml-finance/Daml.Finance.Data/2.0.0/daml-finance-data-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.0/daml-finance-interface-claims-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.0/daml-finance-interface-instrument-base-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.3.0/daml-finance-interface-instrument-swap-0.3.0.dar
+  - .lib/daml-finance/ContingentClaims.Core/2.0.0/contingent-claims-core-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Claims/2.0.1/daml-finance-claims-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.1/daml-finance-interface-claims-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.3.1/daml-finance-interface-instrument-swap-0.3.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.1/daml-finance-interface-types-date-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/2.0.1/daml-finance-util-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar
+build-options: null
+

--- a/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
@@ -4,15 +4,15 @@
 sdk-version: 2.7.0
 name: daml-finance-instrument-token
 source: daml
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.0/daml-finance-interface-instrument-base-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/2.0.0/daml-finance-interface-instrument-token-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/2.0.1/daml-finance-interface-instrument-token-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/2.0.1/daml-finance-util-2.0.1.dar
-
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar
+build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-instrument-token
 source: daml
 version: 2.0.0

--- a/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-interface-account
 source: daml
 version: 2.0.0

--- a/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
@@ -4,13 +4,13 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-account
 source: daml
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.0/daml-finance-interface-holding-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.1/daml-finance-interface-holding-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-interface-claims
 source: daml
 version: 2.0.0

--- a/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
@@ -4,14 +4,14 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-claims
 source: daml
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/ContingentClaims.Core/1.0.1/contingent-claims-core-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.0/daml-finance-interface-instrument-base-2.0.0.dar
+  - .lib/daml-finance/ContingentClaims.Core/2.0.0/contingent-claims-core-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-interface-data
 source: daml
 version: 3.0.0

--- a/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
@@ -4,14 +4,14 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-data
 source: daml
-version: 3.0.0
+version: 3.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.0/daml-finance-interface-lifecycle-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.1/daml-finance-interface-lifecycle-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.1/daml-finance-interface-types-date-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-interface-holding
 source: daml
 version: 2.0.0

--- a/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
@@ -4,12 +4,12 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-holding
 source: daml
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
@@ -4,13 +4,13 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-instrument-base
 source: daml
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.0/daml-finance-interface-holding-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.1/daml-finance-interface-holding-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-interface-instrument-base
 source: daml
 version: 2.0.0

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.6.0
 name: daml-finance-interface-instrument-bond
 source: daml
-version: 0.3.0
+version: 1.0.0
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-interface-instrument-bond
 source: daml
 version: 1.0.0

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
@@ -4,15 +4,15 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-instrument-bond
 source: daml
-version: 1.0.0
+version: 1.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.0/daml-finance-interface-claims-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.0/daml-finance-interface-instrument-base-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.1/daml-finance-interface-claims-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.1/daml-finance-interface-types-date-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
@@ -4,14 +4,14 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-instrument-equity
 source: daml
-version: 0.3.0
+version: 0.3.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.0/daml-finance-interface-instrument-base-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.0/daml-finance-interface-lifecycle-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.1/daml-finance-interface-lifecycle-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-interface-instrument-equity
 source: daml
 version: 0.3.0

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
@@ -4,14 +4,14 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-instrument-generic
 source: daml
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.0/daml-finance-interface-claims-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.0/daml-finance-interface-instrument-base-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.1/daml-finance-interface-claims-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-interface-instrument-generic
 source: daml
 version: 2.0.0

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-interface-instrument-option
 source: daml
 version: 0.2.0

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
@@ -4,13 +4,15 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-instrument-option
 source: daml
-version: 0.2.0
+version: 0.2.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.0/daml-finance-interface-claims-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.0/daml-finance-interface-instrument-base-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.0/daml-finance-interface-lifecycle-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.1/daml-finance-interface-claims-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.1/daml-finance-interface-lifecycle-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+build-options: null
+

--- a/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
@@ -9,10 +9,10 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.0/daml-finance-interface-claims-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.0/daml-finance-interface-instrument-base-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.1/daml-finance-interface-claims-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.1/daml-finance-interface-types-date-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-interface-instrument-structuredproduct
 source: daml
 version: 0.1.0

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
@@ -4,14 +4,14 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-instrument-swap
 source: daml
-version: 0.3.0
+version: 0.3.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.0/daml-finance-interface-instrument-base-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.1/daml-finance-interface-types-date-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-interface-instrument-swap
 source: daml
 version: 0.3.0

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
@@ -4,13 +4,13 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-instrument-token
 source: daml
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.0/daml-finance-interface-instrument-base-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-interface-instrument-token
 source: daml
 version: 2.0.0

--- a/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
@@ -4,14 +4,14 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-lifecycle
 source: daml
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.0/daml-finance-interface-holding-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.0/daml-finance-interface-settlement-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.1/daml-finance-interface-holding-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.1/daml-finance-interface-settlement-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-interface-lifecycle
 source: daml
 version: 2.0.0

--- a/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-interface-settlement
 source: daml
 version: 2.0.0

--- a/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
@@ -4,13 +4,13 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-settlement
 source: daml
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.0/daml-finance-interface-holding-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.1/daml-finance-interface-holding-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-interface-types-common
 source: daml
 version: 1.0.1

--- a/package/main/daml/Daml.Finance.Interface.Types.Date/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Date/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-interface-types-date
 source: daml
 version: 2.0.1

--- a/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
@@ -4,11 +4,11 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-util
 source: daml
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-
+build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.6.0
 name: daml-finance-interface-util
 source: daml
-version: 1.0.1
+version: 2.0.0
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-interface-util
 source: daml
 version: 2.0.0

--- a/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-lifecycle
 source: daml
 version: 2.0.0

--- a/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
@@ -4,16 +4,18 @@
 sdk-version: 2.7.0
 name: daml-finance-lifecycle
 source: daml
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.0/daml-finance-interface-account-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.0/daml-finance-interface-holding-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.0/daml-finance-interface-instrument-base-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.0/daml-finance-interface-lifecycle-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.0/daml-finance-interface-settlement-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.1/daml-finance-interface-account-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.1/daml-finance-interface-holding-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.1/daml-finance-interface-lifecycle-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.1/daml-finance-interface-settlement-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/2.0.1/daml-finance-util-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar
+build-options: null
+

--- a/package/main/daml/Daml.Finance.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Settlement/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-settlement
 source: daml
 version: 2.0.0

--- a/package/main/daml/Daml.Finance.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Settlement/daml.yaml
@@ -4,16 +4,16 @@
 sdk-version: 2.7.0
 name: daml-finance-settlement
 source: daml
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.0/daml-finance-interface-account-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.0/daml-finance-interface-holding-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.0/daml-finance-interface-settlement-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.1/daml-finance-interface-account-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.1/daml-finance-interface-holding-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.1/daml-finance-interface-settlement-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/2.0.1/daml-finance-util-2.0.1.dar
-
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar
+build-options: null
 

--- a/package/main/daml/Daml.Finance.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Util/daml.yaml
@@ -4,13 +4,13 @@
 sdk-version: 2.7.0
 name: daml-finance-util
 source: daml
-version: 3.0.0
+version: 3.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.1/daml-finance-interface-types-date-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+build-options: null
 

--- a/package/main/daml/Daml.Finance.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Util/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.6.0
 name: daml-finance-util
 source: daml
-version: 2.0.1
+version: 3.0.0
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/main/daml/Daml.Finance.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-util
 source: daml
 version: 3.0.0

--- a/package/test/daml/ContingentClaims.Test/daml.yaml
+++ b/package/test/daml/ContingentClaims.Test/daml.yaml
@@ -11,8 +11,8 @@ dependencies:
   - daml-script
 data-dependencies:
   - .lib/daml-ctl/v2.3.0/daml-ctl-2.3.0.dar
-  - .lib/daml-finance/ContingentClaims.Core/1.0.1/contingent-claims-core-1.0.1.dar
-  - .lib/daml-finance/ContingentClaims.Lifecycle/1.0.1/contingent-claims-lifecycle-1.0.1.dar
+  - .lib/daml-finance/ContingentClaims.Core/2.0.0/contingent-claims-core-2.0.0.dar
+  - .lib/daml-finance/ContingentClaims.Lifecycle/2.0.0/contingent-claims-lifecycle-2.0.0.dar
   - .lib/daml-finance/ContingentClaims.Valuation/0.2.1/contingent-claims-valuation-0.2.1.dar
-
+build-options: null
 

--- a/package/test/daml/ContingentClaims.Test/daml.yaml
+++ b/package/test/daml/ContingentClaims.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: contingent-claims-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Account.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Account.Test/daml.yaml
@@ -11,11 +11,11 @@ dependencies:
   - daml-script
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Holding.Test/1.0.0/daml-finance-holding-test-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Holding/2.0.0/daml-finance-holding-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.0/daml-finance-interface-account-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.0/daml-finance-interface-holding-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Holding/2.0.1/daml-finance-holding-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.1/daml-finance-interface-account-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.1/daml-finance-interface-holding-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Account.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Account.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-account-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Data.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Data.Test/daml.yaml
@@ -10,11 +10,11 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Data/2.0.0/daml-finance-data-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Data/3.0.0/daml-finance-interface-data-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.0/daml-finance-interface-lifecycle-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/3.0.1/daml-finance-interface-data-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.1/daml-finance-interface-lifecycle-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.1/daml-finance-interface-types-date-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
-
+build-options: null
 

--- a/package/test/daml/Daml.Finance.Data.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Data.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-data-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
@@ -10,12 +10,12 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Account/2.0.0/daml-finance-account-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Holding/2.0.0/daml-finance-holding-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.0/daml-finance-interface-account-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.0/daml-finance-interface-holding-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Account/2.0.1/daml-finance-account-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Holding/2.0.1/daml-finance-holding-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.1/daml-finance-interface-account-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.1/daml-finance-interface-holding-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
-
+build-options: null
 

--- a/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-holding-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
@@ -10,11 +10,13 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Data/2.0.0/daml-finance-data-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Bond/0.3.0/daml-finance-instrument-bond-0.3.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.0/daml-finance-interface-claims-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/0.3.0/daml-finance-interface-instrument-bond-0.3.0.dar
+  - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Bond/1.0.1/daml-finance-instrument-bond-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.1/daml-finance-interface-claims-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/1.0.1/daml-finance-interface-instrument-bond-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.1/daml-finance-interface-types-date-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
+build-options: null
+

--- a/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-instrument-bond-test
 source: daml
 version: 0.2.0

--- a/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-instrument-equity-test
 source: daml
 version: 0.2.0

--- a/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
@@ -10,18 +10,18 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Holding/2.0.0/daml-finance-holding-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Equity/0.3.0/daml-finance-instrument-equity-0.3.0.dar
+  - .lib/daml-finance/Daml.Finance.Holding/2.0.1/daml-finance-holding-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Equity/0.3.1/daml-finance-instrument-equity-0.3.1.dar
   - .lib/daml-finance/Daml.Finance.Instrument.Option.Test/0.1.0/daml-finance-instrument-option-test-0.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Option/0.2.0/daml-finance-instrument-option-0.2.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.3.0/daml-finance-interface-instrument-equity-0.3.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.2.0/daml-finance-interface-instrument-option-0.2.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.0/daml-finance-interface-lifecycle-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.0/daml-finance-interface-settlement-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Option/0.2.1/daml-finance-instrument-option-0.2.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.3.1/daml-finance-interface-instrument-equity-0.3.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.2.1/daml-finance-interface-instrument-option-0.2.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.1/daml-finance-interface-lifecycle-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.1/daml-finance-interface-settlement-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/2.0.0/daml-finance-lifecycle-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/2.0.0/daml-finance-settlement-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/2.0.1/daml-finance-lifecycle-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/2.0.1/daml-finance-settlement-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
-
+build-options: null
 

--- a/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-instrument-generic-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
@@ -10,19 +10,21 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/ContingentClaims.Core/1.0.1/contingent-claims-core-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Claims/1.0.2/daml-finance-claims-1.0.2.dar
-  - .lib/daml-finance/Daml.Finance.Data/2.0.0/daml-finance-data-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Holding/2.0.0/daml-finance-holding-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Generic/2.0.0/daml-finance-instrument-generic-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.0/daml-finance-interface-account-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.0/daml-finance-interface-claims-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.0/daml-finance-interface-holding-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/2.0.0/daml-finance-interface-instrument-generic-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.0/daml-finance-interface-lifecycle-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.0/daml-finance-interface-settlement-2.0.0.dar
+  - .lib/daml-finance/ContingentClaims.Core/2.0.0/contingent-claims-core-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Claims/2.0.1/daml-finance-claims-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Holding/2.0.1/daml-finance-holding-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Generic/2.0.1/daml-finance-instrument-generic-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.1/daml-finance-interface-account-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.1/daml-finance-interface-claims-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.1/daml-finance-interface-holding-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/2.0.1/daml-finance-interface-instrument-generic-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.1/daml-finance-interface-lifecycle-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.1/daml-finance-interface-settlement-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/2.0.0/daml-finance-lifecycle-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/2.0.0/daml-finance-settlement-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/2.0.1/daml-finance-lifecycle-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/2.0.1/daml-finance-settlement-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
+build-options: null
+

--- a/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
@@ -10,11 +10,13 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Claims/1.0.2/daml-finance-claims-1.0.2.dar
-  - .lib/daml-finance/Daml.Finance.Data/2.0.0/daml-finance-data-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Option/0.2.0/daml-finance-instrument-option-0.2.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.2.0/daml-finance-interface-instrument-option-0.2.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.0/daml-finance-interface-lifecycle-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Claims/2.0.1/daml-finance-claims-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Option/0.2.1/daml-finance-instrument-option-0.2.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.2.1/daml-finance-interface-instrument-option-0.2.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.1/daml-finance-interface-lifecycle-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
+build-options: null
+

--- a/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-instrument-option-test
 source: daml
 version: 0.1.0

--- a/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-instrument-structuredproduct-test
 source: daml
 version: 0.1.0

--- a/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
@@ -10,12 +10,12 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Data/2.0.0/daml-finance-data-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Instrument.StructuredProduct/0.1.0/daml-finance-instrument-structuredproduct-0.1.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.StructuredProduct/0.1.0/daml-finance-interface-instrument-structuredproduct-0.1.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.1/daml-finance-interface-types-date-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-instrument-swap-test
 source: daml
 version: 0.2.0

--- a/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
@@ -10,12 +10,12 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Data/2.0.0/daml-finance-data-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Swap/0.3.0/daml-finance-instrument-swap-0.3.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.3.0/daml-finance-interface-instrument-swap-0.3.0.dar
+  - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Swap/0.3.1/daml-finance-instrument-swap-0.3.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.3.1/daml-finance-interface-instrument-swap-0.3.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.1/daml-finance-interface-types-date-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
-
+build-options: null
 

--- a/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-settlement-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
@@ -10,14 +10,14 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Account/2.0.0/daml-finance-account-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Holding/2.0.0/daml-finance-holding-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.0/daml-finance-interface-account-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.0/daml-finance-interface-holding-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.0/daml-finance-interface-settlement-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Account/2.0.1/daml-finance-account-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Holding/2.0.1/daml-finance-holding-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.1/daml-finance-interface-account-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.1/daml-finance-interface-holding-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.1/daml-finance-interface-settlement-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/2.0.0/daml-finance-settlement-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/2.0.1/daml-finance-settlement-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
-
+build-options: null
 

--- a/package/test/daml/Daml.Finance.Test.Util/daml.yaml
+++ b/package/test/daml/Daml.Finance.Test.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-test-util
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Test.Util/daml.yaml
+++ b/package/test/daml/Daml.Finance.Test.Util/daml.yaml
@@ -10,15 +10,17 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Account/2.0.0/daml-finance-account-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Claims/1.0.2/daml-finance-claims-1.0.2.dar
-  - .lib/daml-finance/Daml.Finance.Data/2.0.0/daml-finance-data-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Token/2.0.0/daml-finance-instrument-token-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.0/daml-finance-interface-account-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.0/daml-finance-interface-holding-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.0/daml-finance-interface-instrument-base-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.0/daml-finance-interface-lifecycle-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Account/2.0.1/daml-finance-account-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Claims/2.0.1/daml-finance-claims-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Token/2.0.1/daml-finance-instrument-token-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.1/daml-finance-interface-account-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.1/daml-finance-interface-holding-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.1/daml-finance-interface-lifecycle-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.1/daml-finance-interface-types-date-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/2.0.0/daml-finance-lifecycle-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/2.0.1/daml-finance-lifecycle-2.0.1.dar
+build-options: null
+

--- a/package/test/daml/Daml.Finance.Util.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Util.Test/daml.yaml
@@ -12,8 +12,8 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.1/daml-finance-interface-types-date-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/1.0.1/daml-finance-interface-util-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/2.0.1/daml-finance-util-2.0.1.dar
-
+  - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar
+build-options: null
 

--- a/package/test/daml/Daml.Finance.Util.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Util.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.6.0
+sdk-version: 2.7.0
 name: daml-finance-util-test
 source: daml
 version: 1.0.0


### PR DESCRIPTION
1.  Update SDK version to `2.7.0`
2. Update assembly version to `1.3.0`
3. Update package versions to be in line with released packages, then run packell
4. Flush released changes out of `CHANGELOG.md`

Important: the current package versions (after step 3) are not following the semantic versioning scheme. I believe this should be a separate step before the next release to align package versions to semantic versioning (based on changelog). I believe doing the opposite is error prone.