### PR TITLE
single-maintainer instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,12 +299,19 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 - Dependencies update
 
+- The `requestors : Parties` was split up into a single-maintainer for the key `instructor : Party`
+  and additional signatories `consenters : Parties`. The `Batch` and `Instruction` views were
+  amended accordingly.
+
 ### Daml.Finance.Interface.Types.Common
 
 - Added a `HoldingFactoryKey` data type which is used to key holding factories.
 
 - Added an enumeration data type `HoldingStandard` for referring to various holding standards. It
   is newly part of the `InstrumentKey`.
+
+- The `requestors : Parties` field of the `InstrumentKey` was replaced by `instructor : Party` (in
+  order to get a single-maintainer of the `Instruction` key).
 
 ### Daml.Finance.Interface.Types.Date
 
@@ -330,6 +337,8 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 - Replaced `lookupByKey` by an `exerciseByKey` in the `Distribution` and `Replacement` rule.
 
+- Replaced `providers : Parties` with `provider : Party` in the `Claim` rule (i.e., in the implementation only).
+
 ### Daml.Finance.Settlement
 
 - Dependencies update
@@ -338,6 +347,10 @@ This document tracks pending changes to packages. It is facilitating the write-u
   need identical `templateTypeRep`. Instead, they should share the same token standard
   (implementation variations are allowed). We rely on code vetting that the holding factories are
   implemented properly.
+
+- The `requestors : Parties` was split up into a single-maintainer for the key `instructor : Party`
+  and additional signatories `consenters : Parties`. The `Batch` and `Instruction` templates were
+  amended accordingly.
 
 ### Daml.Finance.Util
 

--- a/package/main/daml/Daml.Finance.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Claims/daml.yaml
@@ -13,8 +13,8 @@ data-dependencies:
   - .lib/daml-finance/ContingentClaims.Lifecycle/2.0.0/contingent-claims-lifecycle-2.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/0.99.0.20230927.1/daml-finance-interface-instrument-types-0.99.0.20230927.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20230927.1/daml-finance-interface-lifecycle-2.99.0.20230927.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20230927.1/daml-finance-interface-types-date-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar

--- a/package/main/daml/Daml.Finance.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Claims/daml.yaml
@@ -13,8 +13,8 @@ data-dependencies:
   - .lib/daml-finance/ContingentClaims.Lifecycle/2.0.0/contingent-claims-lifecycle-2.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/0.99.0.20231030.1/daml-finance-interface-instrument-types-0.99.0.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20231030.1/daml-finance-interface-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20230927.1/daml-finance-interface-types-date-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar

--- a/package/main/daml/Daml.Finance.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Data/daml.yaml
@@ -9,8 +9,8 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Data/3.0.1/daml-finance-interface-data-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/3.0.0.99.20231030.1/daml-finance-interface-data-3.0.0.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20231030.1/daml-finance-interface-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20230927.1/daml-finance-interface-types-date-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar

--- a/package/main/daml/Daml.Finance.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Data/daml.yaml
@@ -9,8 +9,8 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Data/3.0.0.99.20230927.1/daml-finance-interface-data-3.0.0.99.20230927.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20230927.1/daml-finance-interface-lifecycle-2.99.0.20230927.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/3.0.1/daml-finance-interface-data-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20230927.1/daml-finance-interface-types-date-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -15,7 +15,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/2.0.0/daml-finance-interface-instrument-bond-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/0.99.0.20231030.1/daml-finance-interface-instrument-types-0.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20230927.1/daml-finance-interface-types-date-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -15,7 +15,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/2.0.0/daml-finance-interface-instrument-bond-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/0.99.0.20230927.1/daml-finance-interface-instrument-types-0.99.0.20230927.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20230927.1/daml-finance-interface-types-date-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar

--- a/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
@@ -13,7 +13,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/3.0.0/daml-finance-interface-instrument-generic-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20230927.1/daml-finance-interface-lifecycle-2.99.0.20230927.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.0/daml-finance-lifecycle-3.0.0.dar

--- a/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
@@ -13,7 +13,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/3.0.0/daml-finance-interface-instrument-generic-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20231030.1/daml-finance-interface-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.0/daml-finance-lifecycle-3.0.0.dar

--- a/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
@@ -15,7 +15,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.4.0/daml-finance-interface-instrument-swap-0.4.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/0.99.0.20230927.1/daml-finance-interface-instrument-types-0.99.0.20230927.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20230927.1/daml-finance-interface-types-date-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar

--- a/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
@@ -15,7 +15,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.4.0/daml-finance-interface-instrument-swap-0.4.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/0.99.0.20231030.1/daml-finance-interface-instrument-types-0.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20230927.1/daml-finance-interface-types-date-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar

--- a/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
@@ -4,12 +4,12 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-data
 source: daml
-version: 3.0.1
+version: 3.0.0.99.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20231030.1/daml-finance-interface-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20230927.1/daml-finance-interface-types-date-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar

--- a/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
@@ -4,12 +4,12 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-data
 source: daml
-version: 3.0.0.99.20230927.1
+version: 3.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20230927.1/daml-finance-interface-lifecycle-2.99.0.20230927.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20230927.1/daml-finance-interface-types-date-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
@@ -11,7 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/0.99.0.20231030.1/daml-finance-interface-instrument-types-0.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20230927.1/daml-finance-interface-types-date-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
@@ -11,7 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/0.99.0.20230927.1/daml-finance-interface-instrument-types-0.99.0.20230927.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20230927.1/daml-finance-interface-types-date-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
@@ -10,7 +10,7 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20230927.1/daml-finance-interface-lifecycle-2.99.0.20230927.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
@@ -10,7 +10,7 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20231030.1/daml-finance-interface-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
@@ -11,7 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20230927.1/daml-finance-interface-lifecycle-2.99.0.20230927.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
@@ -11,7 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20231030.1/daml-finance-interface-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
@@ -10,7 +10,7 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/0.99.0.20231030.1/daml-finance-interface-instrument-types-0.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20230927.1/daml-finance-interface-types-date-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
@@ -10,7 +10,7 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/0.99.0.20230927.1/daml-finance-interface-instrument-types-0.99.0.20230927.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20230927.1/daml-finance-interface-types-date-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-instrument-types
 source: daml
-version: 1.0.0
+version: 0.99.0.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-instrument-types
 source: daml
-version: 0.99.0.20230927.1
+version: 1.0.0
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
@@ -4,13 +4,13 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-lifecycle
 source: daml
-version: 3.0.0
+version: 2.99.0.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.99.0.20230927.1/daml-finance-interface-holding-2.99.0.20230927.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.1/daml-finance-interface-settlement-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.0.99.20231030.1/daml-finance-interface-settlement-2.0.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
@@ -4,13 +4,13 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-lifecycle
 source: daml
-version: 2.99.0.20230927.1
+version: 3.0.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.99.0.20230927.1/daml-finance-interface-holding-2.99.0.20230927.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.0.99.20230927.1/daml-finance-interface-settlement-2.0.0.99.20230927.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.1/daml-finance-interface-settlement-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-settlement
 source: daml
-version: 2.0.0.99.20230927.1
+version: 2.0.1
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-settlement
 source: daml
-version: 2.0.1
+version: 2.0.0.99.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
@@ -12,8 +12,8 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Account/2.99.0.20230927.1/daml-finance-interface-account-2.99.0.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.99.0.20230927.1/daml-finance-interface-holding-2.99.0.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20230927.1/daml-finance-interface-lifecycle-2.99.0.20230927.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.0.99.20230927.1/daml-finance-interface-settlement-2.0.0.99.20230927.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.1/daml-finance-interface-settlement-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.99.20230927.1/daml-finance-util-3.0.99.20230927.1.dar

--- a/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
@@ -12,8 +12,8 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Account/2.99.0.20230927.1/daml-finance-interface-account-2.99.0.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.99.0.20230927.1/daml-finance-interface-holding-2.99.0.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.1/daml-finance-interface-settlement-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20231030.1/daml-finance-interface-lifecycle-2.99.0.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.0.99.20231030.1/daml-finance-interface-settlement-2.0.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.99.20230927.1/daml-finance-util-3.0.99.20230927.1.dar

--- a/package/main/daml/Daml.Finance.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Settlement/daml.yaml
@@ -4,14 +4,14 @@
 sdk-version: 2.7.0
 name: daml-finance-settlement
 source: daml
-version: 2.0.1
+version: 2.0.0.99.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Account/2.99.0.20230927.1/daml-finance-interface-account-2.99.0.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.99.0.20230927.1/daml-finance-interface-holding-2.99.0.20230927.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.1/daml-finance-interface-settlement-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.0.99.20231030.1/daml-finance-interface-settlement-2.0.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.99.20230927.1/daml-finance-util-3.0.99.20230927.1.dar

--- a/package/main/daml/Daml.Finance.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Settlement/daml.yaml
@@ -4,14 +4,14 @@
 sdk-version: 2.7.0
 name: daml-finance-settlement
 source: daml
-version: 2.0.0.99.20230927.1
+version: 2.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Account/2.99.0.20230927.1/daml-finance-interface-account-2.99.0.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.99.0.20230927.1/daml-finance-interface-holding-2.99.0.20230927.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.0.99.20230927.1/daml-finance-interface-settlement-2.0.0.99.20230927.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.1/daml-finance-interface-settlement-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.99.20230927.1/daml-finance-util-3.0.99.20230927.1.dar

--- a/package/test/daml/Daml.Finance.Data.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Data.Test/daml.yaml
@@ -11,8 +11,8 @@ dependencies:
   - daml-script
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Data/3.0.0.99.20230927.1/daml-finance-interface-data-3.0.0.99.20230927.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20230927.1/daml-finance-interface-lifecycle-2.99.0.20230927.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/3.0.1/daml-finance-interface-data-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20230927.1/daml-finance-interface-types-date-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar

--- a/package/test/daml/Daml.Finance.Data.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Data.Test/daml.yaml
@@ -11,8 +11,8 @@ dependencies:
   - daml-script
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Data/3.0.1/daml-finance-interface-data-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/3.0.0.99.20231030.1/daml-finance-interface-data-3.0.0.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20231030.1/daml-finance-interface-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20230927.1/daml-finance-interface-types-date-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar

--- a/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
@@ -14,7 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Instrument.Bond/2.0.0/daml-finance-instrument-bond-2.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/2.0.0/daml-finance-interface-instrument-bond-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/0.99.0.20230927.1/daml-finance-interface-instrument-types-0.99.0.20230927.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20230927.1/daml-finance-interface-types-date-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar

--- a/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
@@ -14,7 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Instrument.Bond/2.0.0/daml-finance-instrument-bond-2.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/2.0.0/daml-finance-interface-instrument-bond-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/0.99.0.20231030.1/daml-finance-interface-instrument-types-0.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20230927.1/daml-finance-interface-types-date-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar

--- a/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
@@ -16,12 +16,12 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Instrument.Option/0.3.0/daml-finance-instrument-option-0.3.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.4.0/daml-finance-interface-instrument-equity-0.4.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.3.0/daml-finance-interface-instrument-option-0.3.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20230927.1/daml-finance-interface-lifecycle-2.99.0.20230927.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.0.99.20230927.1/daml-finance-interface-settlement-2.0.0.99.20230927.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.1/daml-finance-interface-settlement-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.0/daml-finance-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/2.0.0.99.20230927.1/daml-finance-settlement-2.0.0.99.20230927.1.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/2.0.1/daml-finance-settlement-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
@@ -16,12 +16,12 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Instrument.Option/0.3.0/daml-finance-instrument-option-0.3.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.4.0/daml-finance-interface-instrument-equity-0.4.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.3.0/daml-finance-interface-instrument-option-0.3.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.1/daml-finance-interface-settlement-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20231030.1/daml-finance-interface-lifecycle-2.99.0.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.0.99.20231030.1/daml-finance-interface-settlement-2.0.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.0/daml-finance-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/2.0.1/daml-finance-settlement-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/2.0.0.99.20231030.1/daml-finance-settlement-2.0.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
@@ -19,13 +19,13 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.99.0.20230927.1/daml-finance-interface-holding-2.99.0.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/3.0.0/daml-finance-interface-instrument-generic-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20230927.1/daml-finance-interface-lifecycle-2.99.0.20230927.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.0.99.20230927.1/daml-finance-interface-settlement-2.0.0.99.20230927.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.1/daml-finance-interface-settlement-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20230927.1/daml-finance-interface-types-date-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.0/daml-finance-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/2.0.0.99.20230927.1/daml-finance-settlement-2.0.0.99.20230927.1.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/2.0.1/daml-finance-settlement-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.99.20230927.1/daml-finance-util-3.0.99.20230927.1.dar
 build-options: null

--- a/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
@@ -19,13 +19,13 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.99.0.20230927.1/daml-finance-interface-holding-2.99.0.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/3.0.0/daml-finance-interface-instrument-generic-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.1/daml-finance-interface-settlement-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20231030.1/daml-finance-interface-lifecycle-2.99.0.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.0.99.20231030.1/daml-finance-interface-settlement-2.0.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20230927.1/daml-finance-interface-types-date-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.0/daml-finance-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/2.0.1/daml-finance-settlement-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/2.0.0.99.20231030.1/daml-finance-settlement-2.0.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.99.20230927.1/daml-finance-util-3.0.99.20230927.1.dar
 build-options: null

--- a/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
@@ -14,7 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Instrument.Option/0.3.0/daml-finance-instrument-option-0.3.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.3.0/daml-finance-interface-instrument-option-0.3.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20231030.1/daml-finance-interface-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar

--- a/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
@@ -14,7 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Instrument.Option/0.3.0/daml-finance-instrument-option-0.3.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.3.0/daml-finance-interface-instrument-option-0.3.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20230927.1/daml-finance-interface-lifecycle-2.99.0.20230927.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar

--- a/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
@@ -13,7 +13,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Instrument.Swap/0.4.0/daml-finance-instrument-swap-0.4.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.4.0/daml-finance-interface-instrument-swap-0.4.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/0.99.0.20231030.1/daml-finance-interface-instrument-types-0.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20230927.1/daml-finance-interface-types-date-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar

--- a/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
@@ -13,7 +13,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Instrument.Swap/0.4.0/daml-finance-instrument-swap-0.4.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.4.0/daml-finance-interface-instrument-swap-0.4.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/0.99.0.20230927.1/daml-finance-interface-instrument-types-0.99.0.20230927.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20230927.1/daml-finance-interface-types-date-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar

--- a/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
@@ -14,10 +14,10 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Holding/2.99.0.20230927.1/daml-finance-holding-2.99.0.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Account/2.99.0.20230927.1/daml-finance-interface-account-2.99.0.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.99.0.20230927.1/daml-finance-interface-holding-2.99.0.20230927.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.1/daml-finance-interface-settlement-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.0.99.20231030.1/daml-finance-interface-settlement-2.0.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/2.0.1/daml-finance-settlement-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/2.0.0.99.20231030.1/daml-finance-settlement-2.0.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
@@ -14,10 +14,10 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Holding/2.99.0.20230927.1/daml-finance-holding-2.99.0.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Account/2.99.0.20230927.1/daml-finance-interface-account-2.99.0.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.99.0.20230927.1/daml-finance-interface-holding-2.99.0.20230927.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.0.99.20230927.1/daml-finance-interface-settlement-2.0.0.99.20230927.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.1/daml-finance-interface-settlement-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/2.0.0.99.20230927.1/daml-finance-settlement-2.0.0.99.20230927.1.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/2.0.1/daml-finance-settlement-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Test.Util/daml.yaml
+++ b/package/test/daml/Daml.Finance.Test.Util/daml.yaml
@@ -19,7 +19,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.99.0.20230927.1/daml-finance-interface-holding-2.99.0.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/3.0.0/daml-finance-interface-instrument-token-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20230927.1/daml-finance-interface-lifecycle-2.99.0.20230927.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20230927.1/daml-finance-interface-types-date-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar

--- a/package/test/daml/Daml.Finance.Test.Util/daml.yaml
+++ b/package/test/daml/Daml.Finance.Test.Util/daml.yaml
@@ -19,7 +19,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.99.0.20230927.1/daml-finance-interface-holding-2.99.0.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/3.0.0/daml-finance-interface-instrument-token-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20231030.1/daml-finance-interface-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20230927.1/daml-finance-interface-types-common-1.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20230927.1/daml-finance-interface-types-date-2.0.99.20230927.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20230927.1/daml-finance-interface-util-2.0.99.20230927.1.dar

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Batch.daml
@@ -16,8 +16,10 @@ type V = View
 -- | View for `Batch`.
 data View = View
   with
-    requestors : Parties
-      -- ^ Parties requesting the settlement.
+    instructor : Party
+      -- ^ Party instructing settlement (and the creation of the `Batch`).
+    consenters : Parties
+      -- ^ Parties consenting with the creation of the `Batch`.
     settlers : Parties
       -- ^ Parties that can trigger the final settlement.
     id : Id

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Factory.daml
@@ -45,8 +45,10 @@ interface Factory where
   nonconsuming choice Instruct : (ContractId Batch.I, [ContractId Instruction.I])
     -- ^ Generate settlement instructions, and a batch for settling them.
     with
-      instructors : Parties
-        -- ^ Parties requesting to instruct a settlement.
+      instructor : Party
+        -- ^ Party instructing settlement (and the creation of the `Batch` and `Instruction`s).
+      consenters : Parties
+        -- ^ Parties consenting with the `Batch` and `Instruction`s being created.
       settlers : Parties
         -- ^ Any of the parties can trigger the final settlement.
       id : Id
@@ -59,6 +61,6 @@ interface Factory where
         -- ^ Routed settlement steps to instruct.
       settlementTime : Optional Time
         -- ^ Settlement time (if any).
-    controller instructors
+    controller instructor, consenters
     do
       instruct this arg

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Instruction.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Instruction.daml
@@ -17,8 +17,10 @@ type V = View
 -- | View for `Instruction`.
 data View = View
   with
-    requestors : Parties
-      -- ^ Parties that instructed settlement.
+    instructor : Party
+      -- ^ Party that instructs settlement (and the creation of the `Instruction`).
+    consenters : Parties
+      -- ^ Parties consenting with the creation of the `Instruction`.
     settlers : Parties
       -- ^ Parties that can execute the Instruction.
     batchId : Id

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Types.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Types.daml
@@ -4,7 +4,7 @@
 module Daml.Finance.Interface.Settlement.Types where
 
 import Daml.Finance.Interface.Holding.Holding qualified as Holding (I)
-import Daml.Finance.Interface.Types.Common.Types (AccountKey, Id, InstrumentQuantity, Parties)
+import Daml.Finance.Interface.Types.Common.Types (AccountKey, Id, InstrumentQuantity)
 
 -- | Describes a transfer of a position between two parties.
 data Step = Step
@@ -63,8 +63,8 @@ data Approval
 -- | A unique key for Instructions.
 data InstructionKey = InstructionKey
   with
-    requestors : Parties
-      -- ^ Parties requesting settlement of the instruction.
+    instructor : Party
+      -- ^ Party instructing settlement (and the creation of the `Instruction`).
     batchId : Id
       -- ^ Id of the batch the instruction belongs to.
     id : Id

--- a/src/main/daml/Daml/Finance/Lifecycle/Rule/Claim.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Rule/Claim.daml
@@ -3,7 +3,7 @@
 
 module Daml.Finance.Lifecycle.Rule.Claim where
 
-import DA.Set (member)
+import DA.Set (member, singleton)
 import Daml.Finance.Interface.Account.Util (getCustodian, getOwner)
 import Daml.Finance.Interface.Holding.Util (getAmount, getInstrument)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (Calculate(..), CalculationResult(..), GetView(..))
@@ -20,8 +20,8 @@ type T = Rule
 -- | Rule contract that allows an actor to claim effects, returning settlement instructions.
 template Rule
   with
-    providers : Parties
-      -- ^ Providers of the claim rule. Together with the actors of the `ClaimEffect` choice the
+    provider : Party
+      -- ^ Provider of the claim rule. Together with the actors of the `ClaimEffect` choice the
       --   authorization requirements to upgrade the holdings being claimed have to be met.
     claimers : Parties
       -- ^ Any of the parties can claim an effect.
@@ -35,11 +35,12 @@ template Rule
       -- ^ Configure whether netting should be enabled for quantities having the same (instrument,
       --   sender, receiver).
   where
-    signatory providers
+    signatory provider
     observer claimers
 
     interface instance Claim.I for Rule where
-      view = Claim.View with providers; claimers; settlers; routeProviderCid; settlementFactoryCid
+      view = Claim.View with
+        providers = singleton provider; claimers; settlers; routeProviderCid; settlementFactoryCid
       claimEffect Claim.ClaimEffect{claimer; holdingCids; effectCid; batchId} = do
         assertMsg "Effect can only be claimed by authorized parties." $
           claimer `member` this.claimers
@@ -75,11 +76,12 @@ template Rule
 
         -- Discover settlement routes
         routedSteps <- exercise routeProviderCid RouteProvider.Discover with
-          discoverors = providers; contextId = None; steps
+          discoverors = singleton provider; contextId = None; steps
 
         -- Generate settlement instructions for other instruments
         (batchCid, instructionCids) <- exercise settlementFactoryCid Settlement.Instruct with
-          instructors = providers
+          instructor = provider
+          consenters = mempty
           settlers
           id = batchId
           description = effectView.description

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -7,7 +7,7 @@ import DA.Action (foldlA)
 import DA.Map qualified as M (fromList, lookup)
 import DA.Optional (catOptionals, fromSomeNote)
 import DA.Set (Set)
-import DA.Set qualified as S (empty, insert, intersection, member, null, union)
+import DA.Set qualified as S (empty, insert, intersection, member, null, singleton)
 import DA.Traversable qualified as T
 import Daml.Finance.Interface.Holding.Util (undisclose)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Cancel(..), I, Settle(..), View(..))
@@ -22,8 +22,10 @@ type T = Batch
 -- | Allows you to atomically settle a set of settlement `Step`.
 template Batch
   with
-    requestors : Parties
-      -- ^ Parties requesting the settlement.
+    instructor : Party
+      -- ^ Party instructing settlement (and the creation of the `Batch`).
+    consenters : Parties
+      -- ^ Parties consenting with the creation of the `Batch`.
     settlers : Parties
       -- ^ Any of the parties can trigger the settlement.
     id : Id
@@ -37,12 +39,12 @@ template Batch
     settlementTime : Optional Time
       -- ^ Settlement time (if any).
   where
-    signatory requestors
+    signatory instructor, consenters
     observer settlers
 
     interface instance Batch.I for Batch where
       view = Batch.View with
-        requestors; settlers; id; description; contextId
+        instructor; consenters; settlers; id; description; contextId
         routedSteps = routedSteps this.routedStepsWithInstructionId; settlementTime
       settle Batch.Settle{actors} = do
         assertMsg "Actors must intersect with settlers." $
@@ -59,7 +61,7 @@ template Batch
             -- execute instruction and get used holding standards for the instrument
             (instructionCid, instruction) <- fetchByKey @Instruction instructionKey
             settledCid <- exercise (toInterfaceContractId @Instruction.I instructionCid)
-              Instruction.Execute with actors = actors `S.union` requestors
+              Instruction.Execute with actors = actors <> S.singleton instructor <> consenters
             join <$> T.mapA (undisclose (context, settlers) actors) settledCid
         -- execute instructions
         orderedSettledCids <- mapA settleInstruction orderedInstructions
@@ -78,7 +80,7 @@ template Batch
             instructionCid <- fst <$> fetchByKey @Instruction instruction
             exercise (toInterfaceContractId @Instruction.I instructionCid)
               Instruction.Cancel with actors
-        allMustAuthorize requestors
+        allMustAuthorize $ S.singleton instructor <> consenters
         -- cancel instructions
         catOptionals <$> mapA (cancelInstruction . buildKey this . snd) routedStepsWithInstructionId
 
@@ -92,8 +94,8 @@ instructionIds = fmap snd
 
 -- | HIDE
 buildKey : Batch -> Id -> InstructionKey
-buildKey Batch {requestors; id} instructionId =
-  InstructionKey with requestors; batchId = id; id = instructionId
+buildKey Batch {instructor; id} instructionId =
+  InstructionKey with instructor; batchId = id; id = instructionId
 
 -- | HIDE
 -- Partially order instructions, so that pass-through chains can be executed in order.

--- a/src/main/daml/Daml/Finance/Settlement/Factory.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Factory.daml
@@ -27,13 +27,14 @@ template Factory
 
     interface instance SettlementFactory.F for Factory where
       view = SettlementFactory.View with provider; observers
-      instruct SettlementFactory.Instruct {instructors; settlers; id; description; contextId;
-        routedSteps; settlementTime} = do
+      instruct SettlementFactory.Instruct {instructor; consenters; settlers; id; description;
+        contextId; routedSteps; settlementTime} = do
           let
             createInstruction index routedStep =
               ( index + 1,
                 Instruction with
-                  requestors = instructors
+                  instructor
+                  consenters
                   settlers
                   batchId = id
                   id = Id (show index)
@@ -50,7 +51,8 @@ template Factory
           instructionCids <- mapA (fmap toInterfaceContractId . create) instructions
           batchCid <- toInterfaceContractId <$>
             create Batch with
-              requestors = instructors
+              instructor
+              consenters
               settlers
               id
               description

--- a/src/main/daml/Daml/Finance/Settlement/Instruction.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Instruction.daml
@@ -4,7 +4,7 @@
 module Daml.Finance.Settlement.Instruction where
 
 import DA.List qualified as L (head)
-import DA.Set qualified as S (Set, empty, fromList, intersection, isSubsetOf, null, singleton, toList, union)
+import DA.Set qualified as S (Set, empty, fromList, insert, intersection, isSubsetOf, null, singleton, toList, union)
 import Daml.Finance.Interface.Account.Account qualified as Account (Credit(..), Debit(..), I, R, disclose, exerciseInterfaceByKey, undisclose)
 import Daml.Finance.Interface.Account.Util (getAccount)
 import Daml.Finance.Interface.Holding.Holding qualified as Holding (I)
@@ -26,8 +26,10 @@ type T = Instruction
 -- - the receiver must define the receiving account
 template Instruction
   with
-    requestors : Parties
-      -- ^ Parties requesting the settlement.
+    instructor : Party
+      -- ^ Party instructing settlement (and the creation of the `Instruction`).
+    consenters : Parties
+      -- ^ Parties consenting with the creation of the `Instruction`.
     settlers : Parties
       -- ^ Any of the parties can trigger the settlement.
     batchId : Id
@@ -49,11 +51,11 @@ template Instruction
     observers : PartiesMap
       -- ^ Observers.
   where
-    signatory requestors, signedSenders, signedReceivers
+    signatory instructor, consenters, signedSenders, signedReceivers
     observer routedStep.sender, routedStep.receiver, settlers, Disclosure.flattenObservers observers
 
-    key instructionKey this : InstructionKey
-    maintainer key.requestors
+    key InstructionKey with instructor; batchId; id : InstructionKey
+    maintainer key.instructor
 
     interface instance Disclosure.I for Instruction where
       view = Disclosure.View with
@@ -64,8 +66,8 @@ template Instruction
 
     interface instance Instruction.I for Instruction where
       view = Instruction.View with
-        requestors; settlers; batchId; id; routedStep; settlementTime; signedSenders
-        signedReceivers; allocation; approval
+        instructor; consenters; settlers; batchId; id; routedStep; settlementTime
+        allocation; approval; signedSenders; signedReceivers
       allocate Instruction.Allocate{actors; allocation} = do
         let
           allMustAuthorize = mustAuthorizeHelper True actors
@@ -92,7 +94,7 @@ template Instruction
             holdingCid <- fromInterfaceContractId @Holding.I <$>
               exercise (toInterfaceContractId @Lockable.I holdingCid)
                 Lockable.Acquire with
-                  newLockers = requestors <> senderAccount.controllers.outgoing
+                  newLockers = S.singleton instructor <> senderAccount.controllers.outgoing
                   context = context this
                   lockType = Lockable.Semaphore
             pure $ Pledge holdingCid
@@ -106,7 +108,7 @@ template Instruction
             mustBe this Sender passThroughAccount.owner
             fromInstruction <- snd <$> fetchByKey @Instruction fromInstructionKey
             assertMsg ("Pass-through-from instruction must be part of the batch. " <> context this)
-              $ fromInstruction.batchId == batchId && fromInstruction.requestors == requestors
+              $ fromInstruction.batchId == batchId && fromInstruction.instructor == instructor
             mustBe this Custodian fromInstruction.routedStep.custodian
             mustBe this Sender fromInstruction.routedStep.receiver
             pure allocation
@@ -148,7 +150,7 @@ template Instruction
             mustBe this Receiver passThroughAccount.owner
             toInstruction <- snd <$> fetchByKey @Instruction toInstructionKey
             assertMsg ("Pass-through-to instruction must be part of the batch. " <> context this) $
-              toInstruction.batchId == batchId && toInstruction.requestors == requestors
+              toInstruction.batchId == batchId && toInstruction.instructor == instructor
             mustBe this Custodian toInstruction.routedStep.custodian
             mustBe this Receiver toInstruction.routedStep.sender
           DebitSender -> do
@@ -162,7 +164,7 @@ template Instruction
           signedReceivers = if approval == Unapproved then S.empty else actors
       execute Instruction.Execute{actors} = do
         let allMustAuthorize = mustAuthorizeHelper True actors
-        allMustAuthorize requestors
+        allMustAuthorize $ S.insert instructor consenters
         assertMsg ("Actors must intersect with settlers. " <> context this) $
           not $ S.null $ actors `S.intersection` settlers
         let
@@ -247,17 +249,13 @@ template Instruction
               _ -> abortOnOffledgerMix
       cancel Instruction.Cancel{actors} = do
         let allMustAuthorize = mustAuthorizeHelper True actors
-        allMustAuthorize requestors
+        allMustAuthorize $ S.insert instructor consenters
         releasePreviousApproval this actors
         releasePreviousAllocation this actors
 
 -- | HIDE
-instructionKey : Instruction -> InstructionKey
-instructionKey Instruction {requestors; batchId; id} = InstructionKey with requestors; batchId; id
-
--- | HIDE
 context : Instruction -> Text
-context = show . instructionKey
+context = show . key
 
 -- | HIDE
 mustBe : Instruction -> Role -> Party -> Update ()

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/DivOption.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/DivOption.daml
@@ -114,7 +114,7 @@ run = script do
   let settlers = fromList [investor, custodian]
   claimRuleCid <- toInterfaceContractId @Claim.I <$> submit custodian do
     createCmd Claim.Rule with
-      providers = singleton custodian
+      provider = custodian
       claimers = fromList [investor, custodian]
       settlers
       routeProviderCid
@@ -185,7 +185,7 @@ run = script do
   -- Create a claim rule
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submit custodian do
     createCmd Claim.Rule with
-      providers = singleton custodian
+      provider = custodian
       claimers = fromList [investor, issuer]
       settlers
       routeProviderCid

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
@@ -103,7 +103,7 @@ run = script do
   -- Enable netting so that there is only one holding with the new correct quantity
   claimRuleCid <- toInterfaceContractId @Claim.I <$> submit custodian do
     createCmd Claim.Rule with
-      providers = S.singleton custodian
+      provider = custodian
       claimers = S.fromList [investor, custodian]
       settlers = S.fromList [investor, custodian]
       routeProviderCid

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Merger.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Merger.daml
@@ -99,7 +99,7 @@ run = script do
     createCmd Factory with provider = custodian; observers = S.singleton publicParty
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submit custodian do
     createCmd Claim.Rule with
-      providers = S.singleton custodian
+      provider = custodian
       claimers = S.fromList [custodian, investor]
       settlers = S.fromList [custodian, investor]
       routeProviderCid

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/RightsIssue.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/RightsIssue.daml
@@ -112,7 +112,7 @@ run = script do
   let settlers = S.fromList [investor, custodian]
   claimRuleCid <- toInterfaceContractId @Claim.I <$> submit custodian do
     createCmd Claim.Rule with
-      providers = S.singleton custodian
+      provider = custodian
       claimers = S.fromList [investor, custodian]
       settlers
       routeProviderCid
@@ -192,7 +192,7 @@ run = script do
   -- Create a claim rule
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submit custodian do
     createCmd Claim.Rule with
-      providers = S.singleton custodian
+      provider = custodian
       claimers = S.fromList [custodian, investor]
       settlers
       routeProviderCid

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/StockSplit.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/StockSplit.daml
@@ -96,7 +96,7 @@ run = script do
     createCmd Factory with provider = issuer; observers = S.singleton publicParty
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submit issuer do
     createCmd Claim.Rule with
-      providers = S.singleton issuer
+      provider = issuer
       claimers = S.fromList [investor, issuer]
       settlers = S.fromList [investor, issuer]
       routeProviderCid

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
@@ -183,7 +183,7 @@ run = script do
 
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submit bank do
     createCmd Claim.Rule with
-      providers = S.singleton bank
+      provider = bank
       claimers = S.fromList [bank, investor]
       settlers
       routeProviderCid

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/EuropeanOption.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/EuropeanOption.daml
@@ -215,7 +215,7 @@ run = script do
   -- Claim effect
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submit bank do
     createCmd Claim.Rule with
-      providers = S.singleton bank
+      provider = bank
       claimers = S.fromList [bank, investor1]
       settlers
       routeProviderCid
@@ -303,7 +303,7 @@ run = script do
 
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submit bank do
     createCmd Claim.Rule with
-      providers = S.singleton bank
+      provider = bank
       claimers = S.fromList [bank, investor2]
       settlers
       routeProviderCid

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardCash.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardCash.daml
@@ -104,11 +104,10 @@ run = script do
       description = "Rule to lifecycle a generic instrument"
 
   (_, [effectCid]) <- submit broker do
-    exerciseCmd lifecycleRuleCid Lifecycle.Evolve
-      with
-        eventCid = clockEventCid
-        observableCids = [observableCid]
-        instrument = genericInstrument
+    exerciseCmd lifecycleRuleCid Lifecycle.Evolve with
+      eventCid = clockEventCid
+      observableCids = [observableCid]
+      instrument = genericInstrument
 
   -- Create route provider
   routeProviderCid <- toInterfaceContractId <$> submit bank do
@@ -120,14 +119,13 @@ run = script do
 
   -- Claim effect
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submit bank do
-    createCmd Claim.Rule
-      with
-        providers = S.singleton bank
-        claimers = S.fromList [bank, investor]
-        settlers
-        routeProviderCid
-        settlementFactoryCid
-        netInstructions = False
+    createCmd Claim.Rule with
+      provider = bank
+      claimers = S.fromList [bank, investor]
+      settlers
+      routeProviderCid
+      settlementFactoryCid
+      netInstructions = False
 
   result <- submitMulti [bank] [publicParty] do
     exerciseCmd lifecycleClaimRuleCid Claim.ClaimEffect with

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardPhysical.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardPhysical.daml
@@ -7,7 +7,7 @@ import ContingentClaims.Core.Claim (and, at, give, one, scale, when)
 import ContingentClaims.Core.Observation (Observation(..))
 import DA.Date (addDays, toDateUTC)
 import DA.Map qualified as M (empty, fromList)
-import DA.Set qualified as S (empty, fromList, singleton, toList)
+import DA.Set qualified as S (empty, singleton, toList)
 import DA.Time (time)
 import Daml.Finance.Data.Time.DateClock (dateToDateClockTime)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
@@ -125,7 +125,7 @@ run = script do
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$>
     submitMulti [bank, investor] [] do
       createCmd Rule with
-        providers = S.fromList [bank, investor]
+        provider = bank
         claimers = S.singleton investor
         settlers
         routeProviderCid

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
@@ -253,7 +253,7 @@ runIntermediatedLifecyclingNonAtomic = script do
   -- LIFECYCLE_BOND_CSD_INVESTOR_BEGIN
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submit csd do
     createCmd Claim.Rule with
-      providers = S.singleton csd
+      provider = csd
       claimers = S.fromList [csd, investor]
       settlers
       routeProviderCid
@@ -378,7 +378,7 @@ runIntermediatedLifecyclingAtomic = script do
 
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submit csd do
     createCmd Claim.Rule with
-      providers = S.singleton csd
+      provider = csd
       claimers = S.singleton csd
       settlers
       routeProviderCid
@@ -410,7 +410,7 @@ runIntermediatedLifecyclingAtomic = script do
     queryContractId csd $ fromInterfaceContractId @Instruction.T issuerCashInstructionCid
   let
     issuerCashInstructionKey = InstructionKey with
-      requestors = issuerCashInstruction.requestors
+      instructor = issuerCashInstruction.instructor
       batchId = issuerCashInstruction.batchId
       id = issuerCashInstruction.id
 
@@ -418,7 +418,7 @@ runIntermediatedLifecyclingAtomic = script do
     queryContractId csd $ fromInterfaceContractId @Instruction.T csdCashInstructionCid
   let
     csdCashInstructionKey = InstructionKey with
-      requestors = csdCashInstruction.requestors
+      instructor = csdCashInstruction.instructor
       batchId = csdCashInstruction.batchId
       id = csdCashInstruction.id
 
@@ -548,7 +548,7 @@ template EffectSettlementService
         settlementFactoryCid <- create Factory with provider = csd; observers = S.empty
 
         lifecycleClaimRuleCid <- create Claim.Rule with
-          providers = S.singleton issuer
+          provider = issuer
           claimers = S.fromList [issuer, csd]
           settlers = S.singleton csd
           routeProviderCid

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/ReverseConvertible.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/ReverseConvertible.daml
@@ -8,7 +8,7 @@ import ContingentClaims.Core.Observation (Observation(..))
 import DA.Assert ((===))
 import DA.Date (Month(..), date)
 import DA.Map qualified as M (empty, fromList)
-import DA.Set qualified as S (empty, fromList, singleton, toList)
+import DA.Set qualified as S (empty, singleton, toList)
 import DA.Time (time)
 import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Time.DateClock (dateToDateClockTime)
@@ -153,7 +153,7 @@ run = script do
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$>
     submitMulti [bank, investor] [] do
       createCmd Rule with
-        providers = S.fromList [bank, investor]
+        provider = bank
         claimers = S.singleton investor
         settlers
         routeProviderCid

--- a/src/test/daml/Daml/Finance/Settlement/Test/Batch.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Batch.daml
@@ -4,7 +4,7 @@
 module Daml.Finance.Settlement.Test.Batch where
 
 import DA.Map qualified as M (fromList)
-import DA.Set qualified as S (fromList, singleton, toList)
+import DA.Set qualified as S (fromList, singleton)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Cancel(..), Settle(..))
 import Daml.Finance.Interface.Settlement.Factory qualified as Settlement (F, Instruct(..))
@@ -54,7 +54,7 @@ data TestParties = TestParties
 -- |     Bank       |                       |
 -- +----------------+-----------------------+
 run: Bool -> Bool -> Script ()
-run settleCashOnledger bankIsRequesting = script do
+run settleCashOnledger bankIsInstructor = script do
   -- Create parties
   TestParties{..} <- setupParties
   let pp = [("PublicParty", S.singleton publicParty)]
@@ -107,20 +107,27 @@ run settleCashOnledger bankIsRequesting = script do
 
   -- Instruct settlement
   let
-    requestors = S.fromList $ if bankIsRequesting then [bank] else [buyer, seller]
+    instructor = if bankIsInstructor then bank else buyer
+    consenters = if bankIsInstructor then [] else [seller]
     settlers = S.fromList [buyer, seller]
-    instructCmd = submitMulti (S.toList requestors) [publicParty] do
+    instructCmd = submitMulti (instructor :: consenters) [publicParty] do
       exerciseCmd settlementFactoryCid Settlement.Instruct with
-        instructors = requestors; settlers; id = Id "APPL 1000@200.0USD"; description = "DVP"
-        contextId = None; routedSteps; settlementTime = None
+        instructor
+        consenters = S.fromList consenters
+        settlers
+        id = Id "APPL 1000@200.0USD"
+        description = "DVP"
+        contextId = None
+        routedSteps
+        settlementTime = None
 
   -- Create batch and instructions, and then cancel
   (batchCid, _) <- instructCmd
   -- seller can't cancel batch
   submitMustFail seller do exerciseCmd batchCid Batch.Cancel with actors = S.singleton seller
-  -- requestors can cancel batch
-  submitMulti (S.toList requestors) [] do
-    exerciseCmd batchCid Batch.Cancel with actors = requestors
+  -- instructor and consenters can cancel batch
+  submitMulti (instructor :: consenters) [] do
+    exerciseCmd batchCid Batch.Cancel with actors = S.fromList $ instructor :: consenters
 
   -- Create batch and instructions
   (batchCid, [equityInstructionCid, cashInstructionCid]) <- instructCmd
@@ -164,7 +171,7 @@ run settleCashOnledger bankIsRequesting = script do
   submitMustFail buyer do
     exerciseCmd cashInstructionCid Instruction.Execute with actors = S.singleton buyer
   -- the bank can't settle the batch
-  if bankIsRequesting then
+  if bankIsInstructor then
     submitMustFail bank do
       exerciseCmd batchCid Batch.Settle with actors = S.singleton bank
   else
@@ -181,18 +188,18 @@ run settleCashOnledger bankIsRequesting = script do
   pure ()
 
 -- Settle cash on-ledger
--- with bank as requestor
+-- with bank as instructor
 run1 : Script ()
 run1 = run True True
--- with buyer and seller as requestors
+-- with buyer as instructor (and seller as consenter)
 run2 : Script ()
 run2 = run True False
 
 -- Settle cash off-ledger
--- with bank as requestor
+-- with bank as instructor
 run3 : Script ()
 run3 = run False True
--- with buyer and seller as requestors
+-- with buyer as instructor (and seller as consenter)
 run4 : Script ()
 run4 = run False False
 

--- a/src/test/daml/Daml/Finance/Settlement/Test/BatchWithIntermediaries.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/BatchWithIntermediaries.daml
@@ -137,7 +137,9 @@ run = script do
   (batchCid, [cashInstruction1Cid, cashInstruction2Cid, equityInstructionCid]) <-
     submitMulti [buyer, seller] [] do
       exerciseCmd settlementFactoryCid Settlement.Instruct with
-        instructors = S.fromList [buyer, seller]; settlers = S.fromList [buyer, seller]
+        instructor = buyer
+        consenters = S.singleton seller
+        settlers = S.fromList [buyer, seller]
         id = Id "APPL 1000@200.0USD"; description = "DVP"; contextId = None; routedSteps
         settlementTime = Some settlementTime
 

--- a/src/test/daml/Daml/Finance/Settlement/Test/Intermediated.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Intermediated.daml
@@ -174,7 +174,9 @@ run useDelegatee = script do
     buyerInstructionCid, bank1InstructionCid, bank2InstructionCid]) <-
     submit agent do
       exerciseCmd settlementFactoryCid Factory.Instruct with
-        instructors = S.singleton agent; settlers = S.singleton agent
+        instructor = agent
+        consenters = mempty
+        settlers = S.singleton agent
         id = Id "SHARE 200000.0@160.0USD DVP"; description = "Crosspayment"; contextId = None
         routedSteps; settlementTime = Some settlementTime
 

--- a/src/test/daml/Daml/Finance/Settlement/Test/Transfer.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Transfer.daml
@@ -97,8 +97,13 @@ run = script do
   -- Instruct transfer
   (batchCid, [cashInstructionCid]) <- submit bank do
     exerciseCmd settlementFactoryCid Settlement.Instruct with
-      instructors = S.singleton bank; settlers = S.singleton bank; id = Id "transfer 1"
-      description = "transfer of USD 200000.0 payment"; contextId = None; routedSteps
+      instructor = bank
+      consenters = mempty
+      settlers = S.singleton bank
+      id = Id "transfer 1"
+      description = "transfer of USD 200000.0 payment"
+      contextId = None
+      routedSteps
       settlementTime = None
 
   -- Allocate instruction
@@ -212,29 +217,49 @@ run2 = script do
   -- Instruct settlement for transfer 1
   (batchCid1, [cashInstructionCid1]) <- submit bank do
     exerciseCmd settlementFactoryCid Settlement.Instruct with
-      instructors = S.singleton bank; settlers = S.singleton bank; id = id1
-      description = "transfer of USD 100000.0 payment"; contextId = None; routedSteps = routedSteps1
+      instructor = bank
+      consenters = mempty
+      settlers = S.singleton bank
+      id = id1
+      description = "transfer of USD 100000.0 payment"
+      contextId = None
+      routedSteps = routedSteps1
       settlementTime = None
   -- the id of the batch must be unique
   submitMustFail bank do
     exerciseCmd settlementFactoryCid Settlement.Instruct with
-      instructors = S.singleton bank; settlers = S.singleton bank; id = id1
-      description = "transfer of USD 200000.0 payment"; contextId = None; routedSteps = routedSteps1
+      instructor = bank
+      consenters = mempty
+      settlers = S.singleton bank
+      id = id1
+      description = "transfer of USD 200000.0 payment"
+      contextId = None
+      routedSteps = routedSteps1
       settlementTime = None
 
   -- Instruct settlement for transfer 2
   (batchCid2, [cashInstructionCid2]) <- submit bank do
     exerciseCmd settlementFactoryCid Settlement.Instruct with
-      instructors = S.singleton bank; settlers = S.singleton bank; id = id2
-      description = "transfer of USD 200000.0 payment"; contextId = None; routedSteps = routedSteps2
+      instructor = bank
+      consenters = mempty
+      settlers = S.singleton bank
+      id = id2
+      description = "transfer of USD 200000.0 payment"
+      contextId = None
+      routedSteps = routedSteps2
       settlementTime = None
 
   -- Instruct settlement for transfer 3
   (batchCid3, [cashInstructionCid3]) <- submit bank do
     exerciseCmd settlementFactoryCid Settlement.Instruct with
-      instructors = S.singleton bank
-      settlers = S.singleton bank; id = id3; description = "transfer of USD 300000.0 payment"
-      contextId = None; routedSteps = routedSteps3; settlementTime = None
+      instructor = bank
+      consenters = mempty
+      settlers = S.singleton bank
+      id = id3
+      description = "transfer of USD 300000.0 payment"
+      contextId = None
+      routedSteps = routedSteps3
+      settlementTime = None
 
   let
     verifyAccountDisclosureContexts :  AccountKey -> [ContractId Instruction.I] -> Script ()
@@ -368,7 +393,8 @@ run3 = script do
   -- Instruct transfer
   (batchCid, [cashInstructionCid]) <- submit bank do
     exerciseCmd settlementFactoryCid Settlement.Instruct with
-      instructors = S.singleton bank
+      instructor = bank
+      consenters = mempty
       settlers = S.fromList [sender, receiver]
       id = Id "transfer 1"
       description = "transfer of USD 200000.0 payment"
@@ -449,7 +475,8 @@ run4 = script do
   -- Instruct transfer
   (batchCid, [cashInstructionCid1, cashInstructionCid2]) <- submit bank do
     exerciseCmd settlementFactoryCid Settlement.Instruct with
-      instructors = S.singleton bank
+      instructor = bank
+      consenters = mempty
       settlers = S.fromList [sender, receiver]
       id = Id "transfer 1"
       description = "transfer of USD 200000.0 and CHF 100000.0 payment"
@@ -537,7 +564,8 @@ run5 = script do
   -- Instruct transfer
   (batchCid, [instructionCid2, instructionCid1]) <- submit bank do
     exerciseCmd settlementFactoryCid Settlement.Instruct with
-      instructors = S.singleton bank
+      instructor = bank
+      consenters = mempty
       settlers = S.singleton settler
       id = Id "transfer 1"
       description = "transfer of USD 200000.0 payment"
@@ -555,14 +583,14 @@ run5 = script do
   instructionCid1 <- submit ccp do
     exerciseCmd instructionCid1 Instruction.Approve with
       actors = S.singleton ccp
-      approval = PassThroughTo (ccpAccount,
-        InstructionKey with requestors = S.singleton bank; batchId = Id "transfer 1"; id = Id "0")
+      approval = PassThroughTo
+        (ccpAccount, InstructionKey with instructor = bank; batchId = Id "transfer 1"; id = Id "0")
   -- Allocate with passthrough
   instructionCid2 <- submit ccp do
     exerciseCmd instructionCid2 Instruction.Allocate with
       actors = S.singleton ccp
-      allocation = PassThroughFrom (ccpAccount,
-        InstructionKey with requestors = S.singleton bank; batchId = Id "transfer 1"; id = Id "1")
+      allocation = PassThroughFrom
+        (ccpAccount, InstructionKey with instructor = bank; batchId = Id "transfer 1"; id = Id "1")
 
   -- Allocate instruction
   (instructionCid1, _) <- submit sender do


### PR DESCRIPTION
FIXES https://github.com/digital-asset/daml-finance/issues/1112

This PR splits up the `requestors : Parties` into a single-maintainer of the key called `instructor : Party`, and additional signatories called `consenters : Parties`.

In particular, this affects `Instruction`, `Batch`, `Settlement.Factory`, and the `InstructionKey`.

Additionally, I replaced `providers : Parties` in the `Claim` rule implementation to `provider : Party` (to more easily be able to assign the `instructor` in some flows). 

Follow up: 
Consider to replace `providers : Parties` to `provider : Party` for the other `Rule`s as well (i.e., `Distibution` and `Replacement`). Currently, those are always instantiated with single parties in our test scripts.