### PR TITLE
Improve schedule rollout logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,3 +201,5 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 - Added a `Lockable` module containing the `aquireImpl` and `releaseImpl` locking utitlity
   functions.
+
+- Fix a bug in the schedule roll-out logic

--- a/src/main/daml/Daml/Finance/Util/Date/RollConvention.daml
+++ b/src/main/daml/Daml/Finance/Util/Date/RollConvention.daml
@@ -25,13 +25,14 @@ next date period EOM
   where
     (y, m, d) = toGregorian date
 next date period (DOM rollDay)
-  | d /= rollDay && (m /= Feb || d /= monthDayCount y m || d > rollDay) =
+  | d /= rollDay && (d /= monthDayCount y m || d > rollDay) =
       error $ "day " <> show d <> " does not match roll convention DOM " <> show rollDay
   | otherwise =
-      let (yEnd, mEnd, dEnd) = toGregorian $ addPeriod date period
-      in if mEnd == Feb && rollDay >= 29
-         then D.date yEnd mEnd (monthDayCount yEnd mEnd)
-         else D.date yEnd mEnd rollDay
+      let
+        (yEnd, mEnd, dEnd) = toGregorian $ addPeriod date period
+        eomEnd = monthDayCount yEnd mEnd 
+      in
+        D.date yEnd mEnd $ min rollDay eomEnd
   where
     (y, m, d) = toGregorian date
 

--- a/src/test/daml/Daml/Finance/Util/Test/Date/RollConvention.daml
+++ b/src/test/daml/Daml/Finance/Util/Test/Date/RollConvention.daml
@@ -32,11 +32,61 @@ test_next = script do
     D.date 2018 Nov 30
   next (D.date 2018 Oct 01) (Period with periodMultiplier = 1; period = M) (DOM 1) ===
     D.date 2018 Nov 01
+  next (D.date 2018 Oct 31) (Period with periodMultiplier = 1; period = M) (DOM 31) ===
+    D.date 2018 Nov 30
+  next (D.date 2018 Nov 30) (Period with periodMultiplier = 1; period = M) (DOM 30) ===
+    D.date 2018 Dec 30
+  next (D.date 2018 Nov 30) (Period with periodMultiplier = 1; period = M) (DOM 31) ===
+    D.date 2018 Dec 31
+
+  -- from end of February
   next (D.date 2018 Feb 28) (Period with periodMultiplier = 3; period = M) (DOM 30) ===
     D.date 2018 May 30
+  next (D.date 2018 Feb 28) (Period with periodMultiplier = 3; period = M) (DOM 31) ===
+    D.date 2018 May 31
+  next (D.date 2018 Feb 28) (Period with periodMultiplier = 9; period = M) (DOM 30) ===
+    D.date 2018 Nov 30
+  next (D.date 2018 Feb 28) (Period with periodMultiplier = 9; period = M) (DOM 31) ===
+    D.date 2018 Nov 30
   next (D.date 2018 Feb 28) (Period with periodMultiplier = 3; period = M) EOM ===
     D.date 2018 May 31
   next (D.date 2018 Feb 28) (Period with periodMultiplier = 2; period = M) EOM ===
     D.date 2018 Apr 30
   next (D.date 2018 Nov 30) (Period with periodMultiplier = 3; period = M) (DOM 30) ===
     D.date 2019 Feb 28
+  next (D.date 2018 Feb 28) (Period with periodMultiplier = 2; period = Y) (DOM 28) ===
+    D.date 2020 Feb 28
+  next (D.date 2018 Feb 28) (Period with periodMultiplier = 2; period = Y) (DOM 29) ===
+    D.date 2020 Feb 29
+  next (D.date 2018 Feb 28) (Period with periodMultiplier = 2; period = Y) (DOM 30) ===
+    D.date 2020 Feb 29
+  next (D.date 2018 Feb 28) (Period with periodMultiplier = 2; period = Y) (DOM 31) ===
+    D.date 2020 Feb 29
+  next (D.date 2018 Feb 28) (Period with periodMultiplier = 2; period = Y) EOM ===
+    D.date 2020 Feb 29
+  next (D.date 2020 Feb 28) (Period with periodMultiplier = 1; period = Y) (DOM 28) ===
+    D.date 2021 Feb 28
+  next (D.date 2020 Feb 29) (Period with periodMultiplier = 1; period = Y) (DOM 29) ===
+    D.date 2021 Feb 28
+  next (D.date 2020 Feb 29) (Period with periodMultiplier = 3; period = M) (DOM 29) ===
+    D.date 2020 May 29
+  next (D.date 2020 Feb 29) (Period with periodMultiplier = 3; period = M) (DOM 30) ===
+    D.date 2020 May 30
+  next (D.date 2020 Feb 29) (Period with periodMultiplier = 3; period = M) (DOM 31) ===
+    D.date 2020 May 31
+  next (D.date 2020 Feb 29) (Period with periodMultiplier = 3; period = M) EOM ===
+    D.date 2020 May 31
+
+  -- to end of February
+  next (D.date 2018 Nov 30) (Period with periodMultiplier = 3; period = M) (DOM 30) ===
+    D.date 2019 Feb 28
+  next (D.date 2018 Nov 30) (Period with periodMultiplier = 3; period = M) (DOM 31) ===
+    D.date 2019 Feb 28
+  next (D.date 2018 Aug 31) (Period with periodMultiplier = 6; period = M) (DOM 31) ===
+    D.date 2019 Feb 28
+  next (D.date 2019 Nov 30) (Period with periodMultiplier = 3; period = M) (DOM 30) ===
+    D.date 2020 Feb 29
+  next (D.date 2019 Nov 30) (Period with periodMultiplier = 3; period = M) (DOM 31) ===
+    D.date 2020 Feb 29
+  next (D.date 2019 Aug 31) (Period with periodMultiplier = 6; period = M) (DOM 31) ===
+    D.date 2020 Feb 29


### PR DESCRIPTION
This PR fixes the previously broken behaviour when using `DOM 31` as roll convention.

Fixes https://github.com/digital-asset/daml-finance/issues/1006
