### PR TITLE
Relax account to not require lockable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,8 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - Dependencies update
 
 - Let the `Account` implement the `Lockable` interface with `custodian` as required authorizer (for
-  exercising the `Acquire` choice).
+  exercising the `Acquire` choice). Note that `Account.I` is not requiring `Lockable`, so an
+  alternative implementation which does not implement `Lockable` is also possible.
 
 - The `Remove` choice of the `Factory` was removed (and is now part of the `Account`).
 
@@ -138,8 +139,6 @@ This document tracks pending changes to packages. It is facilitating the write-u
 ### Daml.Finance.Interface.Account
 
 - Dependencies update
-
-- Let the `Account` require the `Lockable` interface, effectively allowing to freeze an account.
 
 - Removed the `ContractId Holding.F` from the account view.
 

--- a/src/main/daml/Daml/Finance/Interface/Account/Account.daml
+++ b/src/main/daml/Daml/Finance/Interface/Account/Account.daml
@@ -10,7 +10,6 @@ import Daml.Finance.Interface.Holding.Base qualified as Base (I)
 import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), Id, InstrumentKey(..), Parties, PartiesMap, Quantity)
 import Daml.Finance.Interface.Util.Common (exerciseInterfaceByKeyHelper)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (AddObservers(..), GetView(..), I, RemoveObservers(..), flattenObservers)
-import Daml.Finance.Interface.Util.Lockable qualified as Lockable (I)
 
 -- | Type synonym for `Account`.
 type I = Account
@@ -55,7 +54,7 @@ accountKey : (HasToInterface i Account) => i -> AccountKey
 accountKey = toKey . view . toInterface @Account
 
 -- | An interface which represents an established relationship between a provider and an owner.
-interface Account requires Lockable.I, Disclosure.I where
+interface Account requires Disclosure.I where
   viewtype V
 
   getKey : AccountKey


### PR DESCRIPTION
@matteolimberto-da As we discussed at some point, I think it indeed makes sense to relax the `Account.I` to not require `Lockable.I`. We still provide a lockable account implementation, but a user of the library has the option to implement an "unlockable" account implementation if they prefer.