### PR TITLE
Relaxed the settlement consistency check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,9 +197,16 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 - Dependencies update
 
+- The check for consistent settled holdings has changed. Now, holdings of the same instrument don't
+  need identical `templateTypeRep`. Instead, they should share the same token standard: `Fungible`,
+  `NonFungible`, or `NonTransferable` (implementation variations are allowed).
+
 ### Daml.Finance.Util
 
 - Added a `Lockable` module containing the `aquireImpl` and `releaseImpl` locking utitlity
   functions.
 
 - Fix a bug in the schedule roll-out logic
+
+- Added the `isInstanceOf` utility function which checks whether an interface instance is
+  convertible to another interface or template.

--- a/package/test/daml/Daml.Finance.Test.Util/daml.yaml
+++ b/package/test/daml/Daml.Finance.Test.Util/daml.yaml
@@ -13,6 +13,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Account/2.0.1/daml-finance-account-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Claims/2.0.1/daml-finance-claims-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Holding/2.0.1/daml-finance-holding-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Instrument.Token/2.0.1/daml-finance-instrument-token-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.1/daml-finance-interface-account-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.1/daml-finance-interface-holding-2.0.1.dar
@@ -23,5 +24,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.1/daml-finance-interface-types-date-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/2.0.1/daml-finance-lifecycle-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar
 build-options: null
 

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -101,7 +101,7 @@ template Batch
         catOptionals <$> mapA (cancelInstruction . buildKey this . snd) routedStepsWithInstructionId
 
 -- Type of holdings that can be settled as part of a settlement batch.
-data TokenStandard
+data HoldingStandard
   = NonTransferable
     -- ^ Represents a token that implements Base.I but not Transferable.I.
   | NonFungible

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -5,18 +5,22 @@ module Daml.Finance.Settlement.Batch where
 
 import DA.Action (foldlA)
 import DA.Foldable (forA_)
-import DA.Optional (catOptionals, fromOptional, fromSomeNote)
+import DA.List qualified as L (singleton)
+import DA.Map qualified as M (fromList, lookup)
+import DA.Optional (catOptionals, fromSomeNote, optionalToList)
 import DA.Set (Set)
 import DA.Set qualified as S (empty, fromList, insert, intersection, member, null, size, union)
 import DA.Traversable qualified as T
+import Daml.Finance.Interface.Holding.Base qualified as Base (I)
+import Daml.Finance.Interface.Holding.Fungible qualified as Fungible (I)
+import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I)
 import Daml.Finance.Interface.Holding.Util (undisclose)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Cancel(..), I, Settle(..), View(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Cancel(..), Execute(..), I)
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), InstructionKey(..), RoutedStep(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..), Parties)
 import Daml.Finance.Settlement.Instruction (Instruction(..), mustAuthorizeHelper)
-import Daml.Finance.Util.Common (sortAndGroupOn)
-import DA.Map qualified as M (fromList, lookup)
+import Daml.Finance.Util.Common (isInstanceOf, sortAndGroupOn)
 
 -- | Type synonym for `Batch`.
 type T = Batch
@@ -57,28 +61,26 @@ template Batch
         let
           settleInstruction instructionKey = do
             let context = show instructionKey
+            -- execute instruction and get used token standards for the instrument
             (instructionCid, instruction) <- fetchByKey @Instruction instructionKey
-            pledged <- case instruction.allocation of
-              Pledge cid -> Some <$> fetch cid
-              _ -> pure None
+            pledgedTokenStandard <- case instruction.allocation of
+              Pledge cid -> L.singleton <$> getTokenStandard cid
+              _ -> pure []
             settledCid <- exercise (toInterfaceContractId @Instruction.I instructionCid)
               Instruction.Execute with actors = actors `S.union` requestors
-            settled <- T.mapA fetch settledCid
+            settledTokenStandard <- optionalToList <$> T.mapA getTokenStandard settledCid
+
             let
-              usedInterfaceTypeReps =
-                fmap ((instruction.routedStep.quantity.unit, ) . interfaceTypeRep) <$>
-                [pledged, settled]
-            settledCid <-
-              T.mapA
-                (\cid -> fromOptional cid <$> undisclose (context, settlers) actors cid)
-                settledCid
-            pure (settledCid, usedInterfaceTypeReps)
+              instrumentWithTokenStandards = fmap ((instruction.routedStep.quantity.unit, )) $
+                settledTokenStandard <> pledgedTokenStandard
+            settledCid <- join <$> T.mapA (undisclose (context, settlers) actors) settledCid
+            pure (settledCid, instrumentWithTokenStandards)
         -- execute instructions
-        (orderedSettledCids, usedInterfaceTypeReps) <-
-          unzip <$> mapA settleInstruction orderedInstructions
-        -- consistency check
-        forA_ (sortAndGroupOn fst $ catOptionals =<< usedInterfaceTypeReps)
-          \ts -> assertMsg "Same instrument's holdings must have same template type."
+        (orderedSettledCids, instrumentWithTokenStandards) <-
+          fmap concat . unzip <$> mapA settleInstruction orderedInstructions
+        -- assert consistent token standard for each instrument
+        forA_ (sortAndGroupOn fst instrumentWithTokenStandards)
+          \ts -> assertMsg "Each instrument must use a consistent token standard."
             $ S.size (S.fromList ts) == 1
         -- order returned settledCids according to the initial order of the instructions
         let
@@ -97,6 +99,27 @@ template Batch
         allMustAuthorize requestors
         -- cancel instructions
         catOptionals <$> mapA (cancelInstruction . buildKey this . snd) routedStepsWithInstructionId
+
+-- Various token standards.
+data TokenStandard
+  = NonTransferable
+    -- ^ Represents a token that implements Base.I but not Transferable.I.
+  | NonFungible
+    -- ^ Represents a token that implements Transferable.I but not Transferable.I.
+  | Fungible
+    -- ^ Represents a token that implements Fungible.I.
+  deriving (Eq, Ord)
+
+-- | HIDE
+-- Returns the token standard of a holding.
+getTokenStandard : ContractId Base.I -> Update TokenStandard
+getTokenStandard cid = do
+  implementsFungible <- isInstanceOf @Fungible.I cid
+  if implementsFungible then
+    pure Fungible
+  else do
+    implementsTransferable <- isInstanceOf @Transferable.I cid
+    pure $ if implementsTransferable then NonFungible else NonTransferable
 
 -- | HIDE
 routedSteps : [(RoutedStep, Id)] -> [RoutedStep]

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -61,26 +61,26 @@ template Batch
         let
           settleInstruction instructionKey = do
             let context = show instructionKey
-            -- execute instruction and get used token standards for the instrument
+            -- execute instruction and get used holding standards for the instrument
             (instructionCid, instruction) <- fetchByKey @Instruction instructionKey
-            pledgedTokenStandard <- case instruction.allocation of
-              Pledge cid -> L.singleton <$> getTokenStandard cid
+            pledgedHoldingStandard <- case instruction.allocation of
+              Pledge cid -> L.singleton <$> getHoldingStandard cid
               _ -> pure []
             settledCid <- exercise (toInterfaceContractId @Instruction.I instructionCid)
               Instruction.Execute with actors = actors `S.union` requestors
-            settledTokenStandard <- optionalToList <$> T.mapA getTokenStandard settledCid
+            settledHoldingStandard <- optionalToList <$> T.mapA getHoldingStandard settledCid
 
             let
-              instrumentWithTokenStandards = fmap ((instruction.routedStep.quantity.unit, )) $
-                settledTokenStandard <> pledgedTokenStandard
+              instrumentWithHoldingStandards = fmap ((instruction.routedStep.quantity.unit, )) $
+                settledHoldingStandard <> pledgedHoldingStandard
             settledCid <- join <$> T.mapA (undisclose (context, settlers) actors) settledCid
-            pure (settledCid, instrumentWithTokenStandards)
+            pure (settledCid, instrumentWithHoldingStandards)
         -- execute instructions
-        (orderedSettledCids, instrumentWithTokenStandards) <-
+        (orderedSettledCids, instrumentWithHoldingStandards) <-
           fmap concat . unzip <$> mapA settleInstruction orderedInstructions
-        -- assert consistent token standard for each instrument
-        forA_ (sortAndGroupOn fst instrumentWithTokenStandards)
-          \ts -> assertMsg "Each instrument must use a consistent token standard."
+        -- assert consistent holding standard for each instrument
+        forA_ (sortAndGroupOn fst instrumentWithHoldingStandards)
+          \ts -> assertMsg "Each instrument must settle with a consistent holding standard."
             $ S.size (S.fromList ts) == 1
         -- order returned settledCids according to the initial order of the instructions
         let
@@ -105,14 +105,14 @@ data HoldingStandard
   = NonTransferable
     -- ^ Represents a holding that implements Base.I but not Transferable.I.
   | NonFungible
-    -- ^ Represents a token that implements Transferable.I but not Fungible.I.
+    -- ^ Represents a holding that implements Transferable.I but not Fungible.I.
   | Fungible
-    -- ^ Represents a token that implements Fungible.I.
+    -- ^ Represents a holding that implements Fungible.I.
   deriving (Eq, Ord)
 
--- Returns the token standard of a holding.
-getTokenStandard : ContractId Base.I -> Update TokenStandard
-getTokenStandard cid = do
+-- Returns the holding standard of a holding.
+getHoldingStandard : ContractId Base.I -> Update HoldingStandard
+getHoldingStandard cid = do
   implementsFungible <- isInstanceOf @Fungible.I cid
   if implementsFungible then
     pure Fungible

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -48,14 +48,15 @@ template Batch
 
     interface instance Batch.I for Batch where
       view = Batch.View with
-        requestors; settlers; id; description; contextId; routedSteps = routedSteps this.routedStepsWithInstructionId; settlementTime
+        requestors; settlers; id; description; contextId
+        routedSteps = routedSteps this.routedStepsWithInstructionId; settlementTime
       settle Batch.Settle{actors} = do
-        assertMsg "actors must intersect with settlers" $
+        assertMsg "Actors must intersect with settlers." $
           not $ S.null $ actors `S.intersection` settlers
         -- order instructions (such that they can be executed with passthroughs)
         orderedInstructions <-
           orderPassThroughChains . fmap (fmap (buildKey this)) $ routedStepsWithInstructionId
-        assertMsg "ordering must be complete" $
+        assertMsg "Ordering must be complete." $
           length orderedInstructions == length routedStepsWithInstructionId
         -- settle
         let
@@ -87,7 +88,8 @@ template Batch
           orderedInstructionIdsAndSettleCids =
             zip ((.id) <$> orderedInstructions) orderedSettledCids
           settledCids = fromSomeNote "All keys must exist in the map." .
-            (`M.lookup` (M.fromList orderedInstructionIdsAndSettleCids)) <$> instructionIds this.routedStepsWithInstructionId
+            (`M.lookup` (M.fromList orderedInstructionIdsAndSettleCids)) <$>
+            instructionIds this.routedStepsWithInstructionId
         pure $ catOptionals settledCids
       cancel Batch.Cancel{actors} = do
         let
@@ -145,7 +147,7 @@ orderPassThroughChains routedStepsWithInstructions =
         pure (ordered, used)
       else do
         currentInstruction <- snd <$> fetchByKey @Instruction current
-        assertMsg "routed step must match" $ routedStep == currentInstruction.routedStep
+        assertMsg "Routed step must match." $ routedStep == currentInstruction.routedStep
         let
           ordered' = current :: ordered
           used' = S.insert current used
@@ -168,6 +170,6 @@ collectPassThroughChain
     case currentInstruction.approval of
       PassThroughTo (_, next) -> do
         nextInstruction <- snd <$> fetchByKey @Instruction next
-        assertMsg "next instruction must not have been used before" . not $ S.member next used
+        assertMsg "Next instruction must not have been used before." . not $ S.member next used
         collectPassThroughChain (next :: ordered) (S.insert next used) nextInstruction
       _ -> pure (ordered, used)

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -100,7 +100,7 @@ template Batch
         -- cancel instructions
         catOptionals <$> mapA (cancelInstruction . buildKey this . snd) routedStepsWithInstructionId
 
--- Various token standards.
+-- Type of holdings that can be settled as part of a settlement batch.
 data TokenStandard
   = NonTransferable
     -- ^ Represents a token that implements Base.I but not Transferable.I.

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -105,7 +105,7 @@ data TokenStandard
   = NonTransferable
     -- ^ Represents a token that implements Base.I but not Transferable.I.
   | NonFungible
-    -- ^ Represents a token that implements Transferable.I but not Transferable.I.
+    -- ^ Represents a token that implements Transferable.I but not Fungible.I.
   | Fungible
     -- ^ Represents a token that implements Fungible.I.
   deriving (Eq, Ord)

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -110,7 +110,6 @@ data TokenStandard
     -- ^ Represents a token that implements Fungible.I.
   deriving (Eq, Ord)
 
--- | HIDE
 -- Returns the token standard of a holding.
 getTokenStandard : ContractId Base.I -> Update TokenStandard
 getTokenStandard cid = do

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -103,7 +103,7 @@ template Batch
 -- Type of holdings that can be settled as part of a settlement batch.
 data HoldingStandard
   = NonTransferable
-    -- ^ Represents a token that implements Base.I but not Transferable.I.
+    -- ^ Represents a holding that implements Base.I but not Transferable.I.
   | NonFungible
     -- ^ Represents a token that implements Transferable.I but not Fungible.I.
   | Fungible

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -71,7 +71,7 @@ template Batch
             settledHoldingStandard <- optionalToList <$> T.mapA getHoldingStandard settledCid
 
             let
-              instrumentWithHoldingStandards = fmap ((instruction.routedStep.quantity.unit, )) $
+              instrumentWithHoldingStandards = (instruction.routedStep.quantity.unit, ) <$>
                 settledHoldingStandard <> pledgedHoldingStandard
             settledCid <- join <$> T.mapA (undisclose (context, settlers) actors) settledCid
             pure (settledCid, instrumentWithHoldingStandards)

--- a/src/main/daml/Daml/Finance/Util/Common.daml
+++ b/src/main/daml/Daml/Finance/Util/Common.daml
@@ -1,9 +1,12 @@
 -- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
 module Daml.Finance.Util.Common where
 
 import DA.List qualified as L (groupOn, null, sortOn)
+import DA.Optional (isSome)
 
 -- | Checks if the input list is not empty.
 notNull : [a] -> Bool
@@ -12,3 +15,7 @@ notNull = not . L.null
 -- | Like `List.groupOn`, but sorts the list first.
 sortAndGroupOn : Ord k => (a -> k) -> [a] -> [[a]]
 sortAndGroupOn f = L.groupOn f . L.sortOn f
+
+-- | Checks if an interface instance can be converted to another interface/template.
+isInstanceOf : forall i2 i1. (HasFromInterface i2 i1, HasFetch i1) => ContractId i1 -> Update Bool
+isInstanceOf cid = isSome <$> fetchFromInterface @i2 cid

--- a/src/test/daml/Daml/Finance/Settlement/Test/BatchWithIntermediaries.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/BatchWithIntermediaries.daml
@@ -8,6 +8,7 @@ import DA.Map qualified as M (fromList)
 import DA.Set qualified as S (empty, fromList, singleton)
 import DA.Time (time)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
+import Daml.Finance.Holding.NonFungible qualified as NonFungible (Factory(..))
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Factory qualified as Settlement (F, Instruct(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
@@ -20,6 +21,7 @@ import Daml.Finance.Settlement.Hierarchy (Hierarchy(..))
 import Daml.Finance.Settlement.RouteProvider.IntermediatedStatic (IntermediatedStatic(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
+import Daml.Finance.Test.Util.FungibleV2 qualified as FungibleV2 (Factory(..))
 import Daml.Finance.Test.Util.Holding qualified as Holding (verifyNoObservers, verifyOwnerOfHolding)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Script
@@ -65,25 +67,25 @@ run : Bool -> Script ()
 run settleWithOwnAccount = script do
   TestParties{..} <- setupParties
 
-  -- Setup security accounts
+  -- Setup security accounts (utilising non-fungible tokens)
   let pp = [("PublicParty", S.singleton publicParty)]
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory csd []
   holdingFactoryCid <- toInterfaceContractId <$> submit csd do
-    createCmd Fungible.Factory with provider = csd; observers = M.fromList pp
+    createCmd NonFungible.Factory with provider = csd; observers = M.fromList pp
   [buyerSecurityAccount, sellerSecurityAccount] <- mapA (Account.createAccount "Security Account" []
     accountFactoryCid holdingFactoryCid [] Account.Owner csd) [buyer, seller]
 
-  -- Setup cash accounts at CB
+  -- Setup cash accounts at CB (utilising fungible tokens)
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory cb []
   holdingFactoryCid <- toInterfaceContractId <$> submit cb do
     createCmd Fungible.Factory with provider = cb; observers = M.fromList pp
   [buyerCashAccount, bankCashAccount] <- mapA (Account.createAccount "Cash Account" []
     accountFactoryCid holdingFactoryCid [] Account.Owner cb) [buyer, bank]
 
-  -- Setup cash accounts at Bank
+  -- Setup cash accounts at Bank (utilising a different fungible token implementation)
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank []
   holdingFactoryCid <- toInterfaceContractId <$> submit bank do
-    createCmd Fungible.Factory with provider = bank; observers = M.fromList pp
+    createCmd FungibleV2.Factory with provider = bank; observers = M.fromList pp
   [sellerCashAccount] <- mapA (Account.createAccount "Cash Account" [] accountFactoryCid
     holdingFactoryCid [] Account.Owner bank) [seller]
 

--- a/src/test/daml/Daml/Finance/Settlement/Test/BatchWithIntermediaries.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/BatchWithIntermediaries.daml
@@ -63,8 +63,8 @@ data TestParties = TestParties
 -- |          \   /              | securities             |
 -- | Central Security Depository |                        |
 -- +-----------------------------+------------------------+
-run : Bool -> Script ()
-run settleWithOwnAccount = script do
+run : Bool -> Bool -> Script ()
+run bankAllocatesWithOwnHolding bankUsesCompatibleHoldingStandard = script do
   TestParties{..} <- setupParties
 
   -- Setup security accounts (utilising non-fungible tokens)
@@ -84,8 +84,14 @@ run settleWithOwnAccount = script do
 
   -- Setup cash accounts at Bank (utilising a different fungible token implementation)
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank []
-  holdingFactoryCid <- toInterfaceContractId <$> submit bank do
-    createCmd FungibleV2.Factory with provider = bank; observers = M.fromList pp
+  holdingFactoryCid <-
+    if bankUsesCompatibleHoldingStandard
+    then
+      toInterfaceContractId <$> submit bank do
+        createCmd FungibleV2.Factory with provider = bank; observers = M.fromList pp
+    else
+      toInterfaceContractId <$> submit bank do
+        createCmd NonFungible.Factory with provider = bank; observers = M.fromList pp
   [sellerCashAccount] <- mapA (Account.createAccount "Cash Account" [] accountFactoryCid
     holdingFactoryCid [] Account.Owner bank) [seller]
 
@@ -135,7 +141,7 @@ run settleWithOwnAccount = script do
     exerciseCmd cashInstruction1Cid
       Instruction.Allocate with actors = S.singleton buyer; allocation = Pledge buyerCashHoldingCid
   (cashInstruction2Cid, _) <-
-    if settleWithOwnAccount then
+    if bankAllocatesWithOwnHolding then
       do
         ownCashAccount <- Account.createAccount "Own Cash Account" [] accountFactoryCid
           holdingFactoryCid [] Account.Owner bank bank
@@ -174,28 +180,37 @@ run settleWithOwnAccount = script do
   setTime settlementTime
 
   -- Settle batch
-  [bankCashHoldingCid, sellerCashHoldingCid, equityHoldingCid] <-
-    submitMulti [buyer] [publicParty] do
+  if bankUsesCompatibleHoldingStandard
+  then do
+    [bankCashHoldingCid, sellerCashHoldingCid, equityHoldingCid] <-
+      submitMulti [buyer] [publicParty] do
+        exerciseCmd batchCid Batch.Settle with actors = S.singleton buyer
+
+    -- Assert state
+    let ts = [(buyer, equityHoldingCid), (bank, bankCashHoldingCid), (seller, sellerCashHoldingCid)]
+    Holding.verifyOwnerOfHolding ts
+    Holding.verifyNoObservers ts
+
+    pure ()
+  else do
+    submitMultiMustFail [buyer] [publicParty] do
       exerciseCmd batchCid Batch.Settle with actors = S.singleton buyer
 
-  -- Assert state
-  let ts = [(buyer, equityHoldingCid), (bank, bankCashHoldingCid), (seller, sellerCashHoldingCid)]
-  Holding.verifyOwnerOfHolding ts
-  Holding.verifyNoObservers ts
-
-  pure ()
-
--- Settlement where the Bank allocates its `Instruction` using an "own" account. To be more precise,
+-- Settlement where the Bank allocates its `Instruction` using an "own" holding and account, i.e.,
 -- the Bank allocates its `Instruction` (between itself and the seller) using cash which it has
 -- credited to an account where the Bank takes the role as both the custodian and the owner (i.e.,
 -- an IOU to itself). Although this works, it is more efficient for the Bank to allocate using a
 -- direct credit instead (see the following script).
 run1 : Script ()
-run1 = run True
+run1 = run True True
 
 -- Settlement where the Bank allocates its `Instruction` with a direct credit to the seller.
 run2 : Script ()
-run2 = run False
+run2 = run False True
+
+-- Settlement fails due to an incompatible holding standard used by the bank.
+run3 : Script ()
+run3 = run False False
 
 setupParties : Script TestParties
 setupParties = do

--- a/src/test/daml/Daml/Finance/Test/Util/FungibleV2.daml
+++ b/src/test/daml/Daml/Finance/Test/Util/FungibleV2.daml
@@ -1,0 +1,97 @@
+-- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Daml.Finance.Test.Util.FungibleV2 where
+
+-- | Test Implementation of Fungible Holding
+-- This module contains a copy of the code from Daml.Finance.Holding.Fungible. It is used
+-- specifically for testing purposes, allowing the instantiation of an alternate implementation of
+-- the Fungible.I interface.
+
+import DA.Set (fromList, singleton)
+import Daml.Finance.Holding.Util (mergeImpl, splitImpl, transferImpl)
+import Daml.Finance.Interface.Holding.Base qualified as Base (I, View(..))
+import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (Create(..), F, View(..))
+import Daml.Finance.Interface.Holding.Fungible qualified as Fungible (I, View(..))
+import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I, View(..))
+import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), InstrumentKey(..), PartiesMap)
+import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
+import Daml.Finance.Interface.Util.Lockable qualified as Lockable (I, Lock(..), View(..), getLockers)
+import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
+import Daml.Finance.Util.Lockable (acquireImpl, isValidLock, releaseImpl)
+
+-- | Type synonym for `Factory`.
+type F = Factory
+
+-- | Type synonym for `Fungible`.
+type T = Fungible
+
+-- | Implementation of a fungible holding.
+-- The `Fungible` template implements the interface `Fungible.I` (which requires `Transferable.I`,
+-- `Base.I` and `Disclosure.I` to be implemented).
+template Fungible
+  with
+    instrument : InstrumentKey
+      -- ^ The instrument of which units are held.
+    account : AccountKey
+      -- ^ The account at which the holding is held. Defines the holding's owner and custodian.
+    amount : Decimal
+      -- ^ Number of units.
+    lock : Optional Lockable.Lock
+      -- ^ An optional lock for the holding.
+    observers : PartiesMap
+      -- ^ Observers.
+  where
+    signatory account.custodian, account.owner, Lockable.getLockers this
+    observer Disclosure.flattenObservers observers
+
+    ensure amount > 0.0 && isValidLock lock
+
+    interface instance Disclosure.I for Fungible where
+      view = Disclosure.View with
+        disclosureControllers = fromList [account.owner, account.custodian]; observers
+      setObservers = setObserversImpl @_ @Disclosure.I this None
+      addObservers = addObserversImpl @_ @Disclosure.I this None
+      removeObservers = removeObserversImpl @_ @Disclosure.I this None
+
+    interface instance Lockable.I for Fungible where
+      view = Lockable.View with lock; controllers = singleton account.owner
+      acquire = acquireImpl this.lock (\lock -> this with lock)
+      release = releaseImpl this.lock (\lock -> this with lock)
+
+    interface instance Base.I for Fungible where
+      view = Base.View with instrument; account; amount
+
+    interface instance Transferable.I for Fungible where
+      view = Transferable.View {}
+      transfer = transferImpl $ toInterface this
+
+    interface instance Fungible.I for Fungible where
+      view = Fungible.View with modifiers = singleton account.owner
+      split = splitImpl (toInterface @Fungible.I this) (\amount -> this with amount)
+      merge = mergeImpl (toInterface @Fungible.I this) (.amount) (\amount -> this with amount)
+
+-- | Implementation of a factory template for fungible holdings.
+template Factory
+  with
+    provider : Party
+      -- ^ The factory's provider.
+    observers : PartiesMap
+      -- ^ The factory's observers.
+  where
+    signatory provider
+    observer Disclosure.flattenObservers observers
+
+    interface instance HoldingFactory.F for Factory
+      where
+        view = HoldingFactory.View with provider
+        create' HoldingFactory.Create{instrument; account; amount; observers} = do
+          assertMsg "amount must be positive" $ amount > 0.0
+          toInterfaceContractId <$>
+            create Fungible with instrument; account; amount; observers; lock = None
+
+    interface instance Disclosure.I for Factory where
+      view = Disclosure.View with disclosureControllers = singleton provider; observers
+      setObservers = setObserversImpl @Factory @Disclosure.I this None
+      addObservers = addObserversImpl @Factory @Disclosure.I this None
+      removeObservers = removeObserversImpl @Factory @Disclosure.I this None

--- a/src/test/daml/Daml/Finance/Test/Util/FungibleV2.daml
+++ b/src/test/daml/Daml/Finance/Test/Util/FungibleV2.daml
@@ -3,7 +3,7 @@
 
 module Daml.Finance.Test.Util.FungibleV2 where
 
--- | Test Implementation of Fungible Holding
+-- | Test Implementation of Fungible Holding.
 -- This module contains a copy of the code from Daml.Finance.Holding.Fungible. It is used
 -- specifically for testing purposes, allowing the instantiation of an alternate implementation of
 -- the Fungible.I interface.


### PR DESCRIPTION
https://github.com/digital-asset/daml-finance/issues/123

The check for consistent settled holdings has changed. Now, holdings of the same instrument don't  need identical `templateTypeRep`. Instead, they should share the same token standard: `Fungible`, `NonFungible`, or `NonTransferable` (implementation variations are allowed).