### PR TITLE
keyed holding factory interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 - The `Remove` choice of the `Factory` was removed (and is now part of the `Account`).
 
+- Updated the `Account` to reference the `Daml.Finance.Interface.Holding.Factory` using a key
+  (of type `HoldingFactoryKey`) rather than the `ContractId Daml.Finance.Interface.Holding.Factory`.
+
 ### Daml.Finance.Claims
 
 - Dependencies update
@@ -95,6 +98,9 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - Relaxed the check for a consistent transferred holding. Now, the holdings being credited and
   debited don't need identical `templateTypeRep`. Instead, they should share the same token
   standard: `Fungible`, `NonFungible`, or `NonTransferable` (implementation variations are allowed).
+
+- Updated the `Factory` implementation for `Fungible`, `NonFungible`, and `NonTransferable`
+  holdings by introducing an `id : Id` field.
 
 ### Daml.Finance.Instrument.Bond
 
@@ -144,6 +150,9 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 - The `Remove` choice of the `Factory` was moved to the `Account`.
 
+- Changed the `Create` choice of the account `Factory` to take a key (of type `HoldingFactoryKey`)
+  rather than a `ContractId Daml.Finance.Interface.Holding.Factory`.
+
 ### Daml.Finance.Interface.Claims
 
 - Dependencies update
@@ -162,6 +171,9 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - Added an enumeration data type `HoldingStandard` for referring to various holding standards:
   `Fungible`, `NonFungible`, or `NonTransferable`. A utility function `getHoldingStandard` for
   retrieving the holding standard of a holding was also added.
+
+- Updated the `Daml.Finance.Interface.Holding.Factory` to use a key, employing a `Reference`
+  template and the `HoldingFactoryKey` data type.
 
 ### Daml.Finance.Interface.Instrument.Base
 
@@ -231,6 +243,8 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - Dependencies update
 
 ### Daml.Finance.Interface.Types.Common
+
+- Added a `HoldingFactoryKey` data type which is used to key holding factories.
 
 ### Daml.Finance.Interface.Types.Date
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,7 +173,7 @@ This document tracks pending changes to packages. It is facilitating the write-u
   retrieving the holding standard of a holding was also added.
 
 - Updated the `Daml.Finance.Interface.Holding.Factory` to use a key, employing a `Reference`
-  template and the `HoldingFactoryKey` data type.
+  template and the `HoldingFactoryKey` data type. Newly, it also requires the `Disclosure.I`.
 
 ### Daml.Finance.Interface.Instrument.Base
 

--- a/package/main/daml/Daml.Finance.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Account/daml.yaml
@@ -11,7 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.1/daml-finance-interface-account-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.1/daml-finance-interface-holding-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Claims/daml.yaml
@@ -15,7 +15,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.1/daml-finance-interface-lifecycle-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.2/daml-finance-interface-types-date-2.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/2.0.1/daml-finance-lifecycle-2.0.1.dar

--- a/package/main/daml/Daml.Finance.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Data/daml.yaml
@@ -11,7 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Data/3.0.1/daml-finance-interface-data-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.1/daml-finance-interface-lifecycle-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.2/daml-finance-interface-types-date-2.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar

--- a/package/main/daml/Daml.Finance.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Holding/daml.yaml
@@ -11,7 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.1/daml-finance-interface-account-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.1/daml-finance-interface-holding-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -16,7 +16,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/1.0.1/daml-finance-interface-instrument-bond-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.2/daml-finance-interface-types-date-2.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar

--- a/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
@@ -11,7 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.3.1/daml-finance-interface-instrument-equity-0.3.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/2.0.1/daml-finance-lifecycle-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar

--- a/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
@@ -14,7 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/2.0.1/daml-finance-interface-instrument-generic-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.1/daml-finance-interface-lifecycle-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/2.0.1/daml-finance-lifecycle-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar

--- a/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
@@ -14,7 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.1/daml-finance-interface-claims-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.2.1/daml-finance-interface-instrument-option-0.2.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/2.0.1/daml-finance-lifecycle-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar

--- a/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
@@ -15,7 +15,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.2.1/daml-finance-interface-instrument-option-0.2.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.StructuredProduct/0.1.0/daml-finance-interface-instrument-structuredproduct-0.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.2/daml-finance-interface-types-date-2.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar

--- a/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
@@ -16,7 +16,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.3.1/daml-finance-interface-instrument-swap-0.3.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.2/daml-finance-interface-types-date-2.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar

--- a/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
@@ -11,7 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/2.0.1/daml-finance-interface-instrument-token-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
@@ -10,7 +10,7 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.1/daml-finance-interface-holding-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
@@ -11,7 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/2.0.0/contingent-claims-core-2.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
@@ -10,7 +10,7 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.1/daml-finance-interface-lifecycle-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.2/daml-finance-interface-types-date-2.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
@@ -9,7 +9,7 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
@@ -10,7 +10,7 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.1/daml-finance-interface-holding-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
@@ -12,7 +12,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.1/daml-finance-interface-claims-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.2/daml-finance-interface-types-date-2.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
@@ -11,7 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.1/daml-finance-interface-lifecycle-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
@@ -11,7 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.1/daml-finance-interface-claims-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
@@ -12,7 +12,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.1/daml-finance-interface-claims-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.1/daml-finance-interface-lifecycle-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
@@ -11,7 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.1/daml-finance-interface-claims-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.2/daml-finance-interface-types-date-2.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
@@ -11,7 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.2/daml-finance-interface-types-date-2.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
@@ -10,7 +10,7 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
@@ -11,7 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.1/daml-finance-interface-holding-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.1/daml-finance-interface-settlement-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
@@ -10,7 +10,7 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.1/daml-finance-interface-holding-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-types-common
 source: daml
-version: 1.0.1
+version: 1.0.2
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
@@ -9,6 +9,6 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
@@ -14,7 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.1/daml-finance-interface-lifecycle-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.1/daml-finance-interface-settlement-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Settlement/daml.yaml
@@ -12,7 +12,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.1/daml-finance-interface-account-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.1/daml-finance-interface-holding-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.1/daml-finance-interface-settlement-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.1/daml-finance-util-3.0.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Util/daml.yaml
@@ -9,7 +9,7 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.2/daml-finance-interface-types-date-2.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
 build-options: null

--- a/package/test/daml/Daml.Finance.Account.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Account.Test/daml.yaml
@@ -14,7 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Holding/2.0.1/daml-finance-holding-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.1/daml-finance-interface-account-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.1/daml-finance-interface-holding-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options: null

--- a/package/test/daml/Daml.Finance.Data.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Data.Test/daml.yaml
@@ -13,7 +13,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Data/3.0.1/daml-finance-interface-data-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.1/daml-finance-interface-lifecycle-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.2/daml-finance-interface-types-date-2.0.2.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options: null

--- a/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
@@ -14,7 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Holding/2.0.1/daml-finance-holding-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.1/daml-finance-interface-account-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.1/daml-finance-interface-holding-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options: null

--- a/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
@@ -15,7 +15,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/2.0.1/daml-finance-interface-claims-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/1.0.1/daml-finance-interface-instrument-bond-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.2/daml-finance-interface-types-date-2.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar

--- a/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
@@ -18,7 +18,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.2.1/daml-finance-interface-instrument-option-0.2.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.1/daml-finance-interface-lifecycle-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.1/daml-finance-interface-settlement-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/2.0.1/daml-finance-lifecycle-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Settlement/2.0.1/daml-finance-settlement-2.0.1.dar

--- a/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
@@ -21,7 +21,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/2.0.1/daml-finance-interface-instrument-generic-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.1/daml-finance-interface-lifecycle-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.1/daml-finance-interface-settlement-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.2/daml-finance-interface-types-date-2.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/2.0.1/daml-finance-lifecycle-2.0.1.dar

--- a/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
@@ -15,7 +15,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Instrument.Option/0.2.1/daml-finance-instrument-option-0.2.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.2.1/daml-finance-interface-instrument-option-0.2.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.1/daml-finance-interface-lifecycle-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options: null

--- a/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
@@ -13,7 +13,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Instrument.StructuredProduct/0.1.0/daml-finance-instrument-structuredproduct-0.1.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.StructuredProduct/0.1.0/daml-finance-interface-instrument-structuredproduct-0.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.2/daml-finance-interface-types-date-2.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar

--- a/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
@@ -14,7 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Instrument.Swap/0.3.1/daml-finance-instrument-swap-0.3.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.3.1/daml-finance-interface-instrument-swap-0.3.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.2/daml-finance-interface-types-date-2.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar

--- a/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
@@ -15,7 +15,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Account/2.0.1/daml-finance-interface-account-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.0.1/daml-finance-interface-holding-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.1/daml-finance-interface-settlement-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Settlement/2.0.1/daml-finance-settlement-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar

--- a/package/test/daml/Daml.Finance.Test.Util/daml.yaml
+++ b/package/test/daml/Daml.Finance.Test.Util/daml.yaml
@@ -20,7 +20,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.0.1/daml-finance-interface-instrument-base-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/2.0.1/daml-finance-interface-instrument-token-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.0.1/daml-finance-interface-lifecycle-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.2/daml-finance-interface-types-date-2.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/2.0.1/daml-finance-lifecycle-2.0.1.dar

--- a/package/test/daml/Daml.Finance.Util.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Util.Test/daml.yaml
@@ -10,7 +10,7 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.1/daml-finance-interface-types-common-1.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.2/daml-finance-interface-types-common-1.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.2/daml-finance-interface-types-date-2.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.1/daml-finance-interface-util-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar

--- a/src/main/daml/Daml/Finance/Account/Account.daml
+++ b/src/main/daml/Daml/Finance/Account/Account.daml
@@ -7,8 +7,8 @@ import DA.Map qualified as M (empty)
 import DA.Set qualified as S (fromList, null, singleton)
 import Daml.Finance.Interface.Account.Account qualified as Account (Controllers(..), Credit(..), Debit(..), I, View(..), accountKey, createReference, disclosureUpdateReference)
 import Daml.Finance.Interface.Account.Factory qualified as AccountFactory (Create(..), F, View(..))
-import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (Create(..), F)
-import Daml.Finance.Interface.Types.Common.Types (Id, PartiesMap)
+import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (Create(..), F, exerciseInterfaceByKey)
+import Daml.Finance.Interface.Types.Common.Types (HoldingFactoryKey(..), Id, PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (AddObservers(..), I, RemoveObservers(..), View(..), flattenObservers)
 import Daml.Finance.Interface.Util.Lockable qualified as Lockable (Acquire(..), I, Lock, Release(..), View(..), getLockers, mustNotBeLocked)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
@@ -32,7 +32,7 @@ template Account
       -- ^ Identifier of the account.
     description : Text
       -- ^ Description of the account.
-    holdingFactoryCid : ContractId HoldingFactory.F
+    holdingFactory : HoldingFactoryKey
       -- ^ Associated holding factory.
     observers : PartiesMap
       -- ^ Observers.
@@ -48,11 +48,12 @@ template Account
       getKey = Account.accountKey this
       credit Account.Credit{quantity} = do
         Lockable.mustNotBeLocked this
-        exercise holdingFactoryCid HoldingFactory.Create with
-          instrument = quantity.unit
-          account = Account.accountKey this
-          amount = quantity.amount
-          observers = M.empty
+        HoldingFactory.exerciseInterfaceByKey @HoldingFactory.F holdingFactory
+          custodian HoldingFactory.Create with
+            instrument = quantity.unit
+            account = Account.accountKey this
+            amount = quantity.amount
+            observers = M.empty
       debit Account.Debit{holdingCid} = do
         Lockable.mustNotBeLocked this
         holding <- fetch holdingCid
@@ -100,11 +101,11 @@ template Factory
 
     interface instance AccountFactory.F for Factory where
       view = AccountFactory.View with provider
-      create' AccountFactory.Create {account; holdingFactoryCid; controllers; observers;
-        description} = do
+      create' AccountFactory.Create {account; holdingFactory; controllers; observers; description} =
+        do
           cid <- toInterfaceContractId <$> create Account with
             custodian = account.custodian; owner = account.owner; lock = None; controllers
-            id = account.id; holdingFactoryCid; observers; description
+            id = account.id; holdingFactory; observers; description
           Account.createReference account.custodian cid
           pure cid
 

--- a/src/main/daml/Daml/Finance/Holding/Fungible.daml
+++ b/src/main/daml/Daml/Finance/Holding/Fungible.daml
@@ -9,7 +9,7 @@ import Daml.Finance.Interface.Holding.Base qualified as Base (I, View(..))
 import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (Create(..), F, View(..))
 import Daml.Finance.Interface.Holding.Fungible qualified as Fungible (I, View(..))
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I, View(..))
-import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), InstrumentKey(..), PartiesMap)
+import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), Id, InstrumentKey(..), PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Interface.Util.Lockable qualified as Lockable (I, Lock(..), View(..), getLockers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
@@ -71,6 +71,8 @@ template Factory
   with
     provider : Party
       -- ^ The factory's provider.
+    id : Id
+      -- ^ Identifier for the factory.
     observers : PartiesMap
       -- ^ The factory's observers.
   where
@@ -79,7 +81,7 @@ template Factory
 
     interface instance HoldingFactory.F for Factory
       where
-        view = HoldingFactory.View with provider
+        view = HoldingFactory.View with provider; id
         create' HoldingFactory.Create{instrument; account; amount; observers} = do
           assertMsg "amount must be positive" $ amount > 0.0
           toInterfaceContractId <$>

--- a/src/main/daml/Daml/Finance/Holding/NonFungible.daml
+++ b/src/main/daml/Daml/Finance/Holding/NonFungible.daml
@@ -8,7 +8,7 @@ import Daml.Finance.Holding.Util (transferImpl)
 import Daml.Finance.Interface.Holding.Base qualified as Base (I, View(..))
 import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (Create(..), F, View(..))
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I, View(..))
-import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), InstrumentKey(..), PartiesMap)
+import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), Id, InstrumentKey(..), PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Interface.Util.Lockable qualified as Lockable (I, Lock(..), View(..), getLockers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
@@ -65,6 +65,8 @@ template Factory
   with
     provider : Party
       -- ^ The factory's provider.
+    id : Id
+      -- ^ Identifier for the holding factory.
     observers : PartiesMap
       -- ^ The factory's observers.
   where
@@ -73,7 +75,7 @@ template Factory
 
     interface instance HoldingFactory.F for Factory
       where
-        view = HoldingFactory.View with provider
+        view = HoldingFactory.View with provider; id
         create' HoldingFactory.Create{instrument; account; amount; observers} = do
           assertMsg "amount must be positive" $ amount > 0.0
           toInterfaceContractId <$>

--- a/src/main/daml/Daml/Finance/Holding/NonTransferable.daml
+++ b/src/main/daml/Daml/Finance/Holding/NonTransferable.daml
@@ -6,7 +6,7 @@ module Daml.Finance.Holding.NonTransferable where
 import DA.Set (fromList, singleton)
 import Daml.Finance.Interface.Holding.Base qualified as Base (I, View(..))
 import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (Create(..), F, View(..))
-import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), InstrumentKey(..), PartiesMap)
+import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), Id, InstrumentKey(..), PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Interface.Util.Lockable qualified as Lockable (I, Lock(..), View(..), getLockers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
@@ -59,6 +59,8 @@ template Factory
   with
     provider : Party
       -- ^ The factory's provider.
+    id : Id
+      -- ^ Identifier for the factory.
     observers : PartiesMap
       -- ^ The factory's observers.
   where
@@ -67,7 +69,7 @@ template Factory
 
     interface instance HoldingFactory.F for Factory
       where
-        view = HoldingFactory.View with provider
+        view = HoldingFactory.View with provider; id
         create' HoldingFactory.Create{instrument; account; amount; observers} = do
           assertMsg "amount must be positive" $ amount > 0.0
           toInterfaceContractId <$>

--- a/src/main/daml/Daml/Finance/Interface/Account/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Account/Factory.daml
@@ -4,8 +4,7 @@
 module Daml.Finance.Interface.Account.Factory where
 
 import Daml.Finance.Interface.Account.Account qualified as Account (Controllers(..), I)
-import Daml.Finance.Interface.Holding.Factory qualified as Holding (F)
-import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), PartiesMap)
+import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), HoldingFactoryKey, PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
 -- | Type synonym for `Factory`.
@@ -33,7 +32,7 @@ interface Factory requires Disclosure.I where
     with
       account : AccountKey
         -- ^ The account's key.
-      holdingFactoryCid : ContractId Holding.F
+      holdingFactory : HoldingFactoryKey
         -- ^ Associated holding factory for the account.
       controllers : Account.Controllers
         -- ^ Controllers of the account.

--- a/src/main/daml/Daml/Finance/Interface/Holding/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Holding/Factory.daml
@@ -1,14 +1,21 @@
 -- Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
 module Daml.Finance.Interface.Holding.Factory where
 
 import Daml.Finance.Interface.Holding.Base qualified as Base (I)
-import Daml.Finance.Interface.Types.Common.Types (AccountKey, InstrumentKey, PartiesMap)
-import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
+import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), HoldingFactoryKey(..), Id, InstrumentKey(..), Parties, PartiesMap)
+import Daml.Finance.Interface.Util.Common (exerciseInterfaceByKeyHelper)
+import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (AddObservers(..), GetView(..), I, RemoveObservers(..), flattenObservers)
 
 -- | Type synonym for `Factory`.
 type F = Factory
+
+-- | Type synonym for `Reference`. This type is currently used as a work-around given the lack of
+-- interface keys.
+type R = Reference
 
 -- | Type synonym for `View`.
 type V = View
@@ -18,7 +25,13 @@ data View = View
   with
     provider : Party
       -- ^ The provider of the `Factory`.
+    id : Id
+      -- ^ Identifier for the holding factory.
   deriving (Eq, Show)
+
+-- | Convert the account's 'View' to its key.
+toKey : View -> HoldingFactoryKey
+toKey v = HoldingFactoryKey with provider = v.provider; id = v.id
 
 -- | Holding factory contract used to create (credit) holdings.
 interface Factory requires Disclosure.I where
@@ -26,6 +39,15 @@ interface Factory requires Disclosure.I where
 
   create' : Create -> Update (ContractId Base.I)
     -- ^ Implementation of `Create` choice.
+
+  nonconsuming choice GetView : View
+    -- ^ Retrieves the interface view.
+    with
+      viewer : Party
+        -- ^ The party fetching the view.
+    controller viewer
+    do
+      pure $ view this
 
   nonconsuming choice Create : ContractId Base.I
     -- ^ Create a holding on the instrument in the corresponding account.
@@ -41,3 +63,110 @@ interface Factory requires Disclosure.I where
     controller account.custodian, account.owner
       do
         create' this arg
+
+-- | HIDE
+-- This template is used to key a Holding Factory contract. It allows for looking up this contract by key
+-- then acquiring the Factory contract by fetching its contract id on this contract. As updates are
+-- made to a Factory, this Reference contract is required to be kept in sync.
+template Reference
+  with
+    factoryView : View
+      -- ^ The default view for factories.
+    cid : ContractId Factory
+      -- ^ The contract id of the factory.
+    observers : PartiesMap
+  where
+    signatory factoryView.provider
+    observer Disclosure.flattenObservers observers
+
+    key toKey factoryView : HoldingFactoryKey
+    maintainer key.provider
+
+    nonconsuming choice GetCid : ContractId Factory
+      -- ^ Get the `Factory`'s contract id.
+      with
+        viewer : Party
+      controller viewer
+      do
+        pure cid
+
+    choice SetCid : ContractId Reference
+      -- ^ Set the factory cid. This choice should be called only from `Factory` implementations.
+      with
+        newCid : ContractId Factory
+          -- ^ The factory cid.
+      controller signatory this
+      do
+        create this with cid = newCid
+
+    choice SetObservers : ContractId Reference
+      -- ^ Set observers. This choice should be called only from `Factory` implementations.
+      with
+        newObservers : PartiesMap
+          -- ^ The new observers.
+      controller signatory this
+      do
+        create this with observers = newObservers
+
+-- | Create factory including reference.
+createWithReference : (HasCreate f, HasToInterface f Factory) => f -> Update (ContractId Factory)
+createWithReference factory = do
+  cid <- toInterfaceContractId @Factory <$> create factory
+  createReference (view $ toInterface @Factory factory).provider cid
+  pure cid
+
+-- | Exercise interface by key.
+-- This method can be used to exercise a choice on a `Factory` given its `HoldingFactoryKey`.
+-- Requires as input the `HoldingFactoryKey`, the actor fetching the factory and the choice
+-- arguments. For example:
+-- ```
+-- exerciseInterfaceByKey @HoldingFactory.I holdingFactoryKey actor
+--   HoldingFactory.Create with instrument; account; amount; observers
+-- ```
+exerciseInterfaceByKey : forall i c r. (HasInterfaceTypeRep i, HasExercise i c r)
+  => HoldingFactoryKey -- ^ The factory key.
+  -> Party             -- ^ The actor fetching the factory.
+  -> c                 -- ^ The choice arguments.
+  -> Update r
+exerciseInterfaceByKey k viewer arg =
+  exerciseInterfaceByKeyHelper @Reference @Factory @i k (GetCid with viewer) arg
+
+-- | Disclose factory.
+disclose : (Text, Parties) -> Party -> Parties -> HoldingFactoryKey -> Update (ContractId Factory)
+disclose observersToAdd actor disclosers factory =
+  fromInterfaceContractId <$>
+    exerciseInterfaceByKey
+      @Disclosure.I
+      factory
+      actor
+      Disclosure.AddObservers with disclosers; observersToAdd
+
+-- | Undisclose factory.
+undisclose : (Text, Parties) -> Party -> Parties -> HoldingFactoryKey ->
+  Update (Optional (ContractId Factory))
+undisclose observersToRemove actor disclosers factory =
+  fmap fromInterfaceContractId <$>
+    exerciseInterfaceByKey
+      @Disclosure.I
+      factory
+      actor
+      Disclosure.RemoveObservers with disclosers; observersToRemove
+
+-- | HIDE
+-- Create Reference for the factory.
+createReference : Party -> ContractId Factory -> Update (ContractId Reference)
+createReference actor cid = do
+  factoryView <- exercise cid GetView with viewer = actor
+  disclosureView <- exercise
+    (toInterfaceContractId @Disclosure.I cid)
+    Disclosure.GetView with viewer = actor
+  create Reference with factoryView; cid; observers = disclosureView.observers
+
+-- | HIDE
+-- Helper function to update the factory reference once observers are added to the factory.
+disclosureUpdateReference : HoldingFactoryKey -> PartiesMap -> ContractId Factory ->
+  Update (ContractId Disclosure.I)
+disclosureUpdateReference k newObservers iCid = do
+  exerciseByKey @Reference k SetCid with newCid = iCid
+  exerciseByKey @Reference k SetObservers with newObservers
+  pure $ toInterfaceContractId iCid

--- a/src/main/daml/Daml/Finance/Interface/Types/Common/Types.daml
+++ b/src/main/daml/Daml/Finance/Interface/Types/Common/Types.daml
@@ -21,6 +21,15 @@ newtype Id = Id Text
 instance Show Id where
   show (Id t) = t
 
+-- | A unique key for a holding factory.
+data HoldingFactoryKey = HoldingFactoryKey
+  with
+    provider : Party
+      -- ^ Holding factory provider.
+    id : Id
+      -- ^ Unique identifier for a holding factory.
+  deriving (Eq, Ord, Show)
+
 -- | A unique key for Accounts.
 data AccountKey = AccountKey
   with

--- a/src/test/daml/Daml/Finance/Account/Test/Account.daml
+++ b/src/test/daml/Daml/Finance/Account/Test/Account.daml
@@ -9,7 +9,7 @@ import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), cr
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Finance.Interface.Types.Common.Types (Id(..))
 import Daml.Script
-import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactory)
 
 -- | Test the creation and removal of an account.
 test : Script ()
@@ -21,8 +21,8 @@ test = do
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory custodian []
 
   -- Create holding factory
-  holdingFactory <- Holding.createHoldingFactoryWithReference
-    Fungible.Factory with provider = custodian; id = Id "adf"; observers = mempty
+  holdingFactory <- Holding.createHoldingFactory
+    Fungible.Factory with provider = custodian; id = Id "Holding Factory"; observers = mempty
 
   -- Create account
   investorAccount <- Account.createAccount "Default Account" [] accountFactoryCid holdingFactory []

--- a/src/test/daml/Daml/Finance/Account/Test/Account.daml
+++ b/src/test/daml/Daml/Finance/Account/Test/Account.daml
@@ -7,7 +7,9 @@ import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Interface.Account.Account qualified as Account (I, Remove(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, submitExerciseInterfaceByKeyCmd)
 import Daml.Finance.Test.Util.Common (createParties)
+import Daml.Finance.Interface.Types.Common.Types (Id(..))
 import Daml.Script
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference)
 
 -- | Test the creation and removal of an account.
 test : Script ()
@@ -19,13 +21,12 @@ test = do
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory custodian []
 
   -- Create holding factory
-  holdingFactoryCid <- toInterfaceContractId <$> submit custodian do
-    createCmd Fungible.Factory with provider = custodian; observers = mempty
+  holdingFactory <- Holding.createHoldingFactoryWithReference
+    Fungible.Factory with provider = custodian; id = Id "adf"; observers = mempty
 
   -- Create account
-  investorAccount <-
-    Account.createAccount "Default Account" [] accountFactoryCid holdingFactoryCid
-      [] Account.Owner custodian investor
+  investorAccount <- Account.createAccount "Default Account" [] accountFactoryCid holdingFactory []
+    Account.Owner custodian investor
 
   -- Remove account
   Account.submitExerciseInterfaceByKeyCmd @Account.I [custodian, investor] [] investorAccount

--- a/src/test/daml/Daml/Finance/Account/Test/Account.daml
+++ b/src/test/daml/Daml/Finance/Account/Test/Account.daml
@@ -22,7 +22,7 @@ test = do
 
   -- Create holding factory
   holdingFactory <- Holding.createHoldingFactory
-    Fungible.Factory with provider = custodian; id = Id "Holding Factory"; observers = mempty
+    Fungible.Factory with provider = custodian; id = Id "Factory Fungible"; observers = mempty
 
   -- Create account
   investorAccount <- Account.createAccount "Default Account" [] accountFactoryCid holdingFactory []

--- a/src/test/daml/Daml/Finance/Account/Test/Consistency.daml
+++ b/src/test/daml/Daml/Finance/Account/Test/Consistency.daml
@@ -12,24 +12,31 @@ import Daml.Finance.Interface.Account.Factory qualified as Account (Create(..), 
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I, Transfer(..))
 import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), Id(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createFactory, toControllers)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference)
 import Daml.Script
 
--- | Verify that I cannot transfer a non-fungible holding to a fungible account.
+-- | A non-fungible holding can't be transferred to an account for fungibles.
 consistencyCheck : Script ()
 consistencyCheck = script do
   -- Create parties
   tp@TestParties{custodian; issuer; investor; publicParty} <- setupParties
+  let pp = M.fromList [("PublicParty", S.singleton publicParty)]
 
   -- Initialize state with `NonFungible.Factory`
-  let pp = M.fromList [("PublicParty", S.singleton publicParty)]
   TestInitialState {issuerAccount; issuerHoldingCid} <-
-    setupInitialState tp (NonFungible.Factory with
-      provider = custodian; observers = pp) [] Account.Owner
+    setupInitialState
+      tp
+      (NonFungible.Factory with provider = custodian; id = Id "Factory NonFungible"; observers = pp)
+      [] Account.Owner
 
-  -- Create investor account for fungible holdings
+  -- Create account factory
   accountFactoryCid <- toInterfaceContractId @Account.F <$> Account.createFactory custodian []
-  holdingFactoryCid <- toInterfaceContractId <$>
-    submit custodian do createCmd Fungible.Factory with provider = custodian; observers = pp
+
+  -- Create holding factory
+  holdingFactory <- Holding.createHoldingFactoryWithReference
+    Fungible.Factory with provider = custodian; id = Id "Factory Fungible"; observers = pp
+
+  -- Create an account for investor
   let
     id = Id $ show investor <> "@" <> show custodian <> "[" <> "Fungible" <> "]"
     investorAccount = AccountKey with custodian; owner = investor; id
@@ -37,7 +44,7 @@ consistencyCheck = script do
     exerciseCmd accountFactoryCid Account.Create with
       account = investorAccount
       description = "Fungible Account"
-      holdingFactoryCid
+      holdingFactory
       controllers = Account.toControllers custodian investor Account.Owner
       observers = M.fromList [("Issuer", S.singleton issuer)]
 

--- a/src/test/daml/Daml/Finance/Account/Test/Consistency.daml
+++ b/src/test/daml/Daml/Finance/Account/Test/Consistency.daml
@@ -12,7 +12,7 @@ import Daml.Finance.Interface.Account.Factory qualified as Account (Create(..), 
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I, Transfer(..))
 import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), Id(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createFactory, toControllers)
-import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactory)
 import Daml.Script
 
 -- | A non-fungible holding can't be transferred to an account for fungibles.
@@ -33,7 +33,7 @@ consistencyCheck = script do
   accountFactoryCid <- toInterfaceContractId @Account.F <$> Account.createFactory custodian []
 
   -- Create holding factory
-  holdingFactory <- Holding.createHoldingFactoryWithReference
+  holdingFactory <- Holding.createHoldingFactory
     Fungible.Factory with provider = custodian; id = Id "Factory Fungible"; observers = pp
 
   -- Create an account for investor

--- a/src/test/daml/Daml/Finance/Account/Test/Controllers.daml
+++ b/src/test/daml/Daml/Finance/Account/Test/Controllers.daml
@@ -8,6 +8,7 @@ import DA.Set qualified as S (fromList, singleton)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Holding.Test.Common (TestInitialState(..), TestParties(..), setupInitialState, setupParties)
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I, Transfer(..))
+import Daml.Finance.Interface.Types.Common.Types (Id(..))
 import Daml.Finance.Test.Util.Account (ControlledBy(..))
 import Daml.Script
 
@@ -16,11 +17,12 @@ custodianControlled : Script ()
 custodianControlled = script do
   -- Create parties
   tp@TestParties{custodian; issuer; investor; publicParty} <- setupParties
+  let pp = M.fromList [("PublicParty", S.singleton publicParty)]
 
   -- Initialize state with
-  let pp = M.fromList [("PublicParty", S.singleton publicParty)]
-  TestInitialState {issuerAccount; investorAccount; issuerHoldingCid} <-
-    setupInitialState tp (Fungible.Factory with provider = custodian; observers = pp) [] Custodian
+  TestInitialState {issuerAccount; investorAccount; issuerHoldingCid} <- setupInitialState tp
+    (Fungible.Factory with provider = custodian; id = Id "Factory Fungible"; observers = pp) []
+    Custodian
 
   -- Owners can't transfer.
   submitMultiMustFail [issuer, investor] [publicParty] do
@@ -39,11 +41,13 @@ ownerControlled : Script ()
 ownerControlled = script do
   -- Create parties
   tp@TestParties{custodian; issuer; investor; publicParty} <- setupParties
+  let pp = M.fromList [("PublicParty", S.singleton publicParty)]
 
   -- Initialize state with `Fungible.Factory`
-  let pp = M.fromList [("PublicParty", S.singleton publicParty)]
   TestInitialState {issuerAccount; investorAccount; issuerHoldingCid} <-
-    setupInitialState tp (Fungible.Factory with provider = custodian; observers = pp) [] Owner
+    setupInitialState tp
+      (Fungible.Factory with provider = custodian; id = Id "Factory Fungible"; observers = pp)
+      [] Owner
 
   -- Custodian can't transfer.
   submitMultiMustFail [custodian] [publicParty] do
@@ -63,12 +67,12 @@ ownerAndCustodianControlled : Script ()
 ownerAndCustodianControlled = script do
   -- Create parties
   tp@TestParties{custodian; issuer; investor; publicParty} <- setupParties
+  let pp = M.fromList [("PublicParty", S.singleton publicParty)]
 
   -- Initialize state with `Fungible.Factory`
-  let pp = M.fromList [("PublicParty", S.singleton publicParty)]
-  TestInitialState {issuerAccount; investorAccount; issuerHoldingCid} <-
-    setupInitialState tp (Fungible.Factory with provider = custodian; observers = pp) []
-      OwnerAndCustodian
+  TestInitialState {issuerAccount; investorAccount; issuerHoldingCid} <- setupInitialState tp
+    (Fungible.Factory with provider = custodian; id = Id "Factory Fungible"; observers = pp)
+    [] OwnerAndCustodian
 
   -- Owners can't transfer.
   submitMultiMustFail [issuer, investor] [publicParty] do
@@ -94,12 +98,13 @@ ownerControlledWithAutoApproval : Script ()
 ownerControlledWithAutoApproval = script do
   -- Create parties
   tp@TestParties{custodian; issuer; investor; publicParty} <- setupParties
+  let pp = M.fromList [("PublicParty", S.singleton publicParty)]
 
   -- Initialize state with `Fungible.Factory`
-  let pp = M.fromList [("PublicParty", S.singleton publicParty)]
-  TestInitialState {issuerAccount; investorAccount; issuerHoldingCid} <-
-    setupInitialState tp (Fungible.Factory with provider = custodian; observers = pp) (M.toList pp)
-      OwnerWithAutoApproval
+  TestInitialState {issuerAccount; investorAccount; issuerHoldingCid} <- setupInitialState tp
+    (Fungible.Factory with
+      provider = custodian; id = Id "Factory Fungible"; observers = pp)
+    (M.toList pp) OwnerWithAutoApproval
 
   -- Custodian can't transfer.
   submitMultiMustFail [custodian] [publicParty] do

--- a/src/test/daml/Daml/Finance/Account/Test/Lock.daml
+++ b/src/test/daml/Daml/Finance/Account/Test/Lock.daml
@@ -7,6 +7,7 @@ import DA.Set qualified as S (empty, fromList, insert, singleton, toList)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Holding.Test.Common (TestInitialState(..), TestParties(..), setupInitialState, setupParties)
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I, Transfer(..))
+import Daml.Finance.Interface.Types.Common.Types (Id(..))
 import Daml.Finance.Interface.Util.Lockable qualified as Lockable (Acquire(..), I, LockType(..), Release(..))
 import Daml.Finance.Test.Util.Account qualified as Account (submitExerciseInterfaceByKeyCmd, submitMustFailExerciseInterfaceByKeyCmd)
 import Daml.Finance.Test.Util.Account qualified as ControlledBy (ControlledBy(..))
@@ -25,9 +26,9 @@ lockWith f lockOutgoingAccount = script do
   tp@TestParties{custodian; issuer; investor; regulator} <- setupParties
 
   -- Initialize state.
-  TestInitialState {issuerAccount; investorAccount; issuerHoldingCid} <-
-    setupInitialState tp (Fungible.Factory with provider = custodian; observers = mempty) []
-      ControlledBy.Custodian
+  TestInitialState {issuerAccount; investorAccount; issuerHoldingCid} <- setupInitialState tp
+    (Fungible.Factory with provider = custodian; id = Id "Factory Fungible"; observers = mempty)
+    [] ControlledBy.Custodian
   let
     lockers = case f of
       CustodianOnly -> S.singleton custodian

--- a/src/test/daml/Daml/Finance/Holding/Test/Common.daml
+++ b/src/test/daml/Daml/Finance/Holding/Test/Common.daml
@@ -10,7 +10,7 @@ import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (F)
 import Daml.Finance.Interface.Types.Common.Types (AccountKey, InstrumentKey, Id(..), Parties)
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactory)
 import Daml.Finance.Test.Util.Instrument (originate)
 import Daml.Script
 
@@ -68,7 +68,7 @@ setupInitialState (tp : TestParties) (holdingFactory : a) accountObservers contr
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory custodian []
 
   -- Create holding factory
-  holdingFactory <- Holding.createHoldingFactoryWithReference holdingFactory
+  holdingFactory <- Holding.createHoldingFactory holdingFactory
 
   -- Create account
   [issuerAccount, investorAccount] <-

--- a/src/test/daml/Daml/Finance/Holding/Test/Common.daml
+++ b/src/test/daml/Daml/Finance/Holding/Test/Common.daml
@@ -6,10 +6,11 @@ module Daml.Finance.Holding.Test.Common where
 import DA.Map qualified as M (Map)
 import Daml.Finance.Interface.Account.Factory qualified as Account (F)
 import Daml.Finance.Interface.Holding.Base qualified as Base (I)
-import Daml.Finance.Interface.Holding.Factory qualified as Holding (F)
-import Daml.Finance.Interface.Types.Common.Types (AccountKey, InstrumentKey, Parties)
+import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (F)
+import Daml.Finance.Interface.Types.Common.Types (AccountKey, InstrumentKey, Id(..), Parties)
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference)
 import Daml.Finance.Test.Util.Instrument (originate)
 import Daml.Script
 
@@ -55,20 +56,23 @@ setupParties = do
 
 -- | Setup test initial state.
 setupInitialState :
-  ( HasToInterface a Holding.F, HasSignatory a, HasObserver a, HasEnsure a, HasAgreement a
-  , HasCreate a, HasFetch a, HasArchive a, HasTemplateTypeRep a, HasToAnyTemplate a
-  , HasFromAnyTemplate a, HasField "observers" a (M.Map k v), HasField "provider" a Party
-  ) => TestParties -> a -> [(Text, Parties)] -> Account.ControlledBy -> Script TestInitialState
+  ( HasToInterface a HoldingFactory.F, HasSignatory a, HasObserver a, HasEnsure a
+  , HasAgreement a, HasCreate a, HasFetch a, HasArchive a, HasTemplateTypeRep a, HasToAnyTemplate a
+  , HasFromAnyTemplate a, HasField "provider" a Party, HasField "id" a Id
+  , HasField "observers" a (M.Map Text Parties)
+  ) => TestParties -> a -> [(Text, Parties)] -> Account.ControlledBy -> Script (TestInitialState)
 setupInitialState (tp : TestParties) (holdingFactory : a) accountObservers controlledBy = do
   let TestParties{..} = tp
 
-  -- Create account and holding factory
+  -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory custodian []
-  holdingFactoryCid <- toInterfaceContractId <$> submit custodian do createCmd holdingFactory
+
+  -- Create holding factory
+  holdingFactory <- Holding.createHoldingFactoryWithReference holdingFactory
 
   -- Create account
   [issuerAccount, investorAccount] <-
-    mapA (Account.createAccount "Default Account" [] accountFactoryCid holdingFactoryCid
+    mapA (Account.createAccount "Default Account" [] accountFactoryCid holdingFactory
       accountObservers controlledBy custodian) [issuer, investor]
 
   -- Originate instrument

--- a/src/test/daml/Daml/Finance/Holding/Test/Fungible.daml
+++ b/src/test/daml/Daml/Finance/Holding/Test/Fungible.daml
@@ -15,6 +15,7 @@ import Daml.Finance.Interface.Holding.Base qualified as Base (I)
 import Daml.Finance.Interface.Holding.Fungible qualified as Fungible (I, Merge(..), Split(..), SplitResult(..))
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I, Transfer(..))
 import Daml.Finance.Interface.Holding.Util (getAmount)
+import Daml.Finance.Interface.Types.Common.Types (Id(..))
 import Daml.Finance.Interface.Util.Common (verify)
 import Daml.Finance.Interface.Util.Lockable qualified as Lockable (Acquire(..), I, LockType(..), Release(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), submitExerciseInterfaceByKeyCmd, submitMustFailExerciseInterfaceByKeyCmd)
@@ -31,7 +32,9 @@ run = script do
   TestInitialState {investorAccount; issuerAccount; issuerHoldingCid} <- setupInitialState
     tp
     Fungible.Factory with
-      provider = custodian; observers = M.fromList [("PublicParty", S.singleton publicParty)]
+      provider = custodian
+      id = Id "Factory Fungible"
+      observers = M.fromList [("PublicParty", S.singleton publicParty)]
     [] Account.Owner
 
   -- Lock asset

--- a/src/test/daml/Daml/Finance/Holding/Test/NonFungible.daml
+++ b/src/test/daml/Daml/Finance/Holding/Test/NonFungible.daml
@@ -15,7 +15,7 @@ import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I,
 import Daml.Finance.Interface.Types.Common.Types (Id(..))
 import Daml.Finance.Interface.Util.Lockable qualified as Lockable (Acquire(..), I, LockType(..), Release(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, submitExerciseInterfaceByKeyCmd, submitMustFailExerciseInterfaceByKeyCmd)
-import Daml.Finance.Test.Util.Holding (createHoldingFactoryWithReference)
+import Daml.Finance.Test.Util.Holding (createHoldingFactory)
 import Daml.Finance.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
 import Daml.Finance.Test.Util.HoldingDuplicates.NonFungible qualified as NonFungibleV2 (Factory(..))
 import Daml.Script
@@ -83,7 +83,7 @@ run2 = do
       [] Account.Owner
 
   -- A transfer to an account which uses a new holding implementation (here NonFungibleV2) works
-  holdingFactoryNonFungibleV2 <- createHoldingFactoryWithReference $
+  holdingFactoryNonFungibleV2 <- createHoldingFactory $
     NonFungibleV2.Factory with provider = custodian; id = Id "Factory NonFungibleV2"; observers
   issuerAccountNonFungibleV2 <- Account.createAccount "Default Account for NonFungibleV2" []
     accountFactoryCid holdingFactoryNonFungibleV2 [] Account.Owner custodian issuer
@@ -93,7 +93,7 @@ run2 = do
         actors = S.singleton issuer; newOwnerAccount = issuerAccountNonFungibleV2
 
   -- A transfer to an account using a different holding standard (here NonTransferable) must fail
-  holdingFactoryNonTransferable <- createHoldingFactoryWithReference $
+  holdingFactoryNonTransferable <- createHoldingFactory $
     NonTransferable.Factory with provider = custodian; id = Id "Factory NonTransferable"; observers
   issuerAccountForNonFungible <- Account.createAccount "Default Account for NonTransferable" []
     accountFactoryCid holdingFactoryNonTransferable [] Account.Owner custodian issuer
@@ -102,7 +102,7 @@ run2 = do
       actors = S.singleton issuer; newOwnerAccount = issuerAccountForNonFungible
 
   -- A transfer to an account using a different holding standard (here Fungible) must fail
-  holdingFactoryFungible <- createHoldingFactoryWithReference $
+  holdingFactoryFungible <- createHoldingFactory $
     Fungible.Factory with provider = custodian; id = Id "Factory Fungible"; observers
   issuerAccountForFungible <- Account.createAccount "Default Account for Fungible" []
     accountFactoryCid holdingFactoryFungible [] Account.Owner custodian issuer

--- a/src/test/daml/Daml/Finance/Holding/Test/NonFungible.daml
+++ b/src/test/daml/Daml/Finance/Holding/Test/NonFungible.daml
@@ -12,8 +12,10 @@ import Daml.Finance.Holding.Test.Common (TestInitialState(..), TestParties(..), 
 import Daml.Finance.Interface.Account.Account qualified as Account (Debit(..), I)
 import Daml.Finance.Interface.Holding.Fungible qualified as Fungible (I, Split(..))
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I, Transfer(..))
+import Daml.Finance.Interface.Types.Common.Types (Id(..))
 import Daml.Finance.Interface.Util.Lockable qualified as Lockable (Acquire(..), I, LockType(..), Release(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, submitExerciseInterfaceByKeyCmd, submitMustFailExerciseInterfaceByKeyCmd)
+import Daml.Finance.Test.Util.Holding (createHoldingFactoryWithReference)
 import Daml.Finance.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
 import Daml.Finance.Test.Util.HoldingDuplicates.NonFungible qualified as NonFungibleV2 (Factory(..))
 import Daml.Script
@@ -25,8 +27,9 @@ run1 = script do
   let observers = M.fromList [("PublicParty", S.singleton publicParty)]
 
   -- Initialize state with `NonFungible.Factory`
-  TestInitialState {investorAccount; issuerAccount; issuerHoldingCid} <-
-    setupInitialState tp NonFungible.Factory with provider = custodian; observers [] Account.Owner
+  TestInitialState {investorAccount; issuerAccount; issuerHoldingCid} <- setupInitialState tp
+    (NonFungible.Factory with provider = custodian; id = Id "Factor NonFungible"; observers)
+    [] Account.Owner
 
   -- Cannot split
   submitMultiMustFail [issuer, investor] [] do
@@ -75,32 +78,34 @@ run2 = do
 
   -- Initialize state with `NonFungible.Factory`
   TestInitialState {investorAccount; issuerAccount; issuerHoldingCid; accountFactoryCid} <-
-    setupInitialState tp NonFungible.Factory with provider = custodian; observers [] Account.Owner
+    setupInitialState tp
+      (NonFungible.Factory with provider = custodian; id = Id "Factor NonFungible"; observers)
+      [] Account.Owner
 
   -- A transfer to an account which uses a new holding implementation (here NonFungibleV2) works
-  holdingFactoryNonFungibleV2Cid <- toInterfaceContractId <$> submit custodian do
-    createCmd NonFungibleV2.Factory with provider = custodian; observers
+  holdingFactoryNonFungibleV2 <- createHoldingFactoryWithReference $
+    NonFungibleV2.Factory with provider = custodian; id = Id "Factory NonFungibleV2"; observers
   issuerAccountNonFungibleV2 <- Account.createAccount "Default Account for NonFungibleV2" []
-    accountFactoryCid holdingFactoryNonFungibleV2Cid [] Account.Owner custodian issuer
+    accountFactoryCid holdingFactoryNonFungibleV2 [] Account.Owner custodian issuer
   transferableCid <- submitMulti [issuer] [publicParty] do
     exerciseCmd (fromInterfaceContractId @Transferable.I issuerHoldingCid)
       Transferable.Transfer with
         actors = S.singleton issuer; newOwnerAccount = issuerAccountNonFungibleV2
 
-  -- A transfer to an account using the NonTransferable token standard must fail
-  holdingFactoryForNonTransferableCid <- toInterfaceContractId <$> submit custodian do
-    createCmd NonTransferable.Factory with provider = custodian; observers
+  -- A transfer to an account using a different holding standard (here NonTransferable) must fail
+  holdingFactoryNonTransferable <- createHoldingFactoryWithReference $
+    NonTransferable.Factory with provider = custodian; id = Id "Factory NonTransferable"; observers
   issuerAccountForNonFungible <- Account.createAccount "Default Account for NonTransferable" []
-    accountFactoryCid holdingFactoryForNonTransferableCid [] Account.Owner custodian issuer
+    accountFactoryCid holdingFactoryNonTransferable [] Account.Owner custodian issuer
   submitMultiMustFail [issuer] [publicParty] do
     exerciseCmd transferableCid Transferable.Transfer with
       actors = S.singleton issuer; newOwnerAccount = issuerAccountForNonFungible
 
-  -- A transfer to an account using the Fungible holding standard must fail
-  holdingFactoryForFungibleCid <- toInterfaceContractId <$> submit custodian do
-    createCmd Fungible.Factory with provider = custodian; observers
+  -- A transfer to an account using a different holding standard (here Fungible) must fail
+  holdingFactoryFungible <- createHoldingFactoryWithReference $
+    Fungible.Factory with provider = custodian; id = Id "Factory Fungible"; observers
   issuerAccountForFungible <- Account.createAccount "Default Account for Fungible" []
-    accountFactoryCid holdingFactoryForFungibleCid [] Account.Owner custodian issuer
+    accountFactoryCid holdingFactoryFungible [] Account.Owner custodian issuer
   submitMultiMustFail [issuer] [publicParty] do
     exerciseCmd transferableCid
       Transferable.Transfer with

--- a/src/test/daml/Daml/Finance/Holding/Test/NonTransferable.daml
+++ b/src/test/daml/Daml/Finance/Holding/Test/NonTransferable.daml
@@ -13,6 +13,7 @@ import Daml.Finance.Interface.Account.Account qualified as Account (Debit(..), I
 import Daml.Finance.Interface.Holding.Base qualified as Base (I)
 import Daml.Finance.Interface.Holding.Fungible qualified as Fungible (I, Split(..))
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I, Transfer(..))
+import Daml.Finance.Interface.Types.Common.Types (Id(..))
 import Daml.Finance.Interface.Util.Lockable qualified as Lockable (Acquire(..), I, LockType(..), Release(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), submitExerciseInterfaceByKeyCmd, submitMustFailExerciseInterfaceByKeyCmd)
 import Daml.Script
@@ -23,9 +24,9 @@ run = script do
   tp@TestParties{custodian; issuer; investor; locker; locker2} <- setupParties
 
   -- Initialize state with `NonTransferable.Factory`
-  TestInitialState {investorAccount; issuerAccount; issuerHoldingCid} <- setupInitialState
-    tp
-    NonTransferable.Factory with provider = custodian; observers = M.empty
+  TestInitialState {investorAccount; issuerAccount; issuerHoldingCid} <- setupInitialState tp
+    NonTransferable.Factory with
+      provider = custodian; id = Id "Factory NonTransferable"; observers = M.empty
     []
     Account.Owner
 

--- a/src/test/daml/Daml/Finance/Holding/Test/Transfer.daml
+++ b/src/test/daml/Daml/Finance/Holding/Test/Transfer.daml
@@ -10,7 +10,7 @@ import DA.Set qualified as S (fromList, singleton, toList)
 import Daml.Finance.Holding.Fungible qualified as Fungible (Factory(..))
 import Daml.Finance.Holding.Test.Common (TestInitialState(..), TestParties(..), setupInitialState, setupParties)
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I, Transfer(..))
-import Daml.Finance.Interface.Types.Common.Types (AccountKey(..))
+import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), Id(..))
 import Daml.Finance.Interface.Util.Lockable qualified as Lockable (Acquire(..), GetView(..), I, LockType(..), Release(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..))
 import Daml.Script
@@ -23,12 +23,11 @@ testTransfer useReentrantLockTransferService = script do
 
   -- Initialize state with `Fungible.Factory`
   let pp = M.fromList [("PublicParty", S.singleton publicParty)]
-  TestInitialState {issuerAccount; issuerHoldingCid; investorAccount} <-
-    setupInitialState
-      tp
-      Fungible.Factory with provider = custodian; observers = pp
-      []
-      Account.Owner
+  TestInitialState {issuerAccount; issuerHoldingCid; investorAccount} <- setupInitialState tp
+    Fungible.Factory with
+      provider = custodian; id = Id "Factory Fungible"; observers = pp
+    []
+    Account.Owner
 
   -- Lock asset (with 2 contexts)
   lockableCid <- submitMulti [issuer, locker] [] do

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/DivOption.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/DivOption.daml
@@ -24,7 +24,7 @@ import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (verifyOwnerAndAmountOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference, verifyOwnerAndAmountOfHolding)
 import Daml.Finance.Test.Util.Instrument (originate)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (submitExerciseInterfaceByKeyCmd)
 import Daml.Script
@@ -39,16 +39,19 @@ run = script do
   -- Create parties
   [cb, issuer, custodian, investor, publicParty] <-
     createParties ["CentralBank", "Issuer", "Custodian", "Investor", "PublicParty"]
-
-  -- Create holding and account factory
   let pp = [("PublicParty", singleton publicParty)]
+
+  -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory issuer pp
-  holdingFactoryCid <- toInterfaceContractId <$> submit issuer do
-    createCmd Fungible.Factory with provider = issuer; observers = M.fromList pp
+
+  -- Create holding factory
+  holdingFactory <- Holding.createHoldingFactoryWithReference
+    Fungible.Factory with
+      provider = custodian; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts
   investorAccount <-
-    Account.createAccount "Investor Account" [publicParty] accountFactoryCid holdingFactoryCid []
+    Account.createAccount "Investor Account" [publicParty] accountFactoryCid holdingFactory []
     Account.Owner custodian investor
 
   let

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/DivOption.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/DivOption.daml
@@ -24,7 +24,7 @@ import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference, verifyOwnerAndAmountOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactory, verifyOwnerAndAmountOfHolding)
 import Daml.Finance.Test.Util.Instrument (originate)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (submitExerciseInterfaceByKeyCmd)
 import Daml.Script
@@ -45,7 +45,7 @@ run = script do
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory issuer pp
 
   -- Create holding factory
-  holdingFactory <- Holding.createHoldingFactoryWithReference
+  holdingFactory <- Holding.createHoldingFactory
     Fungible.Factory with
       provider = custodian; id = Id "Factory Fungible"; observers = M.fromList pp
 

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
@@ -21,7 +21,7 @@ import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference, verifyOwnerAndAmountOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactory, verifyOwnerAndAmountOfHolding)
 import Daml.Finance.Test.Util.Instrument (originate)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (submitExerciseInterfaceByKeyCmd)
 import Daml.Script
@@ -38,7 +38,7 @@ run = script do
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory issuer pp
 
   -- Create holding factory
-  holdingFactory <- Holding.createHoldingFactoryWithReference
+  holdingFactory <- Holding.createHoldingFactory
     Fungible.Factory with provider = custodian; id =Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
@@ -21,7 +21,7 @@ import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (verifyOwnerAndAmountOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference, verifyOwnerAndAmountOfHolding)
 import Daml.Finance.Test.Util.Instrument (originate)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (submitExerciseInterfaceByKeyCmd)
 import Daml.Script
@@ -32,16 +32,18 @@ run = script do
   -- Create parties
   [cb, issuer, custodian, investor, publicParty] <-
     createParties ["CentralBank", "Issuer", "Custodian", "Investor", "PublicParty"]
-
-  -- Create holding and account factory
   let pp = [("PublicParty", S.singleton publicParty)]
+
+  -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory issuer pp
-  holdingFactoryCid <- toInterfaceContractId <$> submit issuer do
-    createCmd Fungible.Factory with provider = issuer; observers = M.fromList pp
+
+  -- Create holding factory
+  holdingFactory <- Holding.createHoldingFactoryWithReference
+    Fungible.Factory with provider = custodian; id =Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts
   investorAccount <-
-    Account.createAccount "Account" [publicParty] accountFactoryCid holdingFactoryCid []
+    Account.createAccount "Account" [publicParty] accountFactoryCid holdingFactory []
     Account.Owner custodian investor
 
   -- Originate instruments

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Merger.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Merger.daml
@@ -21,7 +21,7 @@ import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference, verifyOwnerOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactory, verifyOwnerOfHolding)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (submitExerciseInterfaceByKeyCmd)
 import Daml.Script
 
@@ -38,7 +38,7 @@ run = script do
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory custodian pp
 
   -- Create holding factory
-  holdingFactory <- Holding.createHoldingFactoryWithReference
+  holdingFactory <- Holding.createHoldingFactory
     Fungible.Factory with
       provider = custodian; id = Id "Factory Fungible"; observers = M.fromList pp
 

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Merger.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Merger.daml
@@ -21,7 +21,7 @@ import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference, verifyOwnerOfHolding)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (submitExerciseInterfaceByKeyCmd)
 import Daml.Script
 
@@ -32,16 +32,19 @@ run = script do
   -- Create parties
   [merging, merged, custodian, investor, publicParty] <-
     createParties ["MergingIssuer", "MergedIssuer", "Custodian", "Investor", "PublicParty"]
-
-  -- Account and holding factory
   let pp = [("PublicParty", S.singleton publicParty)]
+
+  -- Account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory custodian pp
-  holdingFactoryCid <- toInterfaceContractId <$> submit custodian do
-    createCmd Fungible.Factory with provider = custodian; observers = M.fromList pp
+
+  -- Create holding factory
+  holdingFactory <- Holding.createHoldingFactoryWithReference
+    Fungible.Factory with
+      provider = custodian; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts
   investorSecuritiesAccount <- Account.createAccount "Securities Account" [] accountFactoryCid
-    holdingFactoryCid [] Account.Owner custodian investor
+    holdingFactory [] Account.Owner custodian investor
 
   -- CREATE_EQUITY_REPLACEMENT_RULE_BEGIN
   -- Create lifecycle rules

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/RightsIssue.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/RightsIssue.daml
@@ -24,7 +24,7 @@ import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (verifyOwnerAndAmountOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference, verifyOwnerAndAmountOfHolding)
 import Daml.Finance.Test.Util.Instrument (originate)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (submitExerciseInterfaceByKeyCmd)
 import Daml.Finance.Test.Util.Lifecycle (electAndVerifyPaymentEffects)
@@ -40,19 +40,22 @@ run = script do
   -- Create parties
   [cb, issuer, custodian, investor, publicParty] <-
     createParties ["CentralBank", "Issuer", "Custodian", "Investor", "PublicParty"]
-
-  -- Create holding and account factory
   let pp = [("PublicParty", S.singleton publicParty)]
+
+  -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory issuer pp
-  holdingFactoryCid <- toInterfaceContractId <$> submit issuer do
-    createCmd Fungible.Factory with provider = issuer; observers = M.fromList pp
+
+  -- Create holding factory
+  holdingFactory <- Holding.createHoldingFactoryWithReference
+    Fungible.Factory with
+      provider = custodian; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts
   investorAccount <-
-    Account.createAccount "Investor Account" [publicParty] accountFactoryCid holdingFactoryCid []
+    Account.createAccount "Investor Account" [publicParty] accountFactoryCid holdingFactory []
     Account.Owner custodian investor
   issuerAccount <-
-    Account.createAccount "Issuer Account" [publicParty] accountFactoryCid holdingFactoryCid []
+    Account.createAccount "Issuer Account" [publicParty] accountFactoryCid holdingFactory []
     Account.Owner custodian issuer
 
   let

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/RightsIssue.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/RightsIssue.daml
@@ -24,7 +24,7 @@ import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference, verifyOwnerAndAmountOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactory, verifyOwnerAndAmountOfHolding)
 import Daml.Finance.Test.Util.Instrument (originate)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (submitExerciseInterfaceByKeyCmd)
 import Daml.Finance.Test.Util.Lifecycle (electAndVerifyPaymentEffects)
@@ -46,7 +46,7 @@ run = script do
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory issuer pp
 
   -- Create holding factory
-  holdingFactory <- Holding.createHoldingFactoryWithReference
+  holdingFactory <- Holding.createHoldingFactory
     Fungible.Factory with
       provider = custodian; id = Id "Factory Fungible"; observers = M.fromList pp
 

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/StockSplit.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/StockSplit.daml
@@ -20,7 +20,7 @@ import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference, verifyOwnerOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactory, verifyOwnerOfHolding)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (submitExerciseInterfaceByKeyCmd)
 import Daml.Script
 
@@ -35,7 +35,7 @@ run = script do
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory issuer pp
 
   -- Create holding factory
-  holdingFactory <- Holding.createHoldingFactoryWithReference
+  holdingFactory <- Holding.createHoldingFactory
     Fungible.Factory with provider = issuer; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/StockSplit.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/StockSplit.daml
@@ -20,7 +20,7 @@ import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference, verifyOwnerOfHolding)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (submitExerciseInterfaceByKeyCmd)
 import Daml.Script
 
@@ -29,16 +29,18 @@ run : Script ()
 run = script do
   -- Create parties
   [issuer, investor, publicParty] <- createParties ["Issuer", "Investor", "PublicParty"]
+  let pp = [("PublicParty", S.singleton publicParty)]
 
   -- Create factories
-  let pp = [("PublicParty", S.singleton publicParty)]
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory issuer pp
-  holdingFactoryCid <- toInterfaceContractId <$> submit issuer do
-    createCmd Fungible.Factory with provider = issuer; observers = M.fromList pp
+
+  -- Create holding factory
+  holdingFactory <- Holding.createHoldingFactoryWithReference
+    Fungible.Factory with provider = issuer; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts
   investorSecuritiesAccount <- Account.createAccount "Securities Account" [] accountFactoryCid
-    holdingFactoryCid [] Account.Owner issuer investor
+    holdingFactory [] Account.Owner issuer investor
 
   -- CREATE_EQUITY_REPLACEMENT_RULE_BEGIN
   -- Create lifecycle rule

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
@@ -30,6 +30,7 @@ import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Finance.Test.Util.Time (createDateClock)
 import Daml.Script
@@ -77,16 +78,20 @@ run = script do
   --------------
   -- 0. SETUP --
   --------------
-  TestParties{..} <- setupParties
 
-  -- Account and holding factory
+  -- Create parties
+  TestParties{..} <- setupParties
   let pp = [("PublicParty", S.singleton publicParty)]
+
+  -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
-  holdingFactoryCid <- toInterfaceContractId <$> submit bank do
-    createCmd Fungible.Factory with provider = bank; observers = M.fromList pp
+
+  -- Create holding factory
+  holdingFactory <- Holding.createHoldingFactoryWithReference
+    Fungible.Factory with provider = bank; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts
-  investorAccount <- Account.createAccount "Default Account" [] accountFactoryCid holdingFactoryCid
+  investorAccount <- Account.createAccount "Default Account" [] accountFactoryCid holdingFactory
     [] Account.Owner bank investor
 
   -- Originate cash

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
@@ -30,7 +30,7 @@ import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactory)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Finance.Test.Util.Time (createDateClock)
 import Daml.Script
@@ -87,7 +87,7 @@ run = script do
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
 
   -- Create holding factory
-  holdingFactory <- Holding.createHoldingFactoryWithReference
+  holdingFactory <- Holding.createHoldingFactory
     Fungible.Factory with provider = bank; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/EuropeanOption.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/EuropeanOption.daml
@@ -33,6 +33,7 @@ import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Finance.Test.Util.Time (createDateClock)
 import Daml.Script
@@ -77,17 +78,21 @@ run = script do
   --------------
   -- 0. SETUP --
   --------------
-  TestParties{..} <- setupParties
 
-  -- Account and holding factory
+  -- Create parties
+  TestParties{..} <- setupParties
   let pp = [("PublicParty", S.singleton publicParty)]
+
+  -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
-  holdingFactoryCid <- toInterfaceContractId <$> submit bank do
-    createCmd Fungible.Factory with provider = bank; observers = M.fromList pp
+
+  -- Create holding factory
+  holdingFactory <- Holding.createHoldingFactoryWithReference
+    Fungible.Factory with provider = bank; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts
   [investor1Account, investor2Account] <- mapA (Account.createAccount "Default Account" []
-    accountFactoryCid holdingFactoryCid [] Account.Owner bank) [investor1, investor2]
+    accountFactoryCid holdingFactory [] Account.Owner bank) [investor1, investor2]
 
   -- Originate cash
   now <- getTime

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/EuropeanOption.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/EuropeanOption.daml
@@ -33,7 +33,7 @@ import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactory)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Finance.Test.Util.Time (createDateClock)
 import Daml.Script
@@ -87,7 +87,7 @@ run = script do
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
 
   -- Create holding factory
-  holdingFactory <- Holding.createHoldingFactoryWithReference
+  holdingFactory <- Holding.createHoldingFactory
     Fungible.Factory with provider = bank; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardCash.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardCash.daml
@@ -25,7 +25,7 @@ import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference, verifyOwnerOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactory, verifyOwnerOfHolding)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Finance.Test.Util.Time (createClockUpdateEvent)
 import Daml.Script
@@ -59,7 +59,7 @@ run = script do
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
 
   -- Create holding factory
-  holdingFactory <- Holding.createHoldingFactoryWithReference
+  holdingFactory <- Holding.createHoldingFactory
     Fungible.Factory with provider = bank; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardCash.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardCash.daml
@@ -25,7 +25,7 @@ import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference, verifyOwnerOfHolding)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Finance.Test.Util.Time (createClockUpdateEvent)
 import Daml.Script
@@ -51,16 +51,19 @@ data TestParties = TestParties
 -- Cash-settled forward trade lifecycling and settlement (needs observations)
 run : Script ()
 run = script do
+  -- Create parties
   TestParties{..} <- setupParties
-
-  -- Account and holding factory
   let pp = [("PublicParty", S.singleton publicParty)]
+
+  -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
-  holdingFactoryCid <- toInterfaceContractId <$> submit bank do
-    createCmd Fungible.Factory with provider = bank; observers = M.fromList pp
+
+  -- Create holding factory
+  holdingFactory <- Holding.createHoldingFactoryWithReference
+    Fungible.Factory with provider = bank; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts
-  investorAccount <- Account.createAccount "Default Account" [] accountFactoryCid holdingFactoryCid
+  investorAccount <- Account.createAccount "Default Account" [] accountFactoryCid holdingFactory
     [] Account.Owner bank investor
 
   -- Distribute cash

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardPhysical.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardPhysical.daml
@@ -24,7 +24,7 @@ import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference, verifyOwnerOfHolding)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Finance.Test.Util.Time (createClockUpdateEvent)
 import Daml.Script
@@ -54,16 +54,19 @@ data TestParties = TestParties
 -- Physically-settled forward trade lifecycling and settlement (no observations)
 run : Script ()
 run = script do
+  -- Create parties
   TestParties{..} <- setupParties
-
-  -- Account and holding factory
   let pp = [("PublicParty", S.singleton publicParty)]
+
+  -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
-  holdingFactoryCid <- toInterfaceContractId <$> submit bank do
-    createCmd Fungible.Factory with provider = bank; observers = M.fromList pp
+
+  -- Create holding factory
+  holdingFactory <- Holding.createHoldingFactoryWithReference
+    Fungible.Factory with provider = bank; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts
-  investorAccount <- Account.createAccount "Default Account" [] accountFactoryCid holdingFactoryCid
+  investorAccount <- Account.createAccount "Default Account" [] accountFactoryCid holdingFactory
     [] Account.Owner bank investor
 
   -- Distribute assets

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardPhysical.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardPhysical.daml
@@ -24,7 +24,7 @@ import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference, verifyOwnerOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactory, verifyOwnerOfHolding)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Finance.Test.Util.Time (createClockUpdateEvent)
 import Daml.Script
@@ -62,7 +62,7 @@ run = script do
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
 
   -- Create holding factory
-  holdingFactory <- Holding.createHoldingFactoryWithReference
+  holdingFactory <- Holding.createHoldingFactory
     Fungible.Factory with provider = bank; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
@@ -30,7 +30,7 @@ import Daml.Finance.Settlement.Instruction qualified as Instruction (T)
 import Daml.Finance.Settlement.RouteProvider.IntermediatedStatic (IntermediatedStatic(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit, submitExerciseInterfaceByKeyCmd)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (verifyOwnerOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference, verifyOwnerOfHolding)
 import Daml.Finance.Test.Util.Instrument qualified as BaseInstrument (originate)
 import Daml.Finance.Test.Util.Time (createClockUpdateEvent)
 import Daml.Script
@@ -606,9 +606,14 @@ setupParties = do
 -- Setup a set of accounts.
 setupAccounts : Text -> Party -> Party -> [Party] -> Script [AccountKey]
 setupAccounts description custodian publicParty owners = do
+  -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory custodian []
-  holdingFactoryCid <- toInterfaceContractId <$> submit custodian do
-    createCmd Fungible.Factory with
-      provider= custodian; observers = M.fromList [("PublicParty", S.singleton publicParty)]
-  forA owners $ Account.createAccount description [] accountFactoryCid holdingFactoryCid []
+  -- Create holding factory
+  holdingFactory <- Holding.createHoldingFactoryWithReference
+    Fungible.Factory with
+      provider = custodian
+      id = Id "Factory Fungible"
+      observers = M.fromList [("PublicParty", S.singleton publicParty)]
+  -- Create accounts
+  forA owners $ Account.createAccount description [] accountFactoryCid holdingFactory []
     Account.Owner custodian

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
@@ -30,7 +30,7 @@ import Daml.Finance.Settlement.Instruction qualified as Instruction (T)
 import Daml.Finance.Settlement.RouteProvider.IntermediatedStatic (IntermediatedStatic(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit, submitExerciseInterfaceByKeyCmd)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference, verifyOwnerOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactory, verifyOwnerOfHolding)
 import Daml.Finance.Test.Util.Instrument qualified as BaseInstrument (originate)
 import Daml.Finance.Test.Util.Time (createClockUpdateEvent)
 import Daml.Script
@@ -609,7 +609,7 @@ setupAccounts description custodian publicParty owners = do
   -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory custodian []
   -- Create holding factory
-  holdingFactory <- Holding.createHoldingFactoryWithReference
+  holdingFactory <- Holding.createHoldingFactory
     Fungible.Factory with
       provider = custodian
       id = Id "Factory Fungible"

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/ReverseConvertible.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/ReverseConvertible.daml
@@ -29,7 +29,7 @@ import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactory)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Finance.Test.Util.Time (createClockUpdateEvent)
 import Daml.Finance.Util.Date.DayCount (calcDcf)
@@ -75,7 +75,7 @@ run = script do
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
 
   -- Create holding factory
-  holdingFactory <- Holding.createHoldingFactoryWithReference
+  holdingFactory <- Holding.createHoldingFactory
     Fungible.Factory with provider = bank; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/ReverseConvertible.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/ReverseConvertible.daml
@@ -29,6 +29,7 @@ import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Finance.Test.Util.Time (createClockUpdateEvent)
 import Daml.Finance.Util.Date.DayCount (calcDcf)
@@ -68,15 +69,17 @@ data TestParties = TestParties
 run : Script ()
 run = script do
   TestParties{..} <- setupParties
-
-  -- Account and holding factory
   let pp = [("PublicParty", S.singleton publicParty)]
+
+  -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
-  holdingFactoryCid <- toInterfaceContractId <$> submit bank do
-    createCmd Fungible.Factory with provider = bank; observers = M.fromList pp
+
+  -- Create holding factory
+  holdingFactory <- Holding.createHoldingFactoryWithReference
+    Fungible.Factory with provider = bank; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts
-  investorAccount <- Account.createAccount "Default Account" [] accountFactoryCid holdingFactoryCid
+  investorAccount <- Account.createAccount "Default Account" [] accountFactoryCid holdingFactory
     [] Account.Owner bank investor
 
   -- Create cash instruments

--- a/src/test/daml/Daml/Finance/Settlement/Test/Batch.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Batch.daml
@@ -17,7 +17,7 @@ import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (verifyNoObservers, verifyOwnerOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference, verifyNoObservers, verifyOwnerOfHolding)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Script
 
@@ -54,13 +54,16 @@ data TestParties = TestParties
 -- +----------------+-----------------------+
 run: Bool -> Bool -> Script ()
 run settleCashOnledger bankIsRequesting = script do
+  -- Create parties
   TestParties{..} <- setupParties
+  let pp = [("PublicParty", S.singleton publicParty)]
 
-  -- Account and holding factory
+  -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank []
-  holdingFactoryCid <- toInterfaceContractId <$> submit bank do
-    createCmd Fungible.Factory with
-      provider = bank; observers = M.fromList [("PublicParty", S.singleton publicParty)]
+
+  -- Create holding factory
+  holdingFactory <- Holding.createHoldingFactoryWithReference
+    Fungible.Factory with provider = bank; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Originate instruments
   now <- getTime
@@ -69,12 +72,12 @@ run settleCashOnledger bankIsRequesting = script do
 
   -- Custody accounts
   [buyerCustodyAccount, sellerCustodyAccount] <-
-    mapA (Account.createAccount "Custody Account" [] accountFactoryCid holdingFactoryCid []
+    mapA (Account.createAccount "Custody Account" [] accountFactoryCid holdingFactory []
       Account.Owner bank) [buyer, seller]
 
   -- Cash accounts
   [buyerCashAccount, sellerCashAccount] <- mapA (Account.createAccount "Cash Account" []
-    accountFactoryCid holdingFactoryCid [] Account.Owner bank) [buyer, seller]
+    accountFactoryCid holdingFactory [] Account.Owner bank) [buyer, seller]
 
   -- Distribute equity
   equityHoldingCid <- Account.credit [] equityInstrument 1_000.0 sellerCustodyAccount

--- a/src/test/daml/Daml/Finance/Settlement/Test/Batch.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Batch.daml
@@ -17,7 +17,7 @@ import Daml.Finance.Settlement.Factory (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference, verifyNoObservers, verifyOwnerOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactory, verifyNoObservers, verifyOwnerOfHolding)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Script
 
@@ -62,7 +62,7 @@ run settleCashOnledger bankIsRequesting = script do
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank []
 
   -- Create holding factory
-  holdingFactory <- Holding.createHoldingFactoryWithReference
+  holdingFactory <- Holding.createHoldingFactory
     Fungible.Factory with provider = bank; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Originate instruments

--- a/src/test/daml/Daml/Finance/Settlement/Test/BatchWithIntermediaries.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/BatchWithIntermediaries.daml
@@ -21,7 +21,7 @@ import Daml.Finance.Settlement.Hierarchy (Hierarchy(..))
 import Daml.Finance.Settlement.RouteProvider.IntermediatedStatic (IntermediatedStatic(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference, verifyNoObservers, verifyOwnerOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactory, verifyNoObservers, verifyOwnerOfHolding)
 import Daml.Finance.Test.Util.HoldingDuplicates.Fungible qualified as FungibleV2 (Factory(..))
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Script
@@ -73,7 +73,7 @@ run bankAllocatesWithOwnHolding bankUsesCompatibleHoldingStandard = script do
   -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory csd []
   -- Create holding factory
-  holdingFactory <- Holding.createHoldingFactoryWithReference
+  holdingFactory <- Holding.createHoldingFactory
     NonFungible.Factory with provider = csd; id = Id "Factory NonFungible"; observers = M.fromList pp
   -- Create accounts
   [buyerSecurityAccount, sellerSecurityAccount] <- mapA (Account.createAccount "Security Account" []
@@ -83,7 +83,7 @@ run bankAllocatesWithOwnHolding bankUsesCompatibleHoldingStandard = script do
   -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory cb []
   -- Create holding factory
-  holdingFactory <- Holding.createHoldingFactoryWithReference
+  holdingFactory <- Holding.createHoldingFactory
     Fungible.Factory with
       provider = cb; id = Id "Factory Fungible"; observers = M.fromList pp
   -- Create accounts
@@ -98,11 +98,11 @@ run bankAllocatesWithOwnHolding bankUsesCompatibleHoldingStandard = script do
     if bankUsesCompatibleHoldingStandard
     then do
       -- use a factory for a different fungible token implementation
-      Holding.createHoldingFactoryWithReference
+      Holding.createHoldingFactory
         FungibleV2.Factory with
           provider = bank; id = Id "Factory FungibleV2"; observers = M.fromList pp
     else do
-      Holding.createHoldingFactoryWithReference
+      Holding.createHoldingFactory
         NonFungible.Factory with
           provider = bank; id = Id "Factory NonFungible"; observers = M.fromList pp
   -- Create accounts

--- a/src/test/daml/Daml/Finance/Settlement/Test/BatchWithIntermediaries.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/BatchWithIntermediaries.daml
@@ -21,7 +21,7 @@ import Daml.Finance.Settlement.Hierarchy (Hierarchy(..))
 import Daml.Finance.Settlement.RouteProvider.IntermediatedStatic (IntermediatedStatic(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (verifyNoObservers, verifyOwnerOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference, verifyNoObservers, verifyOwnerOfHolding)
 import Daml.Finance.Test.Util.HoldingDuplicates.Fungible qualified as FungibleV2 (Factory(..))
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Script
@@ -65,36 +65,49 @@ data TestParties = TestParties
 -- +-----------------------------+------------------------+
 run : Bool -> Bool -> Script ()
 run bankAllocatesWithOwnHolding bankUsesCompatibleHoldingStandard = script do
+  -- Create parties
   TestParties{..} <- setupParties
-
-  -- Setup security accounts (for non-fungible tokens)
   let pp = [("PublicParty", S.singleton publicParty)]
-  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory csd []
-  holdingFactoryCid <- toInterfaceContractId <$> submit csd do
-    createCmd NonFungible.Factory with provider = csd; observers = M.fromList pp
-  [buyerSecurityAccount, sellerSecurityAccount] <- mapA (Account.createAccount "Security Account" []
-    accountFactoryCid holdingFactoryCid [] Account.Owner csd) [buyer, seller]
 
-  -- Setup cash accounts at CB (for fungible tokens)
+  -- Setup security accounts at CB (utilising non-fungible holdings)
+  -- Create account factory
+  accountFactoryCid <- toInterfaceContractId <$> Account.createFactory csd []
+  -- Create holding factory
+  holdingFactory <- Holding.createHoldingFactoryWithReference
+    NonFungible.Factory with provider = csd; id = Id "Factory NonFungible"; observers = M.fromList pp
+  -- Create accounts
+  [buyerSecurityAccount, sellerSecurityAccount] <- mapA (Account.createAccount "Security Account" []
+    accountFactoryCid holdingFactory [] Account.Owner csd) [buyer, seller]
+
+  -- Setup cash accounts at CB (utilising fungible holdings)
+  -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory cb []
-  holdingFactoryCid <- toInterfaceContractId <$> submit cb do
-    createCmd Fungible.Factory with provider = cb; observers = M.fromList pp
+  -- Create holding factory
+  holdingFactory <- Holding.createHoldingFactoryWithReference
+    Fungible.Factory with
+      provider = cb; id = Id "Factory Fungible"; observers = M.fromList pp
+  -- Create accounts
   [buyerCashAccount, bankCashAccount] <- mapA (Account.createAccount "Cash Account" []
-    accountFactoryCid holdingFactoryCid [] Account.Owner cb) [buyer, bank]
+    accountFactoryCid holdingFactory [] Account.Owner cb) [buyer, bank]
 
   -- Setup cash accounts at Bank
+  -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank []
-  holdingFactoryCid <-
+  -- Create holding factory
+  holdingFactory <-
     if bankUsesCompatibleHoldingStandard
-    then
+    then do
       -- use a factory for a different fungible token implementation
-      toInterfaceContractId <$> submit bank do
-        createCmd FungibleV2.Factory with provider = bank; observers = M.fromList pp
-    else
-      toInterfaceContractId <$> submit bank do
-        createCmd NonFungible.Factory with provider = bank; observers = M.fromList pp
+      Holding.createHoldingFactoryWithReference
+        FungibleV2.Factory with
+          provider = bank; id = Id "Factory FungibleV2"; observers = M.fromList pp
+    else do
+      Holding.createHoldingFactoryWithReference
+        NonFungible.Factory with
+          provider = bank; id = Id "Factory NonFungible"; observers = M.fromList pp
+  -- Create accounts
   [sellerCashAccount] <- mapA (Account.createAccount "Cash Account" [] accountFactoryCid
-    holdingFactoryCid [] Account.Owner bank) [seller]
+    holdingFactory [] Account.Owner bank) [seller]
 
   -- Distribute assets
   now <- getTime
@@ -145,7 +158,7 @@ run bankAllocatesWithOwnHolding bankUsesCompatibleHoldingStandard = script do
     if bankAllocatesWithOwnHolding then
       do
         ownCashAccount <- Account.createAccount "Own Cash Account" [] accountFactoryCid
-          holdingFactoryCid [] Account.Owner bank bank
+          holdingFactory [] Account.Owner bank bank
         ownCashHoldingCid <- Account.credit [] cashInstrument 200_000.0 ownCashAccount
         submit bank do
           exerciseCmd cashInstruction2Cid

--- a/src/test/daml/Daml/Finance/Settlement/Test/Intermediated.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Intermediated.daml
@@ -23,7 +23,7 @@ import Daml.Finance.Settlement.Hierarchy (Hierarchy(..))
 import Daml.Finance.Settlement.RouteProvider.IntermediatedStatic (IntermediatedStatic(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit, submitExerciseInterfaceByKeyCmd)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference, verifyNoObservers, verifyOwnerOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactory, verifyNoObservers, verifyOwnerOfHolding)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Script
 
@@ -108,7 +108,7 @@ run useDelegatee = script do
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory provider pp
 
   -- Create holding factory
-  holdingFactory <- Holding.createHoldingFactoryWithReference
+  holdingFactory <- Holding.createHoldingFactory
     Fungible.Factory with provider; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts

--- a/src/test/daml/Daml/Finance/Settlement/Test/Intermediated.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Intermediated.daml
@@ -23,7 +23,7 @@ import Daml.Finance.Settlement.Hierarchy (Hierarchy(..))
 import Daml.Finance.Settlement.RouteProvider.IntermediatedStatic (IntermediatedStatic(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit, submitExerciseInterfaceByKeyCmd)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (verifyNoObservers, verifyOwnerOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference, verifyNoObservers, verifyOwnerOfHolding)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Script
 
@@ -100,18 +100,21 @@ run2 = run False
 --    delivery to their accounts, respectively.
 run : Bool -> Script ()
 run useDelegatee = script do
+  -- Create parties
   TestParties{..} <- setupParties
-
-  -- Account and holding factory
   let pp = [("PublicParty", S.singleton publicParty)]
+
+  -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory provider pp
-  holdingFactoryCid <- toInterfaceContractId <$> submit provider do
-    createCmd Fungible.Factory with provider; observers = M.fromList pp
+
+  -- Create holding factory
+  holdingFactory <- Holding.createHoldingFactoryWithReference
+    Fungible.Factory with provider; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts
   let
     createAccounts description custodian = mapA (Account.createAccount description [publicParty]
-      accountFactoryCid holdingFactoryCid [] Account.Owner custodian)
+      accountFactoryCid holdingFactory [] Account.Owner custodian)
   -- cash
   [buyerCashAccount] <- createAccounts "Cash Account" bank1 [buyer]
   [sellerCashAccount] <- createAccounts "Cash Account" bank2 [seller]

--- a/src/test/daml/Daml/Finance/Settlement/Test/Transfer.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Transfer.daml
@@ -25,7 +25,7 @@ import Daml.Finance.Settlement.Instruction qualified as Instruction (T)
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (verifyNoObservers, verifyOwnerOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference, verifyNoObservers, verifyOwnerOfHolding)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Script
 
@@ -59,17 +59,20 @@ data TestParties = TestParties
 -- +------------------+-----------------------+
 run : Script ()
 run = script do
+  -- Create parties
   TestParties{..} <- setupParties
-
-  -- Account and holding factory
   let pp = [("PublicParty", S.singleton publicParty)]
+
+  -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
-  holdingFactoryCid <- toInterfaceContractId <$> submit bank do
-    createCmd Fungible.Factory with provider = bank; observers = M.fromList pp
+
+  -- Create holding factory
+  holdingFactory <- Holding.createHoldingFactoryWithReference
+    Fungible.Factory with provider = bank; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts
   [senderAccount, receiverAccount] <- mapA (Account.createAccount "Cash Account" []
-    accountFactoryCid holdingFactoryCid [] Account.Owner bank) [sender, receiver]
+    accountFactoryCid holdingFactory [] Account.Owner bank) [sender, receiver]
 
   -- Distribute asset
   now <- getTime
@@ -159,16 +162,18 @@ run = script do
 run2 : Script ()
 run2 = script do
   TestParties{..} <- setupParties
-
-  -- Account and holding factory
   let pp = [("PublicParty", S.singleton publicParty)]
+
+  -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
-  holdingFactoryCid <- toInterfaceContractId <$> submit bank do
-    createCmd Fungible.Factory with provider = bank; observers = M.fromList pp
+
+  -- Create holding factory
+  holdingFactory <- Holding.createHoldingFactoryWithReference $
+    Fungible.Factory with provider = bank; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts
   [senderAccount, receiverAccount] <- mapA (Account.createAccount "Cash Account" []
-    accountFactoryCid holdingFactoryCid [] Account.Owner bank) [sender, receiver]
+    accountFactoryCid holdingFactory [] Account.Owner bank) [sender, receiver]
 
   -- Distribute asset
   now <- getTime
@@ -330,15 +335,17 @@ run3 : Script ()
 run3 = script do
   TestParties{..} <- setupParties
 
-  -- Account and holding factory
+  -- Create account factory
   let pp = [("PublicParty", S.singleton publicParty)]
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
-  holdingFactoryCid <- toInterfaceContractId <$> submit bank do
-    createCmd Fungible.Factory with provider = bank; observers = M.fromList pp
+
+    -- Create holding factory
+  holdingFactory <- Holding.createHoldingFactoryWithReference $
+    Fungible.Factory with provider = bank; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts
   [senderAccount, receiverAccount] <- mapA (Account.createAccount "Cash Account" []
-    accountFactoryCid holdingFactoryCid [] Account.Owner bank) [sender, receiver]
+    accountFactoryCid holdingFactory [] Account.Owner bank) [sender, receiver]
 
   -- Distribute asset
   now <- getTime
@@ -404,15 +411,17 @@ run4 : Script ()
 run4 = script do
   TestParties{..} <- setupParties
 
-  -- Account and holding factory
+  -- Create account factory
   let pp = [("PublicParty", S.singleton publicParty)]
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
-  holdingFactoryCid <- toInterfaceContractId <$> submit bank do
-    createCmd Fungible.Factory with provider = bank; observers = M.fromList pp
+
+  -- Create holding factory
+  holdingFactory <- Holding.createHoldingFactoryWithReference $
+    Fungible.Factory with provider = bank; id = Id"Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts
   [senderAccount, receiverAccount] <- mapA (Account.createAccount "Cash Account" []
-    accountFactoryCid holdingFactoryCid [] Account.Owner bank) [sender, receiver]
+    accountFactoryCid holdingFactory [] Account.Owner bank) [sender, receiver]
 
   -- Distribute asset
   now <- getTime
@@ -489,15 +498,17 @@ run5 : Script ()
 run5 = script do
   TestParties{..} <- setupParties
 
-  -- Account and holding factory
+  -- Create account factory
   let pp = [("PublicParty", S.singleton publicParty)]
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
-  holdingFactoryCid <- toInterfaceContractId <$> submit bank do
-    createCmd Fungible.Factory with provider = bank; observers = M.fromList pp
+
+  -- Create holding factory
+  holdingFactory <- Holding.createHoldingFactoryWithReference $
+    Fungible.Factory with provider = bank; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts
   [senderAccount, ccpAccount, receiverAccount] <- mapA (Account.createAccount "Cash Account" []
-    accountFactoryCid holdingFactoryCid [] Account.Owner bank) [sender, ccp, receiver]
+    accountFactoryCid holdingFactory [] Account.Owner bank) [sender, ccp, receiver]
 
   -- Distribute asset
   now <- getTime

--- a/src/test/daml/Daml/Finance/Settlement/Test/Transfer.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Transfer.daml
@@ -25,7 +25,7 @@ import Daml.Finance.Settlement.Instruction qualified as Instruction (T)
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
 import Daml.Finance.Test.Util.Common (createParties)
-import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactoryWithReference, verifyNoObservers, verifyOwnerOfHolding)
+import Daml.Finance.Test.Util.Holding qualified as Holding (createHoldingFactory, verifyNoObservers, verifyOwnerOfHolding)
 import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
 import Daml.Script
 
@@ -67,7 +67,7 @@ run = script do
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
 
   -- Create holding factory
-  holdingFactory <- Holding.createHoldingFactoryWithReference
+  holdingFactory <- Holding.createHoldingFactory
     Fungible.Factory with provider = bank; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts
@@ -168,7 +168,7 @@ run2 = script do
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
 
   -- Create holding factory
-  holdingFactory <- Holding.createHoldingFactoryWithReference $
+  holdingFactory <- Holding.createHoldingFactory $
     Fungible.Factory with provider = bank; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts
@@ -340,7 +340,7 @@ run3 = script do
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
 
     -- Create holding factory
-  holdingFactory <- Holding.createHoldingFactoryWithReference $
+  holdingFactory <- Holding.createHoldingFactory $
     Fungible.Factory with provider = bank; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts
@@ -416,7 +416,7 @@ run4 = script do
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
 
   -- Create holding factory
-  holdingFactory <- Holding.createHoldingFactoryWithReference $
+  holdingFactory <- Holding.createHoldingFactory $
     Fungible.Factory with provider = bank; id = Id"Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts
@@ -503,7 +503,7 @@ run5 = script do
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
 
   -- Create holding factory
-  holdingFactory <- Holding.createHoldingFactoryWithReference $
+  holdingFactory <- Holding.createHoldingFactory $
     Fungible.Factory with provider = bank; id = Id "Factory Fungible"; observers = M.fromList pp
 
   -- Create accounts

--- a/src/test/daml/Daml/Finance/Test/Util/Account.daml
+++ b/src/test/daml/Daml/Finance/Test/Util/Account.daml
@@ -13,8 +13,7 @@ import Daml.Finance.Account.Account qualified as Account (Factory(..))
 import Daml.Finance.Interface.Account.Account qualified as Account (Controllers(..), Credit(..), Debit(..), GetCid(..), I, R)
 import Daml.Finance.Interface.Account.Factory qualified as Account (Create(..), F)
 import Daml.Finance.Interface.Holding.Base qualified as Base (GetView(..), I)
-import Daml.Finance.Interface.Holding.Factory qualified as Holding (F)
-import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), Id(..), InstrumentKey, Parties)
+import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), HoldingFactoryKey, Id(..), InstrumentKey, Parties)
 import Daml.Finance.Interface.Util.Common (qty)
 import Daml.Finance.Test.Util.Common (submitExerciseInterfaceByKeyCmdHelper, submitMustFailExerciseInterfaceByKeyCmdHelper)
 import Daml.Script
@@ -50,18 +49,18 @@ createFactory provider observers = submit provider do
   createCmd Account.Factory with provider; observers = M.fromList observers
 
 -- | Create `Account`.
-createAccount : Text -> [Party] -> ContractId Account.F -> ContractId Holding.F ->
+createAccount : Text -> [Party] -> ContractId Account.F -> HoldingFactoryKey ->
   [(Text, Parties)] -> ControlledBy -> Party -> Party -> Script AccountKey
-createAccount description readAs factoryCid holdingFactoryCid
-  observers controlledBy custodian owner = do
-      let
-        account = AccountKey with
-          custodian; owner; id = Id $ show owner <> "@" <> show custodian <> "/" <> description
-      submitMulti [custodian, owner] readAs do
-        exerciseCmd factoryCid Account.Create with
-          account; holdingFactoryCid; controllers = toControllers custodian owner controlledBy
-          observers = M.fromList observers; description
-      pure account
+createAccount description readAs factoryCid holdingFactory observers controlledBy custodian owner =
+  do
+    let
+      account = AccountKey with
+        custodian; owner; id = Id $ show owner <> "@" <> show custodian <> "/" <> description
+    submitMulti [custodian, owner] readAs do
+      exerciseCmd factoryCid Account.Create with
+        account; holdingFactory; controllers = toControllers custodian owner controlledBy
+        observers = M.fromList observers; description
+    pure account
 
 -- | Credit an `Account`.
 credit : [Party] -> InstrumentKey -> Decimal -> AccountKey -> Script (ContractId Base.I)

--- a/src/test/daml/Daml/Finance/Test/Util/Holding.daml
+++ b/src/test/daml/Daml/Finance/Test/Util/Holding.daml
@@ -41,7 +41,7 @@ verifyNoObservers l = forA l
     v.observers === empty
 
 -- | Create a holding factory with refernce.
-createHoldingFactoryWithReference :
+createHoldingFactory :
   forall t.
   ( HasAgreement t
   , HasTemplateTypeRep t
@@ -50,7 +50,7 @@ createHoldingFactoryWithReference :
   , HasToInterface t HoldingFactory.F
   )
   => t -> Script HoldingFactoryKey
-createHoldingFactoryWithReference holdingFactory = do
+createHoldingFactory holdingFactory = do
   let
     factory = toInterface @HoldingFactory.F holdingFactory
     factoryView = view factory

--- a/src/test/daml/Daml/Finance/Test/Util/Holding.daml
+++ b/src/test/daml/Daml/Finance/Test/Util/Holding.daml
@@ -6,6 +6,9 @@ module Daml.Finance.Test.Util.Holding where
 import DA.Assert ((===))
 import DA.Map (empty)
 import Daml.Finance.Interface.Holding.Base qualified as Base (GetView(..), I)
+import Daml.Finance.Interface.Holding.Factory (Reference(..))
+import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (F, toKey)
+import Daml.Finance.Interface.Types.Common.Types (HoldingFactoryKey)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (GetView(..), I)
 import Daml.Script
 
@@ -36,3 +39,24 @@ verifyNoObservers l = forA l
       exerciseCmd (toInterfaceContractId @Disclosure.I holdingCid)
         Disclosure.GetView with viewer = owner
     v.observers === empty
+
+-- | Create a holding factory with refernce.
+createHoldingFactoryWithReference :
+  forall t.
+  ( HasAgreement t
+  , HasTemplateTypeRep t
+  , HasToAnyTemplate t
+  , HasFromAnyTemplate t
+  , HasToInterface t HoldingFactory.F
+  )
+  => t -> Script HoldingFactoryKey
+createHoldingFactoryWithReference holdingFactory = do
+  let
+    factory = toInterface @HoldingFactory.F holdingFactory
+    factoryView = view factory
+  cid <- toInterfaceContractId @HoldingFactory.F <$> submit factoryView.provider do
+    createCmd holdingFactory
+  submit factoryView.provider do
+    createCmd Reference with
+      factoryView; cid; observers = (view $ toInterface @Disclosure.I factory).observers
+  pure $ HoldingFactory.toKey factoryView

--- a/src/test/daml/Daml/Finance/Test/Util/HoldingDuplicates/Fungible.daml
+++ b/src/test/daml/Daml/Finance/Test/Util/HoldingDuplicates/Fungible.daml
@@ -14,7 +14,7 @@ import Daml.Finance.Interface.Holding.Base qualified as Base (I, View(..))
 import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (Create(..), F, View(..))
 import Daml.Finance.Interface.Holding.Fungible qualified as Fungible (I, View(..))
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I, View(..))
-import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), InstrumentKey(..), PartiesMap)
+import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), Id, InstrumentKey(..), PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Interface.Util.Lockable qualified as Lockable (I, Lock(..), View(..), getLockers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
@@ -76,6 +76,8 @@ template Factory
   with
     provider : Party
       -- ^ The factory's provider.
+    id : Id
+      -- ^ Identifier for the holding factory.
     observers : PartiesMap
       -- ^ The factory's observers.
   where
@@ -84,7 +86,7 @@ template Factory
 
     interface instance HoldingFactory.F for Factory
       where
-        view = HoldingFactory.View with provider
+        view = HoldingFactory.View with provider; id
         create' HoldingFactory.Create{instrument; account; amount; observers} = do
           assertMsg "amount must be positive" $ amount > 0.0
           toInterfaceContractId <$>

--- a/src/test/daml/Daml/Finance/Test/Util/HoldingDuplicates/NonFungible.daml
+++ b/src/test/daml/Daml/Finance/Test/Util/HoldingDuplicates/NonFungible.daml
@@ -13,7 +13,7 @@ import Daml.Finance.Holding.Util (transferImpl)
 import Daml.Finance.Interface.Holding.Base qualified as Base (I, View(..))
 import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (Create(..), F, View(..))
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I, View(..))
-import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), InstrumentKey(..), PartiesMap)
+import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), Id, InstrumentKey(..), PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Interface.Util.Lockable qualified as Lockable (I, Lock(..), View(..), getLockers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
@@ -70,6 +70,8 @@ template Factory
   with
     provider : Party
       -- ^ The factory's provider.
+    id : Id
+      -- ^ Identifier for the holding factory.
     observers : PartiesMap
       -- ^ The factory's observers.
   where
@@ -78,7 +80,7 @@ template Factory
 
     interface instance HoldingFactory.F for Factory
       where
-        view = HoldingFactory.View with provider
+        view = HoldingFactory.View with provider; id
         create' HoldingFactory.Create{instrument; account; amount; observers} = do
           assertMsg "amount must be positive" $ amount > 0.0
           toInterfaceContractId <$>

--- a/src/test/daml/Daml/Finance/Test/Util/HoldingDuplicates/NonTransferable.daml
+++ b/src/test/daml/Daml/Finance/Test/Util/HoldingDuplicates/NonTransferable.daml
@@ -11,7 +11,7 @@ module Daml.Finance.Test.Util.HoldingDuplicates.NonTransferable where
 import DA.Set (fromList, singleton)
 import Daml.Finance.Interface.Holding.Base qualified as Base (I, View(..))
 import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (Create(..), F, View(..))
-import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), InstrumentKey(..), PartiesMap)
+import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), Id, InstrumentKey(..), PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Interface.Util.Lockable qualified as Lockable (I, Lock(..), View(..), getLockers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
@@ -64,6 +64,8 @@ template Factory
   with
     provider : Party
       -- ^ The factory's provider.
+    id : Id
+      -- ^ Identifier for the factory.
     observers : PartiesMap
       -- ^ The factory's observers.
   where
@@ -72,7 +74,7 @@ template Factory
 
     interface instance HoldingFactory.F for Factory
       where
-        view = HoldingFactory.View with provider
+        view = HoldingFactory.View with provider; id
         create' HoldingFactory.Create{instrument; account; amount; observers} = do
           assertMsg "amount must be positive" $ amount > 0.0
           toInterfaceContractId <$>


### PR DESCRIPTION
This PR adress the tight coupling between Account <> HoldingFactory by:
 
1. Let the D.F.Interface.Holding.Factory be keyed (with help of corresponding Reference template)

2. Let Account.I refer to a HoldingFactoryKey (instead of ContractId D.F.Interface.Holding.Factory)

The PR also adds a factory for the holding factory to facilitate the creation of a holding factory together with its Reference.