### PR TITLE
Avoid `coerceContractId`

### DIFF
--- a/src/main/daml/Daml/Finance/Account/Account.daml
+++ b/src/main/daml/Daml/Finance/Account/Account.daml
@@ -73,7 +73,7 @@ template Account
       release lockable@Lockable.Release{context} = do
         newLockableCid <- releaseImpl this.lock (\lock -> this with lock) lockable
          -- removing lockers as observers to Account.R
-        optional newLockableCid coerceContractId <$>
+        optional newLockableCid fromInterfaceContractId <$>
           exercise (toInterfaceContractId @Disclosure.I newLockableCid)
             Disclosure.RemoveObservers with
               disclosers = S.fromList $ signatory this


### PR DESCRIPTION
While looking for uses of `coerceContractId` as part of https://github.com/digital-asset/daml/issues/17450, I found a single one in this repo, but it turns out that the stronger-typed `fromInterfaceContractId` works just fine because `interface Lockable` requires `interface Disclosure`

Since I don't have permission to push to this repo, I had to push to my fork. Please feel free to copy the changes and open a new PR from this repo if needed for CI.