### PR TITLE
Rewrite template-local let bindings as plain functions

### DIFF
--- a/src/main/daml/Daml/Finance/Account/Account.daml
+++ b/src/main/daml/Daml/Finance/Account/Account.daml
@@ -89,9 +89,11 @@ template Account
       addObservers = addObserversImpl this $ Some (Account.disclosureUpdateReference (accountKey this))
       removeObservers = removeObserversImpl this $ Some (Account.disclosureUpdateReference (accountKey this))
 
+-- | HIDE
 accountKey : Account -> AccountKey
 accountKey Account {custodian; owner; id} = AccountKey with custodian; owner; id
 
+-- | HIDE
 mustNotBeLocked : Account -> Update ()
 mustNotBeLocked Account {lock} = assertMsg @Update "Must not be locked" $ isNone lock
 

--- a/src/main/daml/Daml/Finance/Account/Account.daml
+++ b/src/main/daml/Daml/Finance/Account/Account.daml
@@ -44,28 +44,24 @@ template Account
     -- Outgoing controllers must be non-empty.
     ensure isValidLock lock && (not . S.null $ controllers.outgoing)
 
-    let
-      account = AccountKey with custodian; owner; id
-      mustNotBeLocked = assertMsg @Update "Must not be locked" $ isNone lock
-
     interface instance Account.I for Account where
       view = Account.View with custodian; id; owner; holdingFactoryCid; description; controllers
-      getKey = account
+      getKey = accountKey this
       credit Account.Credit{quantity} = do
-        mustNotBeLocked
+        mustNotBeLocked this
         exercise holdingFactoryCid HoldingFactory.Create with
           instrument = quantity.unit
-          account
+          account = accountKey this
           amount = quantity.amount
           observers = M.empty
       debit Account.Debit{holdingCid} = do
-        mustNotBeLocked
+        mustNotBeLocked this
         holding <- fetch holdingCid
         let
           vHolding = view holding
           vLockable = view $ toInterface @Lockable.I holding
         assertMsg "Holding must not be locked" $ isNone vLockable.lock
-        assertMsg "Accounts must match" $ vHolding.account == account
+        assertMsg "Accounts must match" $ vHolding.account == accountKey this
         archive holdingCid
 
     interface instance Lockable.I for Account where
@@ -89,9 +85,15 @@ template Account
 
     interface instance Disclosure.I for Account where
       view = Disclosure.View with disclosureControllers = S.fromList [custodian, owner]; observers
-      setObservers = setObserversImpl this $ Some (Account.disclosureUpdateReference account)
-      addObservers = addObserversImpl this $ Some (Account.disclosureUpdateReference account)
-      removeObservers = removeObserversImpl this $ Some (Account.disclosureUpdateReference account)
+      setObservers = setObserversImpl this $ Some (Account.disclosureUpdateReference (accountKey this))
+      addObservers = addObserversImpl this $ Some (Account.disclosureUpdateReference (accountKey this))
+      removeObservers = removeObserversImpl this $ Some (Account.disclosureUpdateReference (accountKey this))
+
+accountKey : Account -> AccountKey
+accountKey Account {custodian; owner; id} = AccountKey with custodian; owner; id
+
+mustNotBeLocked : Account -> Update ()
+mustNotBeLocked Account {lock} = assertMsg @Update "Must not be locked" $ isNone lock
 
 -- | Template used to create accounts.
 template Factory

--- a/src/main/daml/Daml/Finance/Data/Time/DateClock.daml
+++ b/src/main/daml/Daml/Finance/Data/Time/DateClock.daml
@@ -37,25 +37,6 @@ template DateClock
     signatory providers
     observer observers
 
-    let
-      moveClock : ContractId Time.I -> Id -> Text -> Int ->
-        Update (ContractId Time.I, ContractId TimeEvent.I)
-      moveClock self eventId eventDescription offset = do
-        let
-          Unit currentDate = date
-          newDate = addDays currentDate offset
-          clock = this with date = Unit newDate
-        archive self
-        clockCid <- toInterfaceContractId <$> create clock
-        eventCid <- toInterfaceContractId <$> create DateClockUpdateEvent with
-          providers
-          observers
-          id = eventId
-          description = eventDescription
-          eventTime = toUTCTime clock
-          date = newDate
-        pure (clockCid, eventCid)
-
     interface instance TimeObservable.I for DateClock where
       view = TimeObservable.View with providers; id
       getTime =
@@ -65,9 +46,27 @@ template DateClock
     interface instance Time.I for DateClock where
       view = Time.View with providers; id
       advance self Time.Advance{eventId; eventDescription} =
-        moveClock self eventId eventDescription 1
+        moveClock this self eventId eventDescription 1
       rewind self Time.Rewind{eventId; eventDescription} =
-        moveClock self eventId eventDescription (-1)
+        moveClock this self eventId eventDescription (-1)
+
+moveClock : DateClock -> ContractId Time.I -> Id -> Text -> Int ->
+  Update (ContractId Time.I, ContractId TimeEvent.I)
+moveClock this@DateClock {date; providers; observers} self eventId eventDescription offset = do
+  let
+    Unit currentDate = date
+    newDate = addDays currentDate offset
+    clock = this with date = Unit newDate
+  archive self
+  clockCid <- toInterfaceContractId <$> create clock
+  eventCid <- toInterfaceContractId <$> create DateClockUpdateEvent with
+    providers
+    observers
+    id = eventId
+    description = eventDescription
+    eventTime = toUTCTime clock
+    date = newDate
+  pure (clockCid, eventCid)
 
 instance HasUTCTimeConversion DateClock where
   toUTCTime clock = toUTCTime clock.date

--- a/src/main/daml/Daml/Finance/Data/Time/DateClock.daml
+++ b/src/main/daml/Daml/Finance/Data/Time/DateClock.daml
@@ -50,6 +50,7 @@ template DateClock
       rewind self Time.Rewind{eventId; eventDescription} =
         moveClock this self eventId eventDescription (-1)
 
+-- | HIDE
 moveClock : DateClock -> ContractId Time.I -> Id -> Text -> Int ->
   Update (ContractId Time.I, ContractId TimeEvent.I)
 moveClock this@DateClock {date; providers; observers} self eventId eventDescription offset = do

--- a/src/main/daml/Daml/Finance/Instrument/Bond/Callable/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/Callable/Instrument.daml
@@ -100,8 +100,6 @@ template Instrument
 
     ensure noticeDays >= 0
 
-    let instrument = InstrumentKey with depository; issuer; id; version
-
     -- CALLABLE_BOND_CLAIMS_BEGIN
     interface instance Claim.I for Instrument where
       view = Claim.View with acquisitionTime = dateToDateClockTime $ daysSinceEpochToDate 0
@@ -129,12 +127,12 @@ template Instrument
     interface instance BaseInstrument.I for Instrument where
       view = BaseInstrument.View with
         depository; issuer; id; version; description; validAsOf = lastEventTimestamp
-      getKey = instrument
+      getKey = instrumentKey this
 
     interface instance Callable.I for Instrument where
       view = Callable.View with
         callable = Callable with
-          instrument
+          instrument = instrumentKey this
           description
           floatingRate
           couponRate
@@ -163,8 +161,12 @@ template Instrument
     interface instance Disclosure.I for Instrument where
       view = Disclosure.View with disclosureControllers = singleton issuer; observers
       setObservers = setObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       addObservers = addObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       removeObservers = removeObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
+
+instrumentKey : Instrument -> InstrumentKey
+instrumentKey Instrument {depository; issuer; id; version} =
+  InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Bond/Callable/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/Callable/Instrument.daml
@@ -167,6 +167,7 @@ template Instrument
       removeObservers = removeObserversImpl this $
         Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
 
+-- | HIDE
 instrumentKey : Instrument -> InstrumentKey
 instrumentKey Instrument {depository; issuer; id; version} =
   InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate/Instrument.daml
@@ -117,6 +117,7 @@ template Instrument
       removeObservers = removeObserversImpl this $
         Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
 
+-- | HIDE
 instrumentKey : Instrument -> InstrumentKey
 instrumentKey Instrument {depository; issuer; id; version} =
   InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate/Instrument.daml
@@ -64,8 +64,6 @@ template Instrument
     signatory depository, issuer
     observer Disclosure.flattenObservers observers
 
-    let instrument = InstrumentKey with depository; issuer; id; version
-
     -- FIXED_RATE_BOND_CLAIMS_BEGIN
     interface instance Claim.I for Instrument where
       view = Claim.View with acquisitionTime = dateToDateClockTime $ daysSinceEpochToDate 0
@@ -87,12 +85,12 @@ template Instrument
     interface instance BaseInstrument.I for Instrument where
       view = BaseInstrument.View with
         depository; issuer; id; version; description; validAsOf = lastEventTimestamp
-      getKey = instrument
+      getKey = instrumentKey this
 
     interface instance FixedRate.I for Instrument where
       view = FixedRate.View with
         fixedRate = FixedRate with
-          instrument
+          instrument = instrumentKey this
           description
           couponRate
           periodicSchedule
@@ -113,8 +111,12 @@ template Instrument
     interface instance Disclosure.I for Instrument where
       view = Disclosure.View with disclosureControllers = singleton issuer; observers
       setObservers = setObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       addObservers = addObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       removeObservers = removeObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
+
+instrumentKey : Instrument -> InstrumentKey
+instrumentKey Instrument {depository; issuer; id; version} =
+  InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate/Instrument.daml
@@ -69,8 +69,6 @@ template Instrument
     signatory depository, issuer
     observer Disclosure.flattenObservers observers
 
-    let instrument = InstrumentKey with depository; issuer; id; version
-
     interface instance Claim.I for Instrument where
       view = Claim.View with acquisitionTime = dateToDateClockTime $ daysSinceEpochToDate 0
       getClaims Claim.GetClaims{actor} = do
@@ -91,12 +89,12 @@ template Instrument
     interface instance BaseInstrument.I for Instrument where
       view = BaseInstrument.View with
         depository; issuer; id; version; description; validAsOf = lastEventTimestamp
-      getKey = instrument
+      getKey = instrumentKey this
 
     interface instance FloatingRate.I for Instrument where
       view = FloatingRate.View with
         floatingRate = FloatingRate with
-          instrument
+          instrument = instrumentKey this
           description
           referenceRateId
           couponSpread
@@ -118,8 +116,12 @@ template Instrument
     interface instance Disclosure.I for Instrument where
       view = Disclosure.View with disclosureControllers = singleton issuer; observers
       setObservers = setObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       addObservers = addObserversImpl @Instrument this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       removeObservers = removeObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
+
+instrumentKey : Instrument -> InstrumentKey
+instrumentKey Instrument {depository; issuer; id; version} =
+  InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate/Instrument.daml
@@ -122,6 +122,7 @@ template Instrument
       removeObservers = removeObserversImpl this $
         Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
 
+-- | HIDE
 instrumentKey : Instrument -> InstrumentKey
 instrumentKey Instrument {depository; issuer; id; version} =
   InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Bond/InflationLinked/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/InflationLinked/Instrument.daml
@@ -78,8 +78,6 @@ template Instrument
     signatory depository, issuer
     observer Disclosure.flattenObservers observers
 
-    let instrument = InstrumentKey with depository; issuer; id; version
-
     interface instance Claim.I for Instrument where
       view = Claim.View with acquisitionTime = dateToDateClockTime $ daysSinceEpochToDate 0
       getClaims Claim.GetClaims{actor} = do
@@ -120,12 +118,12 @@ template Instrument
     interface instance BaseInstrument.I for Instrument where
       view = BaseInstrument.View with
         depository; issuer; id; version; description; validAsOf = lastEventTimestamp
-      getKey = instrument
+      getKey = instrumentKey this
 
     interface instance InflationLinked.I for Instrument where
       view = InflationLinked.View with
         inflationLinked = InflationLinked with
-          instrument
+          instrument = instrumentKey this
           description
           inflationIndexId
           inflationIndexBaseValue
@@ -148,8 +146,12 @@ template Instrument
     interface instance Disclosure.I for Instrument where
       view = Disclosure.View with disclosureControllers = singleton issuer; observers
       setObservers = setObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       addObservers = addObserversImpl @Instrument this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       removeObservers = removeObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
+
+instrumentKey : Instrument -> InstrumentKey
+instrumentKey Instrument {depository; issuer; id; version} =
+  InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Bond/InflationLinked/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/InflationLinked/Instrument.daml
@@ -152,6 +152,7 @@ template Instrument
       removeObservers = removeObserversImpl this $
         Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
 
+-- | HIDE
 instrumentKey : Instrument -> InstrumentKey
 instrumentKey Instrument {depository; issuer; id; version} =
   InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Bond/ZeroCoupon/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/ZeroCoupon/Instrument.daml
@@ -52,8 +52,6 @@ template Instrument
     signatory depository, issuer
     observer Disclosure.flattenObservers observers
 
-    let instrument = InstrumentKey with depository; issuer; id; version
-
     interface instance Claim.I for Instrument where
       view = Claim.View with acquisitionTime = dateToDateClockTime $ daysSinceEpochToDate 0
       getClaims Claim.GetClaims{} =
@@ -69,12 +67,12 @@ template Instrument
     interface instance BaseInstrument.I for Instrument where
       view = BaseInstrument.View with
         depository; issuer; id; version; description; validAsOf = lastEventTimestamp
-      getKey = instrument
+      getKey = instrumentKey this
 
     interface instance ZeroCoupon.I for Instrument where
       view = ZeroCoupon.View with
         zeroCoupon = ZeroCoupon with
-          instrument; description; issueDate; maturityDate; currency; notional; lastEventTimestamp
+          instrument = instrumentKey this; description; issueDate; maturityDate; currency; notional; lastEventTimestamp
 
     interface instance DynamicInstrument.I for Instrument where
       view = DynamicInstrument.View with lifecycler = issuer; lastEventTimestamp; prevEvents = []
@@ -86,8 +84,12 @@ template Instrument
     interface instance Disclosure.I for Instrument where
       view = Disclosure.View with disclosureControllers = singleton issuer; observers
       setObservers = setObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       addObservers = addObserversImpl @Instrument this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       removeObservers = removeObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
+
+instrumentKey : Instrument -> InstrumentKey
+instrumentKey Instrument{depository; issuer; id; version} =
+  InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Bond/ZeroCoupon/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/ZeroCoupon/Instrument.daml
@@ -90,6 +90,7 @@ template Instrument
       removeObservers = removeObserversImpl this $
         Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
 
+-- | HIDE
 instrumentKey : Instrument -> InstrumentKey
 instrumentKey Instrument{depository; issuer; id; version} =
   InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Equity/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Equity/Instrument.daml
@@ -38,14 +38,12 @@ template Instrument
     signatory depository, issuer
     observer Disclosure.flattenObservers observers
 
-    let instrument = InstrumentKey with depository; issuer; id; version
-
     interface instance BaseInstrument.I for Instrument where
       view = BaseInstrument.View with issuer; depository; id; version; description; validAsOf
-      getKey = instrument
+      getKey = instrumentKey this
 
     interface instance Equity.I for Instrument where
-      view = Equity.View with instrument
+      view = Equity.View with instrument = instrumentKey this
       declareDistribution
         Equity.DeclareDistribution{id; description; effectiveTime; newInstrument;
           perUnitDistribution} =
@@ -55,7 +53,7 @@ template Instrument
                 id
                 description
                 effectiveTime
-                targetInstrument = instrument
+                targetInstrument = instrumentKey this
                 newInstrument
                 perUnitDistribution
                 observers = Disclosure.flattenObservers observers
@@ -74,7 +72,7 @@ template Instrument
                 id
                 description
                 effectiveTime
-                targetInstrument = instrument
+                targetInstrument = instrumentKey this
                 perUnitReplacement = [qty (1.0 / adjustmentFactor) newInstrument]
                 observers = Disclosure.flattenObservers observers
       declareReplacement
@@ -85,15 +83,19 @@ template Instrument
               id
               description
               effectiveTime
-              targetInstrument = instrument
+              targetInstrument = instrumentKey this
               perUnitReplacement
               observers = Disclosure.flattenObservers observers
 
     interface instance Disclosure.I for Instrument where
       view = Disclosure.View with disclosureControllers = singleton issuer; observers
       setObservers = setObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       addObservers = addObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       removeObservers = removeObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
+
+instrumentKey : Instrument -> InstrumentKey
+instrumentKey Instrument {depository; issuer; id; version} =
+  InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Equity/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Equity/Instrument.daml
@@ -96,6 +96,7 @@ template Instrument
       removeObservers = removeObserversImpl this $
         Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
 
+-- | HIDE
 instrumentKey : Instrument -> InstrumentKey
 instrumentKey Instrument {depository; issuer; id; version} =
   InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Instrument.daml
@@ -64,6 +64,7 @@ template Instrument
       removeObservers = removeObserversImpl this $
         Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
 
+-- | HIDE
 instrumentKey : Instrument -> InstrumentKey
 instrumentKey Instrument {depository; issuer; id; version} =
   InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Instrument.daml
@@ -43,10 +43,6 @@ template Instrument
     signatory depository, issuer
     observer Disclosure.flattenObservers observers
 
-    let
-      instrument = InstrumentKey with depository; issuer; id; version
-      lifecycler = issuer
-
     interface instance Claim.I for Instrument where
       view = Claim.View with acquisitionTime
       getClaims _ = pure [TaggedClaim with tag = "Generic"; claim = this.claims]
@@ -54,16 +50,20 @@ template Instrument
     interface instance BaseInstrument.I for Instrument where
       view = BaseInstrument.View with
         depository; issuer; id; version; description; validAsOf = lastEventTimestamp
-      getKey = instrument
+      getKey = instrumentKey this
 
     interface instance GenericInstrument.I for Instrument where
-      view = GenericInstrument.View with instrument; claims
+      view = GenericInstrument.View with instrument = instrumentKey this; claims
 
     interface instance Disclosure.I for Instrument where
       view = Disclosure.View with disclosureControllers = singleton issuer; observers
       setObservers = setObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       addObservers = addObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       removeObservers = removeObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
+
+instrumentKey : Instrument -> InstrumentKey
+instrumentKey Instrument {depository; issuer; id; version} =
+  InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Option/BarrierEuropeanCash/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Option/BarrierEuropeanCash/Instrument.daml
@@ -63,8 +63,6 @@ template Instrument
     signatory depository, issuer
     observer Disclosure.flattenObservers observers
 
-    let instrument = InstrumentKey with depository; issuer; id; version
-
     interface instance Claim.I for Instrument where
       view = Claim.View with acquisitionTime = dateToDateClockTime $ daysSinceEpochToDate 0
       getClaims Claim.GetClaims{actor} = do
@@ -86,12 +84,12 @@ template Instrument
     interface instance BaseInstrument.I for Instrument where
       view = BaseInstrument.View with
         depository; issuer; id; version; description; validAsOf = lastEventTimestamp
-      getKey = instrument
+      getKey = instrumentKey this
 
     interface instance BarrierEuropeanOption.I for Instrument where
       view = BarrierEuropeanOption.View with
         barrierEuropean = BarrierEuropean with
-          instrument
+          instrument = instrumentKey this
           description
           referenceAssetId
           ownerReceives
@@ -114,8 +112,12 @@ template Instrument
     interface instance Disclosure.I for Instrument where
       view = Disclosure.View with disclosureControllers = singleton issuer; observers
       setObservers = setObserversImpl @Instrument this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       addObservers = addObserversImpl @Instrument this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       removeObservers = removeObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
+
+instrumentKey : Instrument -> InstrumentKey
+instrumentKey Instrument {depository; issuer; id; version} =
+  InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Option/BarrierEuropeanCash/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Option/BarrierEuropeanCash/Instrument.daml
@@ -118,6 +118,7 @@ template Instrument
       removeObservers = removeObserversImpl this $
         Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
 
+-- | HIDE
 instrumentKey : Instrument -> InstrumentKey
 instrumentKey Instrument {depository; issuer; id; version} =
   InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Option/Dividend/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Option/Dividend/Instrument.daml
@@ -54,8 +54,6 @@ template Instrument
     signatory depository, issuer
     observer Disclosure.flattenObservers observers
 
-    let instrument = InstrumentKey with depository; issuer; id; version
-
     interface instance Claim.I for Instrument where
       view = Claim.View with acquisitionTime = dateToDateClockTime $ daysSinceEpochToDate 0
       getClaims Claim.GetClaims{actor} = do
@@ -68,12 +66,12 @@ template Instrument
     interface instance BaseInstrument.I for Instrument where
       view = BaseInstrument.View with
         depository; issuer; id; version; description; validAsOf = lastEventTimestamp
-      getKey = instrument
+      getKey = instrumentKey this
 
     interface instance DividendOption.I for Instrument where
       view = DividendOption.View with
         dividend = Dividend with
-          instrument
+          instrument = instrumentKey this
           description
           expiryDate
           cashQuantity
@@ -93,8 +91,12 @@ template Instrument
     interface instance Disclosure.I for Instrument where
       view = Disclosure.View with disclosureControllers = singleton issuer; observers
       setObservers = setObserversImpl @Instrument this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       addObservers = addObserversImpl @Instrument this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       removeObservers = removeObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
+
+instrumentKey : Instrument -> InstrumentKey
+instrumentKey Instrument {depository; issuer; id; version} =
+  InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Option/Dividend/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Option/Dividend/Instrument.daml
@@ -97,6 +97,7 @@ template Instrument
       removeObservers = removeObserversImpl this $
         Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
 
+-- | HIDE
 instrumentKey : Instrument -> InstrumentKey
 instrumentKey Instrument {depository; issuer; id; version} =
   InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Option/EuropeanCash/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Option/EuropeanCash/Instrument.daml
@@ -56,8 +56,6 @@ template Instrument
     signatory depository, issuer
     observer Disclosure.flattenObservers observers
 
-    let instrument = InstrumentKey with depository; issuer; id; version
-
     interface instance Claim.I for Instrument where
       view = Claim.View with acquisitionTime = dateToDateClockTime $ daysSinceEpochToDate 0
       getClaims Claim.GetClaims{actor} = do
@@ -73,12 +71,12 @@ template Instrument
     interface instance BaseInstrument.I for Instrument where
       view = BaseInstrument.View with
         depository; issuer; id; version; description; validAsOf = lastEventTimestamp
-      getKey = instrument
+      getKey = instrumentKey this
 
     interface instance EuropeanOption.I for Instrument where
       view = EuropeanOption.View with
         european = European with
-          instrument
+          instrument = instrumentKey this
           description
           referenceAssetId
           ownerReceives
@@ -98,8 +96,12 @@ template Instrument
     interface instance Disclosure.I for Instrument where
       view = Disclosure.View with disclosureControllers = singleton issuer; observers
       setObservers = setObserversImpl @Instrument this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       addObservers = addObserversImpl @Instrument this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       removeObservers = removeObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
+
+instrumentKey : Instrument -> InstrumentKey
+instrumentKey Instrument {depository; issuer; id; version} =
+  InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Option/EuropeanCash/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Option/EuropeanCash/Instrument.daml
@@ -102,6 +102,7 @@ template Instrument
       removeObservers = removeObserversImpl this $
         Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
 
+-- | HIDE
 instrumentKey : Instrument -> InstrumentKey
 instrumentKey Instrument {depository; issuer; id; version} =
   InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Option/EuropeanPhysical/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Option/EuropeanPhysical/Instrument.daml
@@ -59,8 +59,6 @@ template Instrument
     signatory depository, issuer
     observer Disclosure.flattenObservers observers
 
-    let instrument = InstrumentKey with depository; issuer; id; version
-
     interface instance Claim.I for Instrument where
       view = Claim.View with acquisitionTime = dateToDateClockTime $ daysSinceEpochToDate 0
       getClaims Claim.GetClaims{actor} = do
@@ -75,12 +73,12 @@ template Instrument
     interface instance BaseInstrument.I for Instrument where
       view = BaseInstrument.View with
         depository; issuer; id; version; description; validAsOf = lastEventTimestamp
-      getKey = instrument
+      getKey = instrumentKey this
 
     interface instance EuropeanOption.I for Instrument where
       view = EuropeanOption.View with
         european = European with
-          instrument
+          instrument = instrumentKey this
           description
           referenceAsset
           ownerReceives
@@ -102,8 +100,12 @@ template Instrument
     interface instance Disclosure.I for Instrument where
       view = Disclosure.View with disclosureControllers = singleton issuer; observers
       setObservers = setObserversImpl @Instrument this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       addObservers = addObserversImpl @Instrument this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       removeObservers = removeObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
+
+instrumentKey : Instrument -> InstrumentKey
+instrumentKey Instrument {depository; issuer; id; version} =
+  InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Option/EuropeanPhysical/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Option/EuropeanPhysical/Instrument.daml
@@ -106,6 +106,7 @@ template Instrument
       removeObservers = removeObserversImpl this $
         Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
 
+-- | HIDE
 instrumentKey : Instrument -> InstrumentKey
 instrumentKey Instrument {depository; issuer; id; version} =
   InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/StructuredProduct/BarrierReverseConvertible/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/StructuredProduct/BarrierReverseConvertible/Instrument.daml
@@ -158,6 +158,7 @@ template Instrument
       removeObservers = removeObserversImpl this $
         Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
 
+-- | HIDE
 instrumentKey : Instrument -> InstrumentKey
 instrumentKey Instrument {depository; issuer; id; version} =
   InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/StructuredProduct/BarrierReverseConvertible/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/StructuredProduct/BarrierReverseConvertible/Instrument.daml
@@ -77,8 +77,6 @@ template Instrument
     signatory depository, issuer
     observer Disclosure.flattenObservers observers
 
-    let instrument = InstrumentKey with depository; issuer; id; version
-
     interface instance Claim.I for Instrument where
       view = Claim.View with acquisitionTime = dateToDateClockTime $ daysSinceEpochToDate 0
       getClaims Claim.GetClaims{actor} = do
@@ -121,12 +119,12 @@ template Instrument
     interface instance BaseInstrument.I for Instrument where
       view = BaseInstrument.View with
         depository; issuer; id; version; description; validAsOf = lastEventTimestamp
-      getKey = instrument
+      getKey = instrumentKey this
 
     interface instance BarrierReverseConvertible.I for Instrument where
       view = BarrierReverseConvertible.View with
         barrierReverseConvertible = BarrierReverseConvertible with
-          instrument
+          instrument = instrumentKey this
           description
           referenceAssetId
           strike
@@ -154,8 +152,12 @@ template Instrument
     interface instance Disclosure.I for Instrument where
       view = Disclosure.View with disclosureControllers = singleton issuer; observers
       setObservers = setObserversImpl @Instrument this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       addObservers = addObserversImpl @Instrument this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       removeObservers = removeObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
+
+instrumentKey : Instrument -> InstrumentKey
+instrumentKey Instrument {depository; issuer; id; version} =
+  InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Asset/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Asset/Instrument.daml
@@ -125,6 +125,7 @@ template Instrument
       removeObservers = removeObserversImpl this $
         Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
 
+-- | HIDE
 instrumentKey : Instrument -> InstrumentKey
 instrumentKey Instrument {depository; issuer; id; version} =
   InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Asset/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Asset/Instrument.daml
@@ -72,8 +72,6 @@ template Instrument
     signatory depository, issuer
     observer Disclosure.flattenObservers observers
 
-    let instrument = InstrumentKey with depository; issuer; id; version
-
     interface instance Claim.I for Instrument where
       view = Claim.View with acquisitionTime = dateToDateClockTime $ daysSinceEpochToDate 0
       getClaims Claim.GetClaims{actor} = do
@@ -94,12 +92,12 @@ template Instrument
     interface instance BaseInstrument.I for Instrument where
       view = BaseInstrument.View with
         depository; issuer; id; version; description; validAsOf = lastEventTimestamp
-      getKey = instrument
+      getKey = instrumentKey this
 
     interface instance Asset.I for Instrument where
       view = Asset.View with
         asset = Asset with
-          instrument
+          instrument = instrumentKey this
           description
           referenceAssetId
           ownerReceivesFix
@@ -121,8 +119,12 @@ template Instrument
     interface instance Disclosure.I for Instrument where
       view = Disclosure.View with disclosureControllers = singleton issuer; observers
       setObservers = setObserversImpl @Instrument this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       addObservers = addObserversImpl @Instrument this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       removeObservers = removeObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
+
+instrumentKey : Instrument -> InstrumentKey
+instrumentKey Instrument {depository; issuer; id; version} =
+  InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault/Instrument.daml
@@ -127,6 +127,7 @@ template Instrument
       removeObservers = removeObserversImpl this $
         Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
 
+-- | HIDE
 instrumentKey : Instrument -> InstrumentKey
 instrumentKey Instrument {depository; issuer; id; version} =
   InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault/Instrument.daml
@@ -72,8 +72,6 @@ template Instrument
     signatory depository, issuer
     observer Disclosure.flattenObservers observers
 
-    let instrument = InstrumentKey with depository; issuer; id; version
-
     interface instance Claim.I for Instrument where
       view = Claim.View with acquisitionTime = dateToDateClockTime $ daysSinceEpochToDate 0
       getClaims Claim.GetClaims{actor} = do
@@ -95,12 +93,12 @@ template Instrument
     interface instance BaseInstrument.I for Instrument where
       view = BaseInstrument.View with
         depository; issuer; id; version; description; validAsOf = lastEventTimestamp
-      getKey = instrument
+      getKey = instrumentKey this
 
     interface instance CreditDefaultSwap.I for Instrument where
       view = CreditDefaultSwap.View with
         creditDefault = CreditDefault with
-          instrument
+          instrument = instrumentKey this
           description
           defaultProbabilityReferenceId
           recoveryRateReferenceId
@@ -123,8 +121,12 @@ template Instrument
     interface instance Disclosure.I for Instrument where
       view = Disclosure.View with disclosureControllers = singleton issuer; observers
       setObservers = setObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       addObservers = addObserversImpl @Instrument this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       removeObservers = removeObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
+
+instrumentKey : Instrument -> InstrumentKey
+instrumentKey Instrument {depository; issuer; id; version} =
+  InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Currency/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Currency/Instrument.daml
@@ -76,8 +76,6 @@ template Instrument
     signatory depository, issuer
     observer Disclosure.flattenObservers observers
 
-    let instrument = InstrumentKey with depository; issuer; id; version
-
     interface instance Claim.I for Instrument where
       view = Claim.View with acquisitionTime = dateToDateClockTime $ daysSinceEpochToDate 0
       getClaims Claim.GetClaims{actor} = do
@@ -100,12 +98,12 @@ template Instrument
     interface instance BaseInstrument.I for Instrument where
       view = BaseInstrument.View with
         depository; issuer; id; version; description; validAsOf = lastEventTimestamp
-      getKey = instrument
+      getKey = instrumentKey this
 
     interface instance CurrencySwap.I for Instrument where
       view = CurrencySwap.View with
         currencySwap = CurrencySwap with
-          instrument
+          instrument = instrumentKey this
           description
           ownerReceivesBase
           baseRate
@@ -129,8 +127,12 @@ template Instrument
     interface instance Disclosure.I for Instrument where
       view = Disclosure.View with disclosureControllers = singleton issuer; observers
       setObservers = setObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       addObservers = addObserversImpl @Instrument this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       removeObservers = removeObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
+
+instrumentKey : Instrument -> InstrumentKey
+instrumentKey Instrument {depository; issuer; id; version} =
+  InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Currency/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Currency/Instrument.daml
@@ -133,6 +133,7 @@ template Instrument
       removeObservers = removeObserversImpl this $
         Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
 
+-- | HIDE
 instrumentKey : Instrument -> InstrumentKey
 instrumentKey Instrument {depository; issuer; id; version} =
   InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange/Instrument.daml
@@ -64,8 +64,6 @@ template Instrument
     signatory depository, issuer
     observer Disclosure.flattenObservers observers
 
-    let instrument = InstrumentKey with depository; issuer; id; version
-
     interface instance Claim.I for Instrument where
       view = Claim.View with acquisitionTime = dateToDateClockTime $ daysSinceEpochToDate 0
       getClaims _ = do
@@ -86,12 +84,13 @@ template Instrument
     interface instance BaseInstrument.I for Instrument where
       view = BaseInstrument.View with
         depository; issuer; id; version; description; validAsOf = lastEventTimestamp
-      getKey = instrument
+      getKey = instrumentKey this
 
     interface instance ForeignExchange.I for Instrument where
       view = ForeignExchange.View with
         foreignExchange = ForeignExchange with
-          instrument; description; firstFxRate; finalFxRate; issueDate
+          instrument = instrumentKey this
+          description; firstFxRate; finalFxRate; issueDate
           firstPaymentDate; maturityDate; baseCurrency; foreignCurrency; lastEventTimestamp
 
     interface instance DynamicInstrument.I for Instrument where
@@ -104,8 +103,12 @@ template Instrument
     interface instance Disclosure.I for Instrument where
       view = Disclosure.View with disclosureControllers = singleton issuer; observers
       setObservers = setObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       addObservers = addObserversImpl @Instrument this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       removeObservers = removeObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
+
+instrumentKey : Instrument -> InstrumentKey
+instrumentKey Instrument {depository; issuer; id; version} =
+  InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange/Instrument.daml
@@ -109,6 +109,7 @@ template Instrument
       removeObservers = removeObserversImpl this $
         Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
 
+-- | HIDE
 instrumentKey : Instrument -> InstrumentKey
 instrumentKey Instrument {depository; issuer; id; version} =
   InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
@@ -140,6 +140,7 @@ template Instrument
       removeObservers = removeObserversImpl this $
         Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
 
+-- | HIDE
 instrumentKey : Instrument -> InstrumentKey
 instrumentKey Instrument {depository; issuer; id; version} =
   InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Instrument.daml
@@ -54,8 +54,6 @@ template Instrument
     signatory depository, issuer
     observer Disclosure.flattenObservers observers
 
-    let instrument = InstrumentKey with depository; issuer; id; version
-
     interface instance Claim.I for Instrument where
       view = Claim.View with acquisitionTime = dateToDateClockTime $ daysSinceEpochToDate 0
       getClaims Claim.GetClaims{actor} = do
@@ -113,12 +111,12 @@ template Instrument
     interface instance BaseInstrument.I for Instrument where
       view = BaseInstrument.View with
         depository; issuer; id; version; description; validAsOf = lastEventTimestamp
-      getKey = instrument
+      getKey = instrumentKey this
 
     interface instance Fpml.I for Instrument where
       view = Fpml.View with
         fpml = Fpml with
-          instrument
+          instrument = instrumentKey this
           description
           swapStreams
           issuerPartyRef
@@ -136,8 +134,12 @@ template Instrument
     interface instance Disclosure.I for Instrument where
       view = Disclosure.View with disclosureControllers = singleton issuer; observers
       setObservers = setObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       addObservers = addObserversImpl @Instrument this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       removeObservers = removeObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
+
+instrumentKey : Instrument -> InstrumentKey
+instrumentKey Instrument {depository; issuer; id; version} =
+  InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate/Instrument.daml
@@ -67,8 +67,6 @@ template Instrument
     signatory depository, issuer
     observer Disclosure.flattenObservers observers
 
-    let instrument = InstrumentKey with depository; issuer; id; version
-
     interface instance Claim.I for Instrument where
       view = Claim.View with acquisitionTime = dateToDateClockTime $ daysSinceEpochToDate 0
       getClaims Claim.GetClaims{actor} = do
@@ -89,12 +87,12 @@ template Instrument
     interface instance BaseInstrument.I for Instrument where
       view = BaseInstrument.View with
         depository; issuer; id; version; description; validAsOf = lastEventTimestamp
-      getKey = instrument
+      getKey = instrumentKey this
 
     interface instance InterestRate.I for Instrument where
       view = InterestRate.View with
         interestRate = InterestRate with
-          instrument
+          instrument = instrumentKey this
           description
           referenceRateId
           ownerReceivesFix
@@ -116,8 +114,12 @@ template Instrument
     interface instance Disclosure.I for Instrument where
       view = Disclosure.View with disclosureControllers = singleton issuer; observers
       setObservers = setObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       addObservers = addObserversImpl @Instrument this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       removeObservers = removeObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
+
+instrumentKey : Instrument -> InstrumentKey
+instrumentKey Instrument {depository; issuer; id; version} =
+  InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate/Instrument.daml
@@ -120,6 +120,7 @@ template Instrument
       removeObservers = removeObserversImpl this $
         Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
 
+-- | HIDE
 instrumentKey : Instrument -> InstrumentKey
 instrumentKey Instrument {depository; issuer; id; version} =
   InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Token/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Token/Instrument.daml
@@ -53,6 +53,7 @@ template Instrument
       removeObservers = removeObserversImpl this $
         Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
 
+-- | HIDE
 instrumentKey : Instrument -> InstrumentKey
 instrumentKey Instrument {depository; issuer; id; version} =
   InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Instrument/Token/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Token/Instrument.daml
@@ -37,20 +37,22 @@ template Instrument
     signatory depository, issuer
     observer Disclosure.flattenObservers observers
 
-    let instrument = InstrumentKey with depository; issuer; id; version
-
     interface instance BaseInstrument.I for Instrument where
       view = BaseInstrument.View with depository; issuer; id; validAsOf; description; version
-      getKey = instrument
+      getKey = instrumentKey this
 
     interface instance Token.I for Instrument where
-      view = Token.View with token = Token with instrument; description; validAsOf
+      view = Token.View with token = Token with instrument = instrumentKey this; description; validAsOf
 
     interface instance Disclosure.I for Instrument where
       view = Disclosure.View with disclosureControllers = singleton issuer; observers
       setObservers = setObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       addObservers = addObserversImpl @Instrument this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
       removeObservers = removeObserversImpl this $
-        Some (BaseInstrument.disclosureUpdateReference instrument)
+        Some (BaseInstrument.disclosureUpdateReference (instrumentKey this))
+
+instrumentKey : Instrument -> InstrumentKey
+instrumentKey Instrument {depository; issuer; id; version} =
+  InstrumentKey with depository; issuer; id; version

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -44,7 +44,7 @@ template Batch
 
     interface instance Batch.I for Batch where
       view = Batch.View with
-        requestors; settlers; id; description; contextId; routedSteps = routedSteps this; settlementTime
+        requestors; settlers; id; description; contextId; routedSteps = routedSteps this.routedStepsWithInstructionId; settlementTime
       settle Batch.Settle{actors} = do
         assertMsg "actors must intersect with settlers" $
           not $ S.null $ actors `S.intersection` settlers
@@ -85,7 +85,7 @@ template Batch
           orderedInstructionIdsAndSettleCids =
             zip ((.id) <$> orderedInstructions) orderedSettledCids
           settledCids = fromSomeNote "All keys must exist in the map." .
-            (`M.lookup` (M.fromList orderedInstructionIdsAndSettleCids)) <$> instructionIds this
+            (`M.lookup` (M.fromList orderedInstructionIdsAndSettleCids)) <$> instructionIds this.routedStepsWithInstructionId
         pure $ catOptionals settledCids
       cancel Batch.Cancel{actors} = do
         let
@@ -99,12 +99,12 @@ template Batch
         catOptionals <$> mapA (cancelInstruction . buildKey this . snd) routedStepsWithInstructionId
 
 -- | HIDE
-routedSteps : Batch -> [RoutedStep]
-routedSteps Batch {routedStepsWithInstructionId} = fst <$> routedStepsWithInstructionId
+routedSteps : [(RoutedStep, Id)] -> [RoutedStep]
+routedSteps = fmap fst
 
 -- | HIDE
-instructionIds : Batch -> [Id]
-instructionIds Batch {routedStepsWithInstructionId} = snd <$> routedStepsWithInstructionId
+instructionIds : [(RoutedStep, Id)] -> [Id]
+instructionIds = fmap snd
 
 -- | HIDE
 buildKey : Batch -> Id -> InstructionKey

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -98,12 +98,15 @@ template Batch
         -- cancel instructions
         catOptionals <$> mapA (cancelInstruction . buildKey this . snd) routedStepsWithInstructionId
 
+-- | HIDE
 routedSteps : Batch -> [RoutedStep]
 routedSteps Batch {routedStepsWithInstructionId} = fst <$> routedStepsWithInstructionId
 
+-- | HIDE
 instructionIds : Batch -> [Id]
 instructionIds Batch {routedStepsWithInstructionId} = snd <$> routedStepsWithInstructionId
 
+-- | HIDE
 buildKey : Batch -> Id -> InstructionKey
 buildKey Batch {requestors; id} instructionId =
   InstructionKey with requestors; batchId = id; id = instructionId

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -42,19 +42,15 @@ template Batch
     signatory requestors
     observer settlers
 
-    let
-      (routedSteps, instructionIds) = unzip routedStepsWithInstructionId
-      buildKey instructionId = InstructionKey with requestors; batchId = id; id = instructionId
-
     interface instance Batch.I for Batch where
       view = Batch.View with
-        requestors; settlers; id; description; contextId; routedSteps; settlementTime
+        requestors; settlers; id; description; contextId; routedSteps = routedSteps this; settlementTime
       settle Batch.Settle{actors} = do
         assertMsg "actors must intersect with settlers" $
           not $ S.null $ actors `S.intersection` settlers
         -- order instructions (such that they can be executed with passthroughs)
         orderedInstructions <-
-          orderPassThroughChains . fmap (fmap buildKey) $ routedStepsWithInstructionId
+          orderPassThroughChains . fmap (fmap (buildKey this)) $ routedStepsWithInstructionId
         assertMsg "ordering must be complete" $
           length orderedInstructions == length routedStepsWithInstructionId
         -- settle
@@ -89,7 +85,7 @@ template Batch
           orderedInstructionIdsAndSettleCids =
             zip ((.id) <$> orderedInstructions) orderedSettledCids
           settledCids = fromSomeNote "All keys must exist in the map." .
-            (`M.lookup` (M.fromList orderedInstructionIdsAndSettleCids)) <$> instructionIds
+            (`M.lookup` (M.fromList orderedInstructionIdsAndSettleCids)) <$> instructionIds this
         pure $ catOptionals settledCids
       cancel Batch.Cancel{actors} = do
         let
@@ -100,7 +96,17 @@ template Batch
               Instruction.Cancel with actors
         allMustAuthorize requestors
         -- cancel instructions
-        catOptionals <$> mapA (cancelInstruction . buildKey . snd) routedStepsWithInstructionId
+        catOptionals <$> mapA (cancelInstruction . buildKey this . snd) routedStepsWithInstructionId
+
+routedSteps : Batch -> [RoutedStep]
+routedSteps Batch {routedStepsWithInstructionId} = fst <$> routedStepsWithInstructionId
+
+instructionIds : Batch -> [Id]
+instructionIds Batch {routedStepsWithInstructionId} = snd <$> routedStepsWithInstructionId
+
+buildKey : Batch -> Id -> InstructionKey
+buildKey Batch {requestors; id} instructionId =
+  InstructionKey with requestors; batchId = id; id = instructionId
 
 -- | HIDE
 -- Partially order instructions, so that pass-through chains can be executed in order.

--- a/src/main/daml/Daml/Finance/Settlement/Instruction.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Instruction.daml
@@ -244,12 +244,15 @@ template Instruction
         releasePreviousApproval this actors
         releasePreviousAllocation this actors
 
+-- | HIDE
 instructionKey : Instruction -> InstructionKey
 instructionKey Instruction {requestors; batchId; id} = InstructionKey with requestors; batchId; id
 
+-- | HIDE
 context : Instruction -> Text
 context = show . instructionKey
 
+-- | HIDE
 mustBe : Instruction -> Role -> Party -> Update ()
 mustBe Instruction{routedStep} role party = do
   let
@@ -261,25 +264,31 @@ mustBe Instruction{routedStep} role party = do
     (show party <> " must match " <> show roleParty <> "(" <> show role <> ")") $
     party == roleParty
 
+-- | HIDE
 addSignatories : HasSignatory t => t -> S.Set Party -> S.Set Party
 addSignatories this parties = parties `S.union` S.fromList (signatory this)
 
+-- | HIDE
 discloseAccount : Instruction -> AccountKey -> S.Set Party -> Update (ContractId Account.I)
 discloseAccount this@Instruction {settlers} accountKey actors = discloseAccountHelper Account.disclose (context this, settlers)
   accountKey $ addSignatories this actors
 
+-- | HIDE
 undiscloseAccount : Instruction -> AccountKey -> S.Set Party -> Update (Optional (ContractId Account.I))
 undiscloseAccount this@Instruction {settlers} accountKey actors = discloseAccountHelper Account.undisclose (context this,
   settlers) accountKey $ addSignatories this actors
 
+-- | HIDE
 disclosePledge : Instruction -> ContractId Base.I -> S.Set Party -> Update (ContractId Base.I)
 disclosePledge this@Instruction {settlers} baseCid actors = Holding.disclose @Base.I (context this, settlers) (addSignatories this
   actors) baseCid
 
+-- | HIDE
 undisclosePledge : Instruction -> ContractId Base.I -> S.Set Party -> Update (Optional (ContractId Base.I))
 undisclosePledge this@Instruction {settlers} baseCid actors = Holding.undisclose @Base.I (context this, settlers)
   (addSignatories this actors) baseCid
 
+-- | HIDE
 releasePreviousAllocation : Instruction -> Parties -> Update (Optional (ContractId Base.I))
 releasePreviousAllocation this@Instruction {allocation; signedSenders} actors = do
   let allMustAuthorize = mustAuthorizeHelper True actors
@@ -298,6 +307,7 @@ releasePreviousAllocation this@Instruction {allocation; signedSenders} actors = 
       pure None
     _ -> pure None
 
+-- | HIDE
 releasePreviousApproval : Instruction -> Parties -> Update (Optional (ContractId Account.I))
 releasePreviousApproval this@Instruction {approval; signedReceivers} actors = do
   let allMustAuthorize = mustAuthorizeHelper True actors

--- a/src/main/daml/Daml/Finance/Settlement/Instruction.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Instruction.daml
@@ -4,7 +4,7 @@
 module Daml.Finance.Settlement.Instruction where
 
 import DA.List qualified as L (head)
-import DA.Set qualified as S (empty, fromList, intersection, isSubsetOf, null, singleton, toList, union)
+import DA.Set qualified as S (Set, empty, fromList, intersection, isSubsetOf, null, singleton, toList, union)
 import Daml.Finance.Interface.Account.Account qualified as Account (Credit(..), Debit(..), I, R, disclose, exerciseInterfaceByKey, undisclose)
 import Daml.Finance.Interface.Account.Util (getAccount)
 import Daml.Finance.Interface.Holding.Base qualified as Base (I)
@@ -52,54 +52,8 @@ template Instruction
     signatory requestors, signedSenders, signedReceivers
     observer routedStep.sender, routedStep.receiver, settlers, Disclosure.flattenObservers observers
 
-    key instructionKey : InstructionKey
+    key instructionKey this : InstructionKey
     maintainer key.requestors
-
-    let
-      instructionKey = InstructionKey with requestors; batchId; id
-      context = show instructionKey
-      mustBe role party = do
-        let
-          roleParty = case role of
-            Custodian -> routedStep.custodian
-            Sender -> routedStep.sender
-            Receiver -> routedStep.receiver
-        assertMsg @Update
-          (show party <> " must match " <> show roleParty <> "(" <> show role <> ")") $
-          party == roleParty
-      addSignatories parties = parties `S.union` S.fromList (signatory this)
-      discloseAccount accountKey actors = discloseAccountHelper Account.disclose (context, settlers)
-        accountKey $ addSignatories actors
-      undiscloseAccount accountKey actors = discloseAccountHelper Account.undisclose (context,
-        settlers) accountKey $ addSignatories actors
-      disclosePledge baseCid actors = Holding.disclose @Base.I (context, settlers) (addSignatories
-        actors) baseCid
-      undisclosePledge baseCid actors = Holding.undisclose @Base.I (context, settlers)
-        (addSignatories actors) baseCid
-      releasePreviousAllocation actors = do
-        let allMustAuthorize = mustAuthorizeHelper True actors
-        -- signed senders must agree to release previous allocation
-        allMustAuthorize signedSenders
-        case allocation of
-          Pledge baseCid -> do
-            baseCid <- fromInterfaceContractId @Base.I <$>
-              exercise (toInterfaceContractId @Lockable.I baseCid) Lockable.Release with context
-            base <- fetch baseCid
-            let senderAccountKey = getAccount base
-            undiscloseAccount senderAccountKey actors
-            undisclosePledge baseCid actors
-          PassThroughFrom (passThroughAccountKey, _) -> do
-            undiscloseAccount passThroughAccountKey actors
-            pure None
-          _ -> pure None
-      releasePreviousApproval actors = do
-        let allMustAuthorize = mustAuthorizeHelper True actors
-        -- signed receivers must authorize to release previous approval
-        allMustAuthorize signedReceivers
-        case approval of
-          TakeDelivery receiverAccountKey -> undiscloseAccount receiverAccountKey actors
-          PassThroughTo (passThroughAccountKey, _) -> undiscloseAccount passThroughAccountKey actors
-          _ -> pure None
 
     interface instance Disclosure.I for Instruction where
       view = Disclosure.View with
@@ -117,43 +71,43 @@ template Instruction
           allMustAuthorize = mustAuthorizeHelper True actors
           atLeastOneMustAuthorize = mustAuthorizeHelper False actors
         atLeastOneMustAuthorize $ S.fromList [routedStep.custodian, routedStep.sender]
-        assertMsg ("Allocation must be new. " <> context) $ allocation /= this.allocation
-        releasedCid <- releasePreviousAllocation actors
+        assertMsg ("Allocation must be new. " <> context this) $ allocation /= this.allocation
+        releasedCid <- releasePreviousAllocation this actors
         -- allocate
         newAllocation <- case allocation of
           Pledge baseCid -> do
-            baseCid <- disclosePledge baseCid actors
+            baseCid <- disclosePledge this baseCid actors
             base <- fetch baseCid
             let senderAccountKey = getAccount base
             senderAccount <- view <$> fetchInterfaceByKey @Account.R @Account.I senderAccountKey
-            discloseAccount senderAccountKey actors
+            discloseAccount this senderAccountKey actors
             allMustAuthorize senderAccount.controllers.outgoing
-            mustBe Custodian senderAccount.custodian
-            mustBe Sender senderAccount.owner
-            assertMsg ("Pledged amount must match. " <> context) $
+            mustBe this Custodian senderAccount.custodian
+            mustBe this Sender senderAccount.owner
+            assertMsg ("Pledged amount must match. " <> context this) $
               Holding.getAmount base == routedStep.quantity.amount
-            assertMsg ("Pledged instrument must match. " <> context) $
+            assertMsg ("Pledged instrument must match. " <> context this) $
               Holding.getInstrument base == routedStep.quantity.unit
             baseCid <- fromInterfaceContractId @Base.I <$>
               exercise (toInterfaceContractId @Lockable.I baseCid)
                 Lockable.Acquire with
                   newLockers = requestors <> senderAccount.controllers.outgoing
-                  context
+                  context = context this
                   lockType = Lockable.Semaphore
             pure $ Pledge baseCid
           PassThroughFrom (passThroughAccountKey, fromInstructionKey) -> do
-            discloseAccount passThroughAccountKey actors
+            discloseAccount this passThroughAccountKey actors
             passThroughAccount <- view <$>
               fetchInterfaceByKey @Account.R @Account.I passThroughAccountKey
             allMustAuthorize passThroughAccount.controllers.incoming
             allMustAuthorize passThroughAccount.controllers.outgoing
-            mustBe Custodian passThroughAccount.custodian
-            mustBe Sender passThroughAccount.owner
+            mustBe this Custodian passThroughAccount.custodian
+            mustBe this Sender passThroughAccount.owner
             fromInstruction <- snd <$> fetchByKey @Instruction fromInstructionKey
-            assertMsg ("Pass-through-from instruction must be part of the batch. " <> context) $
+            assertMsg ("Pass-through-from instruction must be part of the batch. " <> context this) $
               fromInstruction.batchId == batchId && fromInstruction.requestors == requestors
-            mustBe Custodian fromInstruction.routedStep.custodian
-            mustBe Sender fromInstruction.routedStep.receiver
+            mustBe this Custodian fromInstruction.routedStep.custodian
+            mustBe this Sender fromInstruction.routedStep.receiver
             pure allocation
           CreditReceiver -> do
             allMustAuthorize $ S.singleton routedStep.custodian
@@ -172,32 +126,32 @@ template Instruction
           allMustAuthorize = mustAuthorizeHelper True actors
           atLeastOneMustAuthorize = mustAuthorizeHelper False actors
         atLeastOneMustAuthorize $ S.fromList [routedStep.custodian, routedStep.receiver]
-        assertMsg ("Approval must be new. " <> context) $ approval /= this.approval
-        releasePreviousApproval actors
+        assertMsg ("Approval must be new. " <> context this) $ approval /= this.approval
+        releasePreviousApproval this actors
         -- approve
         case approval of
           TakeDelivery receiverAccountKey -> do
-            discloseAccount receiverAccountKey actors
+            discloseAccount this receiverAccountKey actors
             receiverAccount <- view <$> fetchInterfaceByKey @Account.R @Account.I receiverAccountKey
             allMustAuthorize receiverAccount.controllers.incoming
-            mustBe Custodian receiverAccount.custodian
-            mustBe Receiver receiverAccount.owner
+            mustBe this Custodian receiverAccount.custodian
+            mustBe this Receiver receiverAccount.owner
           PassThroughTo (passThroughAccountKey, toInstructionKey) -> do
-            discloseAccount passThroughAccountKey actors
+            discloseAccount this passThroughAccountKey actors
             passThroughAccount <- view <$> fetchInterfaceByKey @Account.R @Account.I
               passThroughAccountKey
             allMustAuthorize passThroughAccount.controllers.incoming
             allMustAuthorize passThroughAccount.controllers.outgoing
-            mustBe Custodian passThroughAccount.custodian
-            mustBe Receiver passThroughAccount.owner
+            mustBe this Custodian passThroughAccount.custodian
+            mustBe this Receiver passThroughAccount.owner
             toInstruction <- snd <$> fetchByKey @Instruction toInstructionKey
-            assertMsg ("Pass-through-to instruction must be part of the batch. " <> context) $
+            assertMsg ("Pass-through-to instruction must be part of the batch. " <> context this) $
               toInstruction.batchId == batchId && toInstruction.requestors == requestors
-            mustBe Custodian toInstruction.routedStep.custodian
-            mustBe Receiver toInstruction.routedStep.sender
+            mustBe this Custodian toInstruction.routedStep.custodian
+            mustBe this Receiver toInstruction.routedStep.sender
           DebitSender -> do
             allMustAuthorize $ S.singleton routedStep.custodian
-            mustBe Custodian routedStep.receiver
+            mustBe this Custodian routedStep.receiver
           SettleOffledgerAcknowledge ->
             allMustAuthorize $ S.fromList [routedStep.custodian, routedStep.receiver]
           Unapproved -> pure ()
@@ -207,24 +161,24 @@ template Instruction
       execute Instruction.Execute{actors} = do
         let allMustAuthorize = mustAuthorizeHelper True actors
         allMustAuthorize requestors
-        assertMsg ("Actors must intersect with settlers. " <> context) $
+        assertMsg ("Actors must intersect with settlers. " <> context this) $
           not $ S.null $ actors `S.intersection` settlers
         let
-          abortUnapproved = abort $ "Instruction must be approved. " <> context
+          abortUnapproved = abort $ "Instruction must be approved. " <> context this
           abortOnOffledgerMix =
-            abort $ "Mix of on- and off-ledger settlement is not supported. " <> context
+            abort $ "Mix of on- and off-ledger settlement is not supported. " <> context this
         -- execute
         case (allocation, approval) of
           (Unallocated, Unapproved) ->
-            abort $ "Instruction must be allocated and approved. " <> context
-          (Unallocated, _) -> abort $ "Instruction must be allocated. " <> context
+            abort $ "Instruction must be allocated and approved. " <> context this
+          (Unallocated, _) -> abort $ "Instruction must be allocated. " <> context this
           (_, Unapproved) -> abortUnapproved
           (PassThroughFrom _, _) -> do
             -- Pass-throughs are consumed by the routedStep (*) below
-            abort $ "Holding has not been passed through. " <> context
+            abort $ "Holding has not been passed through. " <> context this
           (Pledge baseCid, a) -> do
             baseCid <- fromInterfaceContractId @Base.I <$>
-              exercise (toInterfaceContractId @Lockable.I baseCid) Lockable.Release with context
+              exercise (toInterfaceContractId @Lockable.I baseCid) Lockable.Release with context = context this
             base <- fetch baseCid
             let senderAccountKey = getAccount base
             case a of
@@ -234,14 +188,14 @@ template Instruction
                   exercise transferableCid Transferable.Transfer with
                     actors = signedSenders <> signedReceivers; newOwnerAccount = receiverAccountKey
                 -- undisclose accounts
-                undiscloseAccount senderAccountKey actors
-                undiscloseAccount receiverAccountKey actors
+                undiscloseAccount this senderAccountKey actors
+                undiscloseAccount this receiverAccountKey actors
                 -- disclose to settlers (such that they can get the TemplateTypeRep in the Batch)
-                Some <$> disclosePledge newBaseCid actors
+                Some <$> disclosePledge this newBaseCid actors
               DebitSender -> do
                 Account.exerciseInterfaceByKey @Account.I senderAccountKey routedStep.custodian
                   Account.Debit with holdingCid = baseCid
-                undiscloseAccount senderAccountKey actors
+                undiscloseAccount this senderAccountKey actors
                 pure None
               PassThroughTo (passThroughAccountKey, toInstructionKey) -> do
                 let transferableCid = fromInterfaceContractId @Transferable.I baseCid
@@ -251,33 +205,33 @@ template Instruction
                     newOwnerAccount = passThroughAccountKey
                 (toInstructionCid, toInstruction) <- fetchByKey @Instruction toInstructionKey
                 assertMsg ("The pass-through process must be compatible between the origin and " <>
-                  "destination endpoints. " <> context) $
+                  "destination endpoints. " <> context this) $
                   toInstruction.allocation == PassThroughFrom (passThroughAccountKey, key this)
                 -- (*) in case of a pass-through, the newly created holding is immediately allocated
                 -- to the next routedStep
                 exercise (toInterfaceContractId @Instruction.I toInstructionCid)
                   Instruction.Allocate with
                     actors = signedSenders <> signedReceivers; allocation = Pledge baseCid
-                undiscloseAccount senderAccountKey actors
-                undiscloseAccount passThroughAccountKey actors
+                undiscloseAccount this senderAccountKey actors
+                undiscloseAccount this passThroughAccountKey actors
                 pure None
               SettleOffledgerAcknowledge -> abortOnOffledgerMix
               Unapproved -> abortUnapproved
           (CreditReceiver, a) ->
             case a of
               TakeDelivery receiverAccountKey -> do
-                mustBe Custodian routedStep.sender
+                mustBe this Custodian routedStep.sender
                 baseCid <- Account.exerciseInterfaceByKey @Account.I receiverAccountKey
                   routedStep.custodian Account.Credit with quantity = routedStep.quantity
-                undiscloseAccount receiverAccountKey actors
+                undiscloseAccount this receiverAccountKey actors
                 -- disclose to actors (such that they can get the TemplateTypeRep in the Batch)
-                Some <$> disclosePledge baseCid actors
+                Some <$> disclosePledge this baseCid actors
               DebitSender -> do
-                assertMsg ("Sender must be the same party as receiver. " <> context) $
+                assertMsg ("Sender must be the same party as receiver. " <> context this) $
                   routedStep.sender == routedStep.receiver
                 pure None
               PassThroughTo _ -> abort $
-                "Credit-receiver and pass-through-to combination is not supported. " <> context
+                "Credit-receiver and pass-through-to combination is not supported. " <> context this
               SettleOffledgerAcknowledge -> abortOnOffledgerMix
               Unapproved -> abortUnapproved
           (SettleOffledger, a) ->
@@ -287,8 +241,72 @@ template Instruction
       cancel Instruction.Cancel{actors} = do
         let allMustAuthorize = mustAuthorizeHelper True actors
         allMustAuthorize requestors
-        releasePreviousApproval actors
-        releasePreviousAllocation actors
+        releasePreviousApproval this actors
+        releasePreviousAllocation this actors
+
+instructionKey : Instruction -> InstructionKey
+instructionKey Instruction {requestors; batchId; id} = InstructionKey with requestors; batchId; id
+
+context : Instruction -> Text
+context = show . instructionKey
+
+mustBe : Instruction -> Role -> Party -> Update ()
+mustBe Instruction{routedStep} role party = do
+  let
+    roleParty = case role of
+      Custodian -> routedStep.custodian
+      Sender -> routedStep.sender
+      Receiver -> routedStep.receiver
+  assertMsg @Update
+    (show party <> " must match " <> show roleParty <> "(" <> show role <> ")") $
+    party == roleParty
+
+addSignatories : HasSignatory t => t -> S.Set Party -> S.Set Party
+addSignatories this parties = parties `S.union` S.fromList (signatory this)
+
+discloseAccount : Instruction -> AccountKey -> S.Set Party -> Update (ContractId Account.I)
+discloseAccount this@Instruction {settlers} accountKey actors = discloseAccountHelper Account.disclose (context this, settlers)
+  accountKey $ addSignatories this actors
+
+undiscloseAccount : Instruction -> AccountKey -> S.Set Party -> Update (Optional (ContractId Account.I))
+undiscloseAccount this@Instruction {settlers} accountKey actors = discloseAccountHelper Account.undisclose (context this,
+  settlers) accountKey $ addSignatories this actors
+
+disclosePledge : Instruction -> ContractId Base.I -> S.Set Party -> Update (ContractId Base.I)
+disclosePledge this@Instruction {settlers} baseCid actors = Holding.disclose @Base.I (context this, settlers) (addSignatories this
+  actors) baseCid
+
+undisclosePledge : Instruction -> ContractId Base.I -> S.Set Party -> Update (Optional (ContractId Base.I))
+undisclosePledge this@Instruction {settlers} baseCid actors = Holding.undisclose @Base.I (context this, settlers)
+  (addSignatories this actors) baseCid
+
+releasePreviousAllocation : Instruction -> Parties -> Update (Optional (ContractId Base.I))
+releasePreviousAllocation this@Instruction {allocation; signedSenders} actors = do
+  let allMustAuthorize = mustAuthorizeHelper True actors
+  -- signed senders must agree to release previous allocation
+  allMustAuthorize signedSenders
+  case allocation of
+    Pledge baseCid -> do
+      baseCid <- fromInterfaceContractId @Base.I <$>
+        exercise (toInterfaceContractId @Lockable.I baseCid) Lockable.Release with context = context this
+      base <- fetch baseCid
+      let senderAccountKey = getAccount base
+      undiscloseAccount this senderAccountKey actors
+      undisclosePledge this baseCid actors
+    PassThroughFrom (passThroughAccountKey, _) -> do
+      undiscloseAccount this passThroughAccountKey actors
+      pure None
+    _ -> pure None
+
+releasePreviousApproval : Instruction -> Parties -> Update (Optional (ContractId Account.I))
+releasePreviousApproval this@Instruction {approval; signedReceivers} actors = do
+  let allMustAuthorize = mustAuthorizeHelper True actors
+  -- signed receivers must authorize to release previous approval
+  allMustAuthorize signedReceivers
+  case approval of
+    TakeDelivery receiverAccountKey -> undiscloseAccount this receiverAccountKey actors
+    PassThroughTo (passThroughAccountKey, _) -> undiscloseAccount this passThroughAccountKey actors
+    _ -> pure None
 
 -- | HIDE
 data Role


### PR DESCRIPTION
This is necessary because template-local let bindings will be deprecated soon (https://github.com/digital-asset/daml/issues/17262)

Fixes #998 