### PR TITLE
changing name convention for imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,8 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - Added an enumeration data type `HoldingStandard` to the `InstrumentKey` for referring to various
   holding standards.
 
+- Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+
 ### Daml.Finance.Instrument.Equity
 
 - Dependencies update
@@ -125,12 +127,16 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - Added an enumeration data type `HoldingStandard` to the `InstrumentKey` for referring to various
   holding standards.
 
+- Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+
 ### Daml.Finance.Instrument.Generic
 
 - Dependencies update
 
 - Added an enumeration data type `HoldingStandard` to the `InstrumentKey` for referring to various
   holding standards.
+
+- Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
 
 ### Daml.Finance.Instrument.Option
 
@@ -143,6 +149,8 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - Added an enumeration data type `HoldingStandard` to the `InstrumentKey` for referring to various
   holding standards.
 
+- Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+
 ### Daml.Finance.Instrument.StructuredProduct
 
 - Dependencies update
@@ -154,6 +162,8 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - Added an enumeration data type `HoldingStandard` to the `InstrumentKey` for referring to various
   holding standards.
 
+- Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+
 ### Daml.Finance.Instrument.Swap
 
 - Dependencies update
@@ -163,12 +173,16 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - Added an enumeration data type `HoldingStandard` to the `InstrumentKey` for referring to various
   holding standards.
 
+- Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+
 ### Daml.Finance.Instrument.Token
 
 - Dependencies update
 
 - Added an enumeration data type `HoldingStandard` to the `InstrumentKey` for referring to various
   holding standards.
+
+- Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
 
 ### Daml.Finance.Interface.Account
 
@@ -181,6 +195,8 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - Changed the `Create` choice of the account `Factory` to take a key (of type `HoldingFactoryKey`)
   rather than a `ContractId Daml.Finance.Interface.Holding.Factory`.
 
+- Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+
 ### Daml.Finance.Interface.Claims
 
 - Dependencies update
@@ -191,6 +207,9 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 - Dependencies update
 
+- Added `I` as type synonym for each `Factory` in the package (the `F` type synonyms are to be
+  deprecated).
+
 ### Daml.Finance.Interface.Holding
 
 - Dependencies update
@@ -199,12 +218,14 @@ This document tracks pending changes to packages. It is facilitating the write-u
   `Lockable` of the `Daml.Finance.Interface.Util` package.
 
 - Updated the `Daml.Finance.Interface.Holding.Factory` to use a key, employing a `Reference`
-  template and the `HoldingFactoryKey` data type. Additionally, It also requires the `Disclosure.I` and
-  has a `getKey` method and `Remove` choice.
+  template and the `HoldingFactoryKey` data type. Additionally, It also requires the `Disclosure.I`
+  and has a `getKey` method and `Remove` choice.
 
 - Removed the requirement that a `Fungible.I` requires `Transferable.I`.
 
 - Renamed `Base` to `Holding`.
+
+- Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
 
 ### Daml.Finance.Interface.Instrument.Base
 
@@ -217,6 +238,8 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - Added an enumeration data type `HoldingStandard` to the `InstrumentKey` for referring to various
   holding standards.
 
+- Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+
 ### Daml.Finance.Interface.Instrument.Bond
 
 - Dependencies update
@@ -228,6 +251,8 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - Added an enumeration data type `HoldingStandard` to the `InstrumentKey` for referring to various
   holding standards.
 
+- Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+
 ### Daml.Finance.Interface.Instrument.Equity
 
 - Dependencies update
@@ -237,6 +262,8 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - Added an enumeration data type `HoldingStandard` to the `InstrumentKey` for referring to various
   holding standards.
 
+- Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+
 ### Daml.Finance.Interface.Instrument.Generic
 
 - Dependencies update
@@ -245,6 +272,8 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 - Added an enumeration data type `HoldingStandard` to the `InstrumentKey` for referring to various
   holding standards.
+
+- Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
 
 ### Daml.Finance.Interface.Instrument.Option
 
@@ -257,6 +286,8 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - Added an enumeration data type `HoldingStandard` to the `InstrumentKey` for referring to various
   holding standards.
 
+- Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+
 ### Daml.Finance.Interface.Instrument.StructuredProduct
 
 - First release
@@ -265,6 +296,8 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 - Added an enumeration data type `HoldingStandard` to the `InstrumentKey` for referring to various
   holding standards.
+
+- Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
 
 ### Daml.Finance.Interface.Instrument.Swap
 
@@ -277,6 +310,8 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - Added an enumeration data type `HoldingStandard` to the `InstrumentKey` for referring to various
   holding standards.
 
+- Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+
 ### Daml.Finance.Interface.Instrument.Token
 
 - Dependencies update
@@ -286,6 +321,8 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - Added an enumeration data type `HoldingStandard` to the `InstrumentKey` for referring to various
   holding standards.
 
+- Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+
 ### Daml.Finance.Interface.Instrument.Types
 
 - New package
@@ -294,6 +331,9 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 - Changed the `Calculate` choice of the `Effect.I` to take a quantity as argument instead of a
   `ContractId Holding` (in order to not leak information about the holding to the effect provider).
+
+- Added `I` as type synonym for each `Factory` in the package (the `F` type synonyms are to be
+  deprecated).
 
 ### Daml.Finance.Interface.Settlement
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This document tracks pending changes to packages. It is facilitating the write-u
 | Daml.Finance.Instrument.Token              | 2.0.0              | 3.0.0          |
 | Daml.Finance.Interface.Account             | 2.0.0              | 3.0.0          |
 | Daml.Finance.Interface.Claims              | 2.0.0              | 3.0.0          |
-| Daml.Finance.Interface.Data                | 3.0.0              | 3.0.1          |
+| Daml.Finance.Interface.Data                | 3.0.0              | 3.1.0          |
 | Daml.Finance.Interface.Holding             | 2.0.0              | 3.0.0          |
 | Daml.Finance.Interface.Instrument.Base     | 2.0.0              | 3.0.0          |
 | Daml.Finance.Interface.Instrument.Bond     | 1.0.0              | 2.0.0          |

--- a/docs/code-samples/README.md
+++ b/docs/code-samples/README.md
@@ -88,4 +88,3 @@ well as `daml-head start` to ensure the Sandbox can be started successfully.
 12. Raise a PR against the `main` Daml branch and ask the daml team to approve the PR.
 
 13. If applicable, backport the PR merged in step `12` to the target release line branch.
-

--- a/docs/code-samples/getting-started/daml/Scripts/Holding.daml
+++ b/docs/code-samples/getting-started/daml/Scripts/Holding.daml
@@ -5,9 +5,9 @@ import DA.Set qualified as Set (fromList)
 import Daml.Script
 
 -- INTERFACE DEPENDENCIES --
-import Daml.Finance.Interface.Account.Factory qualified as Account (F)
+import Daml.Finance.Interface.Account.Factory qualified as Account.Factory (F)
 import Daml.Finance.Interface.Holding.Holding qualified as Holding (I)
-import Daml.Finance.Interface.Instrument.Token.Factory qualified as Token (F, Create(..))
+import Daml.Finance.Interface.Instrument.Token.Factory qualified as Token.Factory (F, Create(..))
 import Daml.Finance.Interface.Instrument.Token.Types (Token(..))
 import Daml.Finance.Interface.Types.Common.Types (AccountKey, HoldingStandard(..), Id(..), InstrumentKey(..))
 
@@ -33,7 +33,7 @@ setupHolding = do
 
   -- Account Factory (it is used by the bank to create accounts)
   -- CREATE_ACCOUNT_FACTORY_BEGIN
-  accountFactoryCid <- toInterfaceContractId @Account.F <$> submit bank do
+  accountFactoryCid <- toInterfaceContractId @Account.Factory.F <$> submit bank do
     createCmd Account.Factory with
       provider = bank
       observers = mempty
@@ -51,7 +51,7 @@ setupHolding = do
   -- Instrument Factory (it is used by the bank to create instruments with the desired
   -- implementation)
   -- CREATE_INSTRUMENT_FACTORY_BEGIN
-  tokenFactoryCid <- toInterfaceContractId @Token.F <$> submit bank do
+  tokenFactoryCid <- toInterfaceContractId @Token.Factory.F <$> submit bank do
     createCmd Token.Factory with
       provider = bank
       observers = mempty
@@ -97,7 +97,7 @@ setupHolding = do
   now <- getTime
 
   submit bank do
-    exerciseCmd tokenFactoryCid Token.Create with
+    exerciseCmd tokenFactoryCid Token.Factory.Create with
       token = Token with
         instrument = instrumentKey
         description = "Instrument representing units of a generic token"
@@ -135,5 +135,5 @@ data HoldingState = HoldingState
     aliceAccount : AccountKey
     bobAccount : AccountKey
     cashInstrument : InstrumentKey
-    tokenFactoryCid : ContractId Token.F
+    tokenFactoryCid : ContractId Token.Factory.F
     aliceCashHoldingCid : ContractId Holding.I

--- a/docs/code-samples/getting-started/daml/Scripts/Holding.daml
+++ b/docs/code-samples/getting-started/daml/Scripts/Holding.daml
@@ -5,9 +5,9 @@ import DA.Set qualified as Set (fromList)
 import Daml.Script
 
 -- INTERFACE DEPENDENCIES --
-import Daml.Finance.Interface.Account.Factory qualified as Account.Factory (F)
+import Daml.Finance.Interface.Account.Factory qualified as AccountFactory (I)
 import Daml.Finance.Interface.Holding.Holding qualified as Holding (I)
-import Daml.Finance.Interface.Instrument.Token.Factory qualified as Token.Factory (F, Create(..))
+import Daml.Finance.Interface.Instrument.Token.Factory qualified as TokenFactory (Create(..), I)
 import Daml.Finance.Interface.Instrument.Token.Types (Token(..))
 import Daml.Finance.Interface.Types.Common.Types (AccountKey, HoldingStandard(..), Id(..), InstrumentKey(..))
 
@@ -33,7 +33,7 @@ setupHolding = do
 
   -- Account Factory (it is used by the bank to create accounts)
   -- CREATE_ACCOUNT_FACTORY_BEGIN
-  accountFactoryCid <- toInterfaceContractId @Account.Factory.F <$> submit bank do
+  accountFactoryCid <- toInterfaceContractId @AccountFactory.I <$> submit bank do
     createCmd Account.Factory with
       provider = bank
       observers = mempty
@@ -51,7 +51,7 @@ setupHolding = do
   -- Instrument Factory (it is used by the bank to create instruments with the desired
   -- implementation)
   -- CREATE_INSTRUMENT_FACTORY_BEGIN
-  tokenFactoryCid <- toInterfaceContractId @Token.Factory.F <$> submit bank do
+  tokenFactoryCid <- toInterfaceContractId @TokenFactory.I <$> submit bank do
     createCmd Token.Factory with
       provider = bank
       observers = mempty
@@ -68,8 +68,8 @@ setupHolding = do
     exerciseCmd aliceRequestCid CreateAccount.Accept with
       label = "Alice@Bank"
       description = "Account of Alice at Bank"
-      accountFactoryCid = accountFactoryCid
-      holdingFactory = holdingFactory
+      accountFactoryCid -- This is equivalent to writing accountFactoryCid = accountFactoryCid
+      holdingFactory
       observers = []
   -- SETUP_ALICE_ACCOUNT_END
 
@@ -79,8 +79,8 @@ setupHolding = do
     exerciseCmd bobRequestCid CreateAccount.Accept with
       label = "Bob@Bank"
       description = "Account of Bob at Bank"
-      accountFactoryCid = accountFactoryCid
-      holdingFactory = holdingFactory
+      accountFactoryCid
+      holdingFactory
       observers = [alice]
 
   -- Bank creates the cash instrument
@@ -97,7 +97,7 @@ setupHolding = do
   now <- getTime
 
   submit bank do
-    exerciseCmd tokenFactoryCid Token.Factory.Create with
+    exerciseCmd tokenFactoryCid TokenFactory.Create with
       token = Token with
         instrument = instrumentKey
         description = "Instrument representing units of a generic token"
@@ -135,5 +135,5 @@ data HoldingState = HoldingState
     aliceAccount : AccountKey
     bobAccount : AccountKey
     cashInstrument : InstrumentKey
-    tokenFactoryCid : ContractId Token.Factory.F
+    tokenFactoryCid : ContractId TokenFactory.I
     aliceCashHoldingCid : ContractId Holding.I

--- a/docs/code-samples/getting-started/daml/Scripts/Lifecycling.daml
+++ b/docs/code-samples/getting-started/daml/Scripts/Lifecycling.daml
@@ -4,7 +4,7 @@ import DA.Set (singleton)
 import Daml.Script
 
 -- INTERFACE DEPENDENCIES --
-import Daml.Finance.Interface.Instrument.Token.Factory qualified as Token.Factory (Create(..))
+import Daml.Finance.Interface.Instrument.Token.Factory qualified as TokenFactory (Create(..))
 import Daml.Finance.Interface.Instrument.Token.Types (Token(..))
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I)
 import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), I)
@@ -51,7 +51,7 @@ runLifecycling = do
   let newTokenInstrument = tokenInstrument with version = "1"
   now <- getTime
   submit bank do
-    exerciseCmd tokenFactoryCid Token.Factory.Create with
+    exerciseCmd tokenFactoryCid TokenFactory.Create with
       token = Token with
         instrument = newTokenInstrument
         description = "Instrument representing units of a generic token after a distribution event"

--- a/docs/code-samples/getting-started/daml/Scripts/Lifecycling.daml
+++ b/docs/code-samples/getting-started/daml/Scripts/Lifecycling.daml
@@ -4,7 +4,7 @@ import DA.Set (singleton)
 import Daml.Script
 
 -- INTERFACE DEPENDENCIES --
-import Daml.Finance.Interface.Instrument.Token.Factory qualified as Token (Create(..))
+import Daml.Finance.Interface.Instrument.Token.Factory qualified as Token.Factory (Create(..))
 import Daml.Finance.Interface.Instrument.Token.Types (Token(..))
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I)
 import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), I)
@@ -51,7 +51,7 @@ runLifecycling = do
   let newTokenInstrument = tokenInstrument with version = "1"
   now <- getTime
   submit bank do
-    exerciseCmd tokenFactoryCid Token.Create with
+    exerciseCmd tokenFactoryCid Token.Factory.Create with
       token = Token with
         instrument = newTokenInstrument
         description = "Instrument representing units of a generic token after a distribution event"

--- a/docs/code-samples/getting-started/daml/Scripts/Settlement.daml
+++ b/docs/code-samples/getting-started/daml/Scripts/Settlement.daml
@@ -5,10 +5,10 @@ import Daml.Script
 
 -- INTERFACE DEPENDENCIES --
 import Daml.Finance.Interface.Holding.Holding qualified as Holding (I)
-import Daml.Finance.Interface.Instrument.Token.Factory qualified as Token.Factory (F, Create(..))
+import Daml.Finance.Interface.Instrument.Token.Factory qualified as TokenFactory (Create(..), I)
 import Daml.Finance.Interface.Instrument.Token.Types (Token(..))
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
-import Daml.Finance.Interface.Settlement.Factory qualified as Settlement.Factory (F)
+import Daml.Finance.Interface.Settlement.Factory qualified as SettlementFactory (I)
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Settlement.RouteProvider qualified as RouteProvider (I)
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..))
@@ -58,7 +58,7 @@ runSettlement = do
   now <- getTime
 
   submit bank do
-    exerciseCmd tokenFactoryCid Token.Factory.Create with
+    exerciseCmd tokenFactoryCid TokenFactory.Create with
       token = Token with
         instrument = tokenInstrument
         description = "Instrument representing units of a generic token"
@@ -84,7 +84,7 @@ runSettlement = do
   -- Setup a Settlement Factory facility
   -- This is used to generate settlement instructions from a list of `RoutedStep`s
   -- SETTLEMENT_FACTORY_BEGIN
-  settlementFactoryCid <- toInterfaceContractId @Settlement.Factory.F <$> submit bank do
+  settlementFactoryCid <- toInterfaceContractId @SettlementFactory.I <$> submit bank do
     createCmd Settlement.Factory with
       provider = bank
       observers = fromList [alice, bob]
@@ -161,6 +161,6 @@ data SettlementState = SettlementState
     usdInstrument : InstrumentKey
     tokenInstrument : InstrumentKey
     routeProviderCid : ContractId RouteProvider.I
-    settlementFactoryCid : ContractId Settlement.Factory.F
-    tokenFactoryCid : ContractId Token.Factory.F
+    settlementFactoryCid : ContractId SettlementFactory.I
+    tokenFactoryCid : ContractId TokenFactory.I
     bobHoldingCid : ContractId Holding.I

--- a/docs/code-samples/getting-started/daml/Scripts/Settlement.daml
+++ b/docs/code-samples/getting-started/daml/Scripts/Settlement.daml
@@ -5,10 +5,10 @@ import Daml.Script
 
 -- INTERFACE DEPENDENCIES --
 import Daml.Finance.Interface.Holding.Holding qualified as Holding (I)
-import Daml.Finance.Interface.Instrument.Token.Factory qualified as Token (F, Create(..))
+import Daml.Finance.Interface.Instrument.Token.Factory qualified as Token.Factory (F, Create(..))
 import Daml.Finance.Interface.Instrument.Token.Types (Token(..))
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
-import Daml.Finance.Interface.Settlement.Factory qualified as Settlement (F)
+import Daml.Finance.Interface.Settlement.Factory qualified as Settlement.Factory (F)
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Settlement.RouteProvider qualified as RouteProvider (I)
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..))
@@ -58,7 +58,7 @@ runSettlement = do
   now <- getTime
 
   submit bank do
-    exerciseCmd tokenFactoryCid Token.Create with
+    exerciseCmd tokenFactoryCid Token.Factory.Create with
       token = Token with
         instrument = tokenInstrument
         description = "Instrument representing units of a generic token"
@@ -84,7 +84,7 @@ runSettlement = do
   -- Setup a Settlement Factory facility
   -- This is used to generate settlement instructions from a list of `RoutedStep`s
   -- SETTLEMENT_FACTORY_BEGIN
-  settlementFactoryCid <- toInterfaceContractId @Settlement.F <$> submit bank do
+  settlementFactoryCid <- toInterfaceContractId @Settlement.Factory.F <$> submit bank do
     createCmd Settlement.Factory with
       provider = bank
       observers = fromList [alice, bob]
@@ -161,6 +161,6 @@ data SettlementState = SettlementState
     usdInstrument : InstrumentKey
     tokenInstrument : InstrumentKey
     routeProviderCid : ContractId RouteProvider.I
-    settlementFactoryCid : ContractId Settlement.F
-    tokenFactoryCid : ContractId Token.F
+    settlementFactoryCid : ContractId Settlement.Factory.F
+    tokenFactoryCid : ContractId Token.Factory.F
     bobHoldingCid : ContractId Holding.I

--- a/docs/code-samples/getting-started/daml/Scripts/Transfer.daml
+++ b/docs/code-samples/getting-started/daml/Scripts/Transfer.daml
@@ -4,7 +4,7 @@ import Daml.Script
 
 -- INTERFACE DEPENDENCIES --
 import Daml.Finance.Interface.Holding.Holding qualified as Holding (I)
-import Daml.Finance.Interface.Instrument.Token.Factory qualified as Token.Factory (F)
+import Daml.Finance.Interface.Instrument.Token.Factory qualified as TokenFactory (I)
 import Daml.Finance.Interface.Types.Common.Types (AccountKey, InstrumentKey(..))
 
 -- IMPLEMENTATION DEPENDENCIES --
@@ -63,4 +63,4 @@ data TransferState = TransferState
     bobAccount : AccountKey
     usdInstrument : InstrumentKey
     bobCashHoldingCid : ContractId Holding.I
-    tokenFactoryCid : ContractId Token.Factory.F
+    tokenFactoryCid : ContractId TokenFactory.I

--- a/docs/code-samples/getting-started/daml/Scripts/Transfer.daml
+++ b/docs/code-samples/getting-started/daml/Scripts/Transfer.daml
@@ -4,7 +4,7 @@ import Daml.Script
 
 -- INTERFACE DEPENDENCIES --
 import Daml.Finance.Interface.Holding.Holding qualified as Holding (I)
-import Daml.Finance.Interface.Instrument.Token.Factory qualified as Token (F)
+import Daml.Finance.Interface.Instrument.Token.Factory qualified as Token.Factory (F)
 import Daml.Finance.Interface.Types.Common.Types (AccountKey, InstrumentKey(..))
 
 -- IMPLEMENTATION DEPENDENCIES --
@@ -63,4 +63,4 @@ data TransferState = TransferState
     bobAccount : AccountKey
     usdInstrument : InstrumentKey
     bobCashHoldingCid : ContractId Holding.I
-    tokenFactoryCid : ContractId Token.F
+    tokenFactoryCid : ContractId Token.Factory.F

--- a/docs/code-samples/getting-started/daml/Scripts/Util.daml
+++ b/docs/code-samples/getting-started/daml/Scripts/Util.daml
@@ -3,8 +3,7 @@ module Scripts.Util where
 import Daml.Script
 
 -- INTERFACE DEPENDENCIES --
-import Daml.Finance.Interface.Holding.Factory (Reference(..))
-import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (F)
+import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (I, Reference(..))
 import Daml.Finance.Interface.Types.Common.Types (HoldingFactoryKey(..))
 
 -- IMPLEMENTATION DEPENDENCIES --
@@ -22,11 +21,11 @@ createParty name = do
 -- https://docs.daml.com/daml-finance/reference/patterns.html#reference-pattern
 createHoldingFactory : Holding.Factory -> Script HoldingFactoryKey
 createHoldingFactory holdingFactory = do
-  cid <- toInterfaceContractId @HoldingFactory.F <$> submit holdingFactory.provider do
+  cid <- toInterfaceContractId @HoldingFactory.I <$> submit holdingFactory.provider do
     createCmd holdingFactory
   submit holdingFactory.provider do
-    createCmd Reference with
-      factoryView = view $ toInterface @HoldingFactory.F holdingFactory
+    createCmd HoldingFactory.Reference with
+      factoryView = view $ toInterface @HoldingFactory.I holdingFactory
       cid
       observers = holdingFactory.observers
   pure $ HoldingFactoryKey with provider = holdingFactory.provider; id = holdingFactory.id

--- a/docs/code-samples/getting-started/daml/Workflow/CreateAccount.daml
+++ b/docs/code-samples/getting-started/daml/Workflow/CreateAccount.daml
@@ -5,7 +5,7 @@ import DA.Set qualified as Set (fromList, singleton)
 
 -- INTERFACE DEPENDENCIES --
 import Daml.Finance.Interface.Account.Account qualified as Account (Controllers(..))
-import Daml.Finance.Interface.Account.Factory qualified as Account (Create(..), F)
+import Daml.Finance.Interface.Account.Factory qualified as Account.Factory (Create(..), F)
 import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), HoldingFactoryKey, Id(..))
 
 -- | Initiate / Accept template to open an account.
@@ -30,7 +30,7 @@ template Request
           -- ^ A textual label.
         description : Text
           -- ^ An extended textual description.
-        accountFactoryCid : ContractId Account.F
+        accountFactoryCid : ContractId Account.Factory.F
           -- ^ The account factory. This is used to create the account template.
         holdingFactory : HoldingFactoryKey
           -- ^ The holding factory. This is used within an account to create holdings.
@@ -45,7 +45,7 @@ template Request
             id = Id label
           observersSet = Set.fromList observers
 
-        accountCid <- exercise accountFactoryCid Account.Create with
+        accountCid <- exercise accountFactoryCid Account.Factory.Create with
           account = accountKey
           description
           holdingFactory

--- a/docs/code-samples/getting-started/daml/Workflow/CreateAccount.daml
+++ b/docs/code-samples/getting-started/daml/Workflow/CreateAccount.daml
@@ -5,7 +5,7 @@ import DA.Set qualified as Set (fromList, singleton)
 
 -- INTERFACE DEPENDENCIES --
 import Daml.Finance.Interface.Account.Account qualified as Account (Controllers(..))
-import Daml.Finance.Interface.Account.Factory qualified as Account.Factory (Create(..), F)
+import Daml.Finance.Interface.Account.Factory qualified as AccountFactory (Create(..), I)
 import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), HoldingFactoryKey, Id(..))
 
 -- | Initiate / Accept template to open an account.
@@ -30,7 +30,7 @@ template Request
           -- ^ A textual label.
         description : Text
           -- ^ An extended textual description.
-        accountFactoryCid : ContractId Account.Factory.F
+        accountFactoryCid : ContractId AccountFactory.I
           -- ^ The account factory. This is used to create the account template.
         holdingFactory : HoldingFactoryKey
           -- ^ The holding factory. This is used within an account to create holdings.
@@ -45,7 +45,7 @@ template Request
             id = Id label
           observersSet = Set.fromList observers
 
-        accountCid <- exercise accountFactoryCid Account.Factory.Create with
+        accountCid <- exercise accountFactoryCid AccountFactory.Create with
           account = accountKey
           description
           holdingFactory

--- a/docs/code-samples/getting-started/daml/Workflow/DvP.daml
+++ b/docs/code-samples/getting-started/daml/Workflow/DvP.daml
@@ -4,7 +4,7 @@ import DA.Set (fromList, singleton)
 
 -- INTERFACE DEPENDENCIES --
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (I)
-import Daml.Finance.Interface.Settlement.Factory qualified as Settlement.Factory (F, Instruct(..))
+import Daml.Finance.Interface.Settlement.Factory qualified as SettlementFactory (I, Instruct(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (I)
 import Daml.Finance.Interface.Settlement.RouteProvider qualified as RouteProvider (Discover(..), I)
 import Daml.Finance.Interface.Settlement.Types (Step(..))
@@ -24,7 +24,7 @@ template Proposal
       -- ^ The trade counterparty. They receive the pay leg in exchange for the receiving leg.
     routeProviderCid : ContractId RouteProvider.I
       -- ^ The route provider to discover settlement paths.
-    settlementFactoryCid : ContractId Settlement.Factory.F
+    settlementFactoryCid : ContractId SettlementFactory.I
       -- ^ The factory contract for the settlement batch.
     id : Text
       -- ^ A textual identifier.
@@ -52,7 +52,7 @@ template Proposal
 
         -- INSTRUCT_BEGIN
         (containerCid, [recInstructionCid, payInstructionCid]) <-
-          exercise settlementFactoryCid Settlement.Factory.Instruct with
+          exercise settlementFactoryCid SettlementFactory.Instruct with
             instructor = proposer
             consenters = singleton counterparty
             settlers = singleton proposer

--- a/docs/code-samples/getting-started/daml/Workflow/DvP.daml
+++ b/docs/code-samples/getting-started/daml/Workflow/DvP.daml
@@ -4,7 +4,7 @@ import DA.Set (fromList, singleton)
 
 -- INTERFACE DEPENDENCIES --
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (I)
-import Daml.Finance.Interface.Settlement.Factory qualified as Settlement (F, Instruct(..))
+import Daml.Finance.Interface.Settlement.Factory qualified as Settlement.Factory (F, Instruct(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (I)
 import Daml.Finance.Interface.Settlement.RouteProvider qualified as RouteProvider (Discover(..), I)
 import Daml.Finance.Interface.Settlement.Types (Step(..))
@@ -24,7 +24,7 @@ template Proposal
       -- ^ The trade counterparty. They receive the pay leg in exchange for the receiving leg.
     routeProviderCid : ContractId RouteProvider.I
       -- ^ The route provider to discover settlement paths.
-    settlementFactoryCid : ContractId Settlement.F
+    settlementFactoryCid : ContractId Settlement.Factory.F
       -- ^ The factory contract for the settlement batch.
     id : Text
       -- ^ A textual identifier.
@@ -52,7 +52,7 @@ template Proposal
 
         -- INSTRUCT_BEGIN
         (containerCid, [recInstructionCid, payInstructionCid]) <-
-          exercise settlementFactoryCid Settlement.Instruct with
+          exercise settlementFactoryCid Settlement.Factory.Instruct with
             instructor = proposer
             consenters = singleton counterparty
             settlers = singleton proposer

--- a/docs/code-samples/lifecycling/daml/Scripts/CallableBond.daml
+++ b/docs/code-samples/lifecycling/daml/Scripts/CallableBond.daml
@@ -6,10 +6,10 @@ import DA.Set qualified as Set (fromList, singleton)
 import Daml.Script
 
 -- INTERFACE DEPENDENCIES --
-import Daml.Finance.Interface.Instrument.Bond.Callable.Factory qualified as Callable.Factory (Create(..), F(..))
+import Daml.Finance.Interface.Instrument.Bond.Callable.Factory qualified as CallableBondFactory (Create(..), I)
 import Daml.Finance.Interface.Instrument.Bond.Callable.Types (Callable(..))
 import Daml.Finance.Interface.Lifecycle.Election qualified as Election (Apply(..), Exercisable)
-import Daml.Finance.Interface.Lifecycle.Election.Factory qualified as Election.Factory (Create(..), F)
+import Daml.Finance.Interface.Lifecycle.Election.Factory qualified as ElectionFactory (Create(..), I)
 import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), I)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
@@ -21,7 +21,7 @@ import Daml.Finance.Interface.Types.Date.RollConvention (PeriodEnum(..))
 
 -- IMPLEMENTATION DEPENDENCIES --
 import Daml.Finance.Data.Time.DateClock (dateToDateClockTime)
-import Daml.Finance.Instrument.Bond.Callable.Factory qualified as Callable (Factory(..))
+import Daml.Finance.Instrument.Bond.Callable.Factory qualified as CallableBond (Factory(..))
 import Daml.Finance.Lifecycle.Election qualified as Election (Factory(..))
 import Daml.Finance.Lifecycle.Rule.Claim qualified as Claim (Rule(..))
 
@@ -74,8 +74,8 @@ runCallableBond = do
 
   -- CREATE_CALLABLE_BOND_INSTRUMENT_BEGIN
   -- Create a callable bond factory
-  callableBondFactoryCid <- toInterfaceContractId @Callable.Factory.F <$> submit bank do
-    createCmd Callable.Factory with
+  callableBondFactoryCid <- toInterfaceContractId @CallableBondFactory.I <$> submit bank do
+    createCmd CallableBond.Factory with
       provider = bank
       observers = mempty
 
@@ -90,7 +90,7 @@ runCallableBond = do
 
   -- Bank creates the bond instrument
   callableBondCid <- submit bank do
-    exerciseCmd callableBondFactoryCid Callable.Factory.Create with
+    exerciseCmd callableBondFactoryCid CallableBondFactory.Create with
       callable = Callable with
         instrument = bondInstrument
         description = "Instrument representing units of a callable bond"
@@ -125,7 +125,7 @@ runCallableBond = do
   -- CREATE_ELECTION_FACTORY_BEGIN
   -- Create election factory to allow holders to create elections
   electionFactoryCid <- submit bank do
-    toInterfaceContractId @Election.Factory.F <$> createCmd Election.Factory with
+    toInterfaceContractId @ElectionFactory.I <$> createCmd Election.Factory with
       provider = bank
       observers = Map.fromList [("Observers", Set.fromList [bob, bank])]
   -- CREATE_ELECTION_FACTORY_END
@@ -133,7 +133,7 @@ runCallableBond = do
   -- CREATE_ELECTION_BEGIN
   -- Create an Election for the first coupon date: do not call the bond.
   electionCid <- submit bank do
-    exerciseCmd electionFactoryCid Election.Factory.Create with
+    exerciseCmd electionFactoryCid ElectionFactory.Create with
       actors = Set.singleton bank
       id = Id "election id"
       description = "election for a callable bond"

--- a/docs/code-samples/lifecycling/daml/Scripts/CallableBond.daml
+++ b/docs/code-samples/lifecycling/daml/Scripts/CallableBond.daml
@@ -6,10 +6,10 @@ import DA.Set qualified as Set (fromList, singleton)
 import Daml.Script
 
 -- INTERFACE DEPENDENCIES --
-import Daml.Finance.Interface.Instrument.Bond.Callable.Factory qualified as Callable (Create(..), F(..))
+import Daml.Finance.Interface.Instrument.Bond.Callable.Factory qualified as Callable.Factory (Create(..), F(..))
 import Daml.Finance.Interface.Instrument.Bond.Callable.Types (Callable(..))
 import Daml.Finance.Interface.Lifecycle.Election qualified as Election (Apply(..), Exercisable)
-import Daml.Finance.Interface.Lifecycle.Election.Factory qualified as Election (Create(..), F)
+import Daml.Finance.Interface.Lifecycle.Election.Factory qualified as Election.Factory (Create(..), F)
 import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), I)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
@@ -74,7 +74,7 @@ runCallableBond = do
 
   -- CREATE_CALLABLE_BOND_INSTRUMENT_BEGIN
   -- Create a callable bond factory
-  callableBondFactoryCid <- toInterfaceContractId @Callable.F <$> submit bank do
+  callableBondFactoryCid <- toInterfaceContractId @Callable.Factory.F <$> submit bank do
     createCmd Callable.Factory with
       provider = bank
       observers = mempty
@@ -90,7 +90,7 @@ runCallableBond = do
 
   -- Bank creates the bond instrument
   callableBondCid <- submit bank do
-    exerciseCmd callableBondFactoryCid Callable.Create with
+    exerciseCmd callableBondFactoryCid Callable.Factory.Create with
       callable = Callable with
         instrument = bondInstrument
         description = "Instrument representing units of a callable bond"
@@ -125,7 +125,7 @@ runCallableBond = do
   -- CREATE_ELECTION_FACTORY_BEGIN
   -- Create election factory to allow holders to create elections
   electionFactoryCid <- submit bank do
-    toInterfaceContractId @Election.F <$> createCmd Election.Factory with
+    toInterfaceContractId @Election.Factory.F <$> createCmd Election.Factory with
       provider = bank
       observers = Map.fromList [("Observers", Set.fromList [bob, bank])]
   -- CREATE_ELECTION_FACTORY_END
@@ -133,7 +133,7 @@ runCallableBond = do
   -- CREATE_ELECTION_BEGIN
   -- Create an Election for the first coupon date: do not call the bond.
   electionCid <- submit bank do
-    exerciseCmd electionFactoryCid Election.Create with
+    exerciseCmd electionFactoryCid Election.Factory.Create with
       actors = Set.singleton bank
       id = Id "election id"
       description = "election for a callable bond"

--- a/docs/code-samples/lifecycling/daml/Scripts/FixedRateBond.daml
+++ b/docs/code-samples/lifecycling/daml/Scripts/FixedRateBond.daml
@@ -6,15 +6,15 @@ import DA.Set qualified as Set (singleton)
 import Daml.Script
 
 -- INTERFACE DEPENDENCIES --
-import Daml.Finance.Interface.Account.Factory qualified as Account.Factory (F)
+import Daml.Finance.Interface.Account.Factory qualified as AccountFactory (I)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (I)
-import Daml.Finance.Interface.Instrument.Bond.FixedRate.Factory qualified as FixedRate.Factory (Create(..), F(..))
+import Daml.Finance.Interface.Instrument.Bond.FixedRate.Factory qualified as FixedRateBondFactory (Create(..), I(..))
 import Daml.Finance.Interface.Instrument.Bond.FixedRate.Types (FixedRate(..))
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I)
 import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), I)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (Evolve(..), I)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
-import Daml.Finance.Interface.Settlement.Factory qualified as Settlement.Factory (F)
+import Daml.Finance.Interface.Settlement.Factory qualified as SettlementFactory (I)
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Settlement.RouteProvider qualified as RouteProvider (I)
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..))
@@ -31,7 +31,7 @@ import Daml.Finance.Data.Reference.HolidayCalendar (HolidayCalendar(..))
 import Daml.Finance.Data.Time.DateClock (dateToDateClockTime)
 import Daml.Finance.Data.Time.DateClockUpdate qualified as DataTime (DateClockUpdateEvent(..))
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
-import Daml.Finance.Instrument.Bond.FixedRate.Factory qualified as FixedRate (Factory(..))
+import Daml.Finance.Instrument.Bond.FixedRate.Factory qualified as FixedRateBond (Factory(..))
 import Daml.Finance.Instrument.Token.Instrument (Instrument(..))
 import Daml.Finance.Lifecycle.Rule.Claim qualified as Claim (Rule(..))
 import Daml.Finance.Settlement.Factory qualified as Settlement (Factory(..))
@@ -54,7 +54,7 @@ data FixedRateState = FixedRateState
     holidayCalendarIds : [Text]
     lifecycleRuleCid : ContractId Lifecycle.I
     routeProviderCid : ContractId RouteProvider.I
-    settlementFactoryCid : ContractId Settlement.Factory.F
+    settlementFactoryCid : ContractId SettlementFactory.I
     lifecycleClaimRuleCid : ContractId Claim.I
     firstCouponClockEventCid : ContractId Event.I
     initialTimestamp : Time
@@ -74,7 +74,7 @@ runFixedRateBond = do
   [bank, bob, public] <- mapA createParty ["Bank", "Bob", "Public"]
 
   -- Account Factory (it is used by the bank to create accounts)
-  accountFactoryCid <- toInterfaceContractId @Account.Factory.F <$> submit bank do
+  accountFactoryCid <- toInterfaceContractId @AccountFactory.I <$> submit bank do
     createCmd Account.Factory with provider = bank; observers = mempty
 
   -- Holding Factory (it is used by the bank to create holdings with the desired implementation)
@@ -90,8 +90,8 @@ runFixedRateBond = do
     exerciseCmd bobRequestCid CreateAccount.Accept with
       label = "Bob@Bank"
       description = "Account of Bob at Bank"
-      accountFactoryCid = accountFactoryCid
-      holdingFactory = holdingFactory
+      accountFactoryCid -- This is equivalent to writing accountFactoryCid = accountFactoryCid
+      holdingFactory
       observers = []
 
   -- Setup a route provider
@@ -102,7 +102,7 @@ runFixedRateBond = do
 
   -- Setup a Settlement Factory facility
   -- This is used to generate settlement instructions from a list of `RoutedStep`s
-  settlementFactoryCid <- toInterfaceContractId @Settlement.Factory.F <$> submit bank do
+  settlementFactoryCid <- toInterfaceContractId @SettlementFactory.I <$> submit bank do
     createCmd Settlement.Factory with
       provider = bank
       observers = Set.singleton bob
@@ -188,8 +188,8 @@ runFixedRateBond = do
 
   -- CREATE_FIXED_RATE_BOND_INSTRUMENT_BEGIN
   -- Create a fixed rate bond factory
-  fixedRateBondFactoryCid <- toInterfaceContractId @FixedRate.Factory.F <$> submit bank do
-    createCmd FixedRate.Factory with
+  fixedRateBondFactoryCid <- toInterfaceContractId @FixedRateBondFactory.I <$> submit bank do
+    createCmd FixedRateBond.Factory with
       provider = bank
       observers = mempty
 
@@ -205,7 +205,7 @@ runFixedRateBond = do
 
   -- Bank creates the bond instrument
   fixedRateBondCid <- submit bank do
-    exerciseCmd fixedRateBondFactoryCid FixedRate.Factory.Create with
+    exerciseCmd fixedRateBondFactoryCid FixedRateBondFactory.Create with
       fixedRate = FixedRate with
         instrument = bondInstrument
         description = "Instrument representing units of a fixed rate bond"

--- a/docs/code-samples/lifecycling/daml/Scripts/FixedRateBond.daml
+++ b/docs/code-samples/lifecycling/daml/Scripts/FixedRateBond.daml
@@ -6,15 +6,15 @@ import DA.Set qualified as Set (singleton)
 import Daml.Script
 
 -- INTERFACE DEPENDENCIES --
-import Daml.Finance.Interface.Account.Factory qualified as Account (F)
+import Daml.Finance.Interface.Account.Factory qualified as Account.Factory (F)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (I)
-import Daml.Finance.Interface.Instrument.Bond.FixedRate.Factory qualified as FixedRate (Create(..), F(..))
+import Daml.Finance.Interface.Instrument.Bond.FixedRate.Factory qualified as FixedRate.Factory (Create(..), F(..))
 import Daml.Finance.Interface.Instrument.Bond.FixedRate.Types (FixedRate(..))
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I)
 import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), I)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (Evolve(..), I)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
-import Daml.Finance.Interface.Settlement.Factory qualified as Settlement (F)
+import Daml.Finance.Interface.Settlement.Factory qualified as Settlement.Factory (F)
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Settlement.RouteProvider qualified as RouteProvider (I)
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..))
@@ -54,7 +54,7 @@ data FixedRateState = FixedRateState
     holidayCalendarIds : [Text]
     lifecycleRuleCid : ContractId Lifecycle.I
     routeProviderCid : ContractId RouteProvider.I
-    settlementFactoryCid : ContractId Settlement.F
+    settlementFactoryCid : ContractId Settlement.Factory.F
     lifecycleClaimRuleCid : ContractId Claim.I
     firstCouponClockEventCid : ContractId Event.I
     initialTimestamp : Time
@@ -74,7 +74,7 @@ runFixedRateBond = do
   [bank, bob, public] <- mapA createParty ["Bank", "Bob", "Public"]
 
   -- Account Factory (it is used by the bank to create accounts)
-  accountFactoryCid <- toInterfaceContractId @Account.F <$> submit bank do
+  accountFactoryCid <- toInterfaceContractId @Account.Factory.F <$> submit bank do
     createCmd Account.Factory with provider = bank; observers = mempty
 
   -- Holding Factory (it is used by the bank to create holdings with the desired implementation)
@@ -102,7 +102,7 @@ runFixedRateBond = do
 
   -- Setup a Settlement Factory facility
   -- This is used to generate settlement instructions from a list of `RoutedStep`s
-  settlementFactoryCid <- toInterfaceContractId @Settlement.F <$> submit bank do
+  settlementFactoryCid <- toInterfaceContractId @Settlement.Factory.F <$> submit bank do
     createCmd Settlement.Factory with
       provider = bank
       observers = Set.singleton bob
@@ -188,7 +188,7 @@ runFixedRateBond = do
 
   -- CREATE_FIXED_RATE_BOND_INSTRUMENT_BEGIN
   -- Create a fixed rate bond factory
-  fixedRateBondFactoryCid <- toInterfaceContractId @FixedRate.F <$> submit bank do
+  fixedRateBondFactoryCid <- toInterfaceContractId @FixedRate.Factory.F <$> submit bank do
     createCmd FixedRate.Factory with
       provider = bank
       observers = mempty
@@ -205,7 +205,7 @@ runFixedRateBond = do
 
   -- Bank creates the bond instrument
   fixedRateBondCid <- submit bank do
-    exerciseCmd fixedRateBondFactoryCid FixedRate.Create with
+    exerciseCmd fixedRateBondFactoryCid FixedRate.Factory.Create with
       fixedRate = FixedRate with
         instrument = bondInstrument
         description = "Instrument representing units of a fixed rate bond"

--- a/docs/code-samples/lifecycling/daml/Scripts/FloatingRateBond.daml
+++ b/docs/code-samples/lifecycling/daml/Scripts/FloatingRateBond.daml
@@ -6,7 +6,7 @@ import DA.Set qualified as Set (singleton)
 import Daml.Script
 
 -- INTERFACE DEPENDENCIES --
-import Daml.Finance.Interface.Instrument.Bond.FloatingRate.Factory qualified as FloatingRate (Create(..), F(..))
+import Daml.Finance.Interface.Instrument.Bond.FloatingRate.Factory qualified as FloatingRate.Factory (Create(..), F(..))
 import Daml.Finance.Interface.Instrument.Bond.FloatingRate.Types (FloatingRate(..))
 import Daml.Finance.Interface.Instrument.Types.FloatingRate qualified as Types (DateRelativeToEnum(..), FloatingRate(..), ReferenceRateTypeEnum(..))
 import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..))
@@ -78,7 +78,7 @@ runFloatingRateBond = do
 
   -- CREATE_FLOATING_RATE_BOND_INSTRUMENT_BEGIN
   -- Create a floating rate bond factory
-  floatingRateBondFactoryCid <- toInterfaceContractId @FloatingRate.F <$> submit bank do
+  floatingRateBondFactoryCid <- toInterfaceContractId @FloatingRate.Factory.F <$> submit bank do
     createCmd FloatingRate.Factory with
       provider = bank
       observers = mempty
@@ -94,7 +94,7 @@ runFloatingRateBond = do
 
   -- Bank creates the bond instrument
   floatingRateBondCid <- submit bank do
-    exerciseCmd floatingRateBondFactoryCid FloatingRate.Create with
+    exerciseCmd floatingRateBondFactoryCid FloatingRate.Factory.Create with
       floatingRate = FloatingRate with
         instrument = bondInstrument
         description = "Instrument representing units of a floating rate bond"

--- a/docs/code-samples/lifecycling/daml/Scripts/FloatingRateBond.daml
+++ b/docs/code-samples/lifecycling/daml/Scripts/FloatingRateBond.daml
@@ -6,9 +6,9 @@ import DA.Set qualified as Set (singleton)
 import Daml.Script
 
 -- INTERFACE DEPENDENCIES --
-import Daml.Finance.Interface.Instrument.Bond.FloatingRate.Factory qualified as FloatingRate.Factory (Create(..), F(..))
+import Daml.Finance.Interface.Instrument.Bond.FloatingRate.Factory qualified as FloatingRateBondFactory (Create(..), I(..))
 import Daml.Finance.Interface.Instrument.Bond.FloatingRate.Types (FloatingRate(..))
-import Daml.Finance.Interface.Instrument.Types.FloatingRate qualified as Types (DateRelativeToEnum(..), FloatingRate(..), ReferenceRateTypeEnum(..))
+import Daml.Finance.Interface.Instrument.Types.FloatingRate qualified as FloatinRateTypes (DateRelativeToEnum(..), FloatingRate(..), ReferenceRateTypeEnum(..))
 import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..))
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (Evolve(..))
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
@@ -23,7 +23,7 @@ import Daml.Finance.Interface.Types.Date.RollConvention (PeriodEnum(..))
 -- IMPLEMENTATION DEPENDENCIES --
 import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Time.DateClock (dateToDateClockTime)
-import Daml.Finance.Instrument.Bond.FloatingRate.Factory qualified as FloatingRate (Factory(..))
+import Daml.Finance.Instrument.Bond.FloatingRate.Factory qualified as FloatingRateBond (Factory(..))
 
 import Workflow.CreditAccount qualified as CreditAccount
 
@@ -65,9 +65,9 @@ runFloatingRateBond = do
     couponPeriodMultiplier = 3
     dayCountConvention = ActActISDA
     businessDayConvention = Following
-    floatingRate = Types.FloatingRate with
+    floatingRate = FloatinRateTypes.FloatingRate with
       referenceRateId
-      referenceRateType = Types.SingleFixing Types.CalculationPeriodStartDate
+      referenceRateType = FloatinRateTypes.SingleFixing FloatinRateTypes.CalculationPeriodStartDate
       fixingDates = DateOffset with
         periodMultiplier = 0
         period = D
@@ -78,8 +78,8 @@ runFloatingRateBond = do
 
   -- CREATE_FLOATING_RATE_BOND_INSTRUMENT_BEGIN
   -- Create a floating rate bond factory
-  floatingRateBondFactoryCid <- toInterfaceContractId @FloatingRate.Factory.F <$> submit bank do
-    createCmd FloatingRate.Factory with
+  floatingRateBondFactoryCid <- toInterfaceContractId @FloatingRateBondFactory.I <$> submit bank do
+    createCmd FloatingRateBond.Factory with
       provider = bank
       observers = mempty
 
@@ -94,7 +94,7 @@ runFloatingRateBond = do
 
   -- Bank creates the bond instrument
   floatingRateBondCid <- submit bank do
-    exerciseCmd floatingRateBondFactoryCid FloatingRate.Factory.Create with
+    exerciseCmd floatingRateBondFactoryCid FloatingRateBondFactory.Create with
       floatingRate = FloatingRate with
         instrument = bondInstrument
         description = "Instrument representing units of a floating rate bond"

--- a/docs/code-samples/lifecycling/daml/Scripts/Util.daml
+++ b/docs/code-samples/lifecycling/daml/Scripts/Util.daml
@@ -3,8 +3,7 @@ module Scripts.Util where
 import Daml.Script
 
 -- INTERFACE DEPENDENCIES --
-import Daml.Finance.Interface.Holding.Factory (Reference(..))
-import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (F)
+import Daml.Finance.Interface.Holding.Factory qualified as Holding.Factory (F, Reference(..))
 import Daml.Finance.Interface.Types.Common.Types (HoldingFactoryKey(..))
 
 -- IMPLEMENTATION DEPENDENCIES --
@@ -22,11 +21,11 @@ createParty name = do
 -- https://docs.daml.com/daml-finance/reference/patterns.html#reference-pattern
 createHoldingFactory : Holding.Factory -> Script HoldingFactoryKey
 createHoldingFactory holdingFactory = do
-  cid <- toInterfaceContractId @HoldingFactory.F <$> submit holdingFactory.provider do
+  cid <- toInterfaceContractId @Holding.Factory.F <$> submit holdingFactory.provider do
     createCmd holdingFactory
   submit holdingFactory.provider do
-    createCmd Reference with
-      factoryView = view $ toInterface @HoldingFactory.F holdingFactory
+    createCmd Holding.Factory.Reference with
+      factoryView = view $ toInterface @Holding.Factory.F holdingFactory
       cid
       observers = holdingFactory.observers
   pure $ HoldingFactoryKey with provider = holdingFactory.provider; id = holdingFactory.id

--- a/docs/code-samples/lifecycling/daml/Scripts/Util.daml
+++ b/docs/code-samples/lifecycling/daml/Scripts/Util.daml
@@ -3,7 +3,7 @@ module Scripts.Util where
 import Daml.Script
 
 -- INTERFACE DEPENDENCIES --
-import Daml.Finance.Interface.Holding.Factory qualified as Holding.Factory (F, Reference(..))
+import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (I, Reference(..))
 import Daml.Finance.Interface.Types.Common.Types (HoldingFactoryKey(..))
 
 -- IMPLEMENTATION DEPENDENCIES --
@@ -21,11 +21,11 @@ createParty name = do
 -- https://docs.daml.com/daml-finance/reference/patterns.html#reference-pattern
 createHoldingFactory : Holding.Factory -> Script HoldingFactoryKey
 createHoldingFactory holdingFactory = do
-  cid <- toInterfaceContractId @Holding.Factory.F <$> submit holdingFactory.provider do
+  cid <- toInterfaceContractId @HoldingFactory.I <$> submit holdingFactory.provider do
     createCmd holdingFactory
   submit holdingFactory.provider do
-    createCmd Holding.Factory.Reference with
-      factoryView = view $ toInterface @Holding.Factory.F holdingFactory
+    createCmd HoldingFactory.Reference with
+      factoryView = view $ toInterface @HoldingFactory.I holdingFactory
       cid
       observers = holdingFactory.observers
   pure $ HoldingFactoryKey with provider = holdingFactory.provider; id = holdingFactory.id

--- a/docs/code-samples/lifecycling/daml/Workflow/CreateAccount.daml
+++ b/docs/code-samples/lifecycling/daml/Workflow/CreateAccount.daml
@@ -5,7 +5,7 @@ import DA.Set qualified as Set (fromList, singleton)
 
 -- INTERFACE DEPENDENCIES --
 import Daml.Finance.Interface.Account.Account qualified as Account (Controllers(..))
-import Daml.Finance.Interface.Account.Factory qualified as Account (Create(..), F)
+import Daml.Finance.Interface.Account.Factory qualified as Account.Factory (Create(..), F)
 import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), HoldingFactoryKey, Id(..))
 
 -- | Initiate / Accept template to open an account.
@@ -30,7 +30,7 @@ template Request
           -- ^ A textual label.
         description : Text
           -- ^ An extended textual description.
-        accountFactoryCid : ContractId Account.F
+        accountFactoryCid : ContractId Account.Factory.F
           -- ^ The account factory. This is used to create the account template.
         holdingFactory : HoldingFactoryKey
           -- ^ The holding factory. This is used within an account to create holdings.
@@ -45,7 +45,7 @@ template Request
             id = Id label
           observersSet = Set.fromList observers
 
-        accountCid <- exercise accountFactoryCid Account.Create with
+        accountCid <- exercise accountFactoryCid Account.Factory.Create with
           account = accountKey
           description
           holdingFactory

--- a/docs/code-samples/lifecycling/daml/Workflow/CreateAccount.daml
+++ b/docs/code-samples/lifecycling/daml/Workflow/CreateAccount.daml
@@ -5,7 +5,7 @@ import DA.Set qualified as Set (fromList, singleton)
 
 -- INTERFACE DEPENDENCIES --
 import Daml.Finance.Interface.Account.Account qualified as Account (Controllers(..))
-import Daml.Finance.Interface.Account.Factory qualified as Account.Factory (Create(..), F)
+import Daml.Finance.Interface.Account.Factory qualified as AccountFactory (Create(..), I)
 import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), HoldingFactoryKey, Id(..))
 
 -- | Initiate / Accept template to open an account.
@@ -30,7 +30,7 @@ template Request
           -- ^ A textual label.
         description : Text
           -- ^ An extended textual description.
-        accountFactoryCid : ContractId Account.Factory.F
+        accountFactoryCid : ContractId AccountFactory.I
           -- ^ The account factory. This is used to create the account template.
         holdingFactory : HoldingFactoryKey
           -- ^ The holding factory. This is used within an account to create holdings.
@@ -45,7 +45,7 @@ template Request
             id = Id label
           observersSet = Set.fromList observers
 
-        accountCid <- exercise accountFactoryCid Account.Factory.Create with
+        accountCid <- exercise accountFactoryCid AccountFactory.Create with
           account = accountKey
           description
           holdingFactory

--- a/docs/code-samples/payoff-modeling/daml/Util.daml
+++ b/docs/code-samples/payoff-modeling/daml/Util.daml
@@ -38,7 +38,8 @@ mapClaim c instrumentMap =
 printEffect : Effect.V -> Script ()
 printEffect effect = do
   debug $ "--- EFFECT on " <> show effect.id <> " ---"
-  debug $ "TARGET INSTRUMENT : " <> show effect.targetInstrument.id <> " version " <> effect.targetInstrument.version
+  debug $ "TARGET INSTRUMENT : " <> show effect.targetInstrument.id <> " version " <>
+    effect.targetInstrument.version
   debug "RECEIVING"
   forA_ effect.otherProduced \otherProduced ->
     printAmount otherProduced.amount otherProduced.unit.id
@@ -48,4 +49,3 @@ printEffect effect = do
 
 printAmount : Decimal -> Id -> Script ()
 printAmount amount unit = debug $ " => " <> show amount <> " " <> show unit
-

--- a/docs/code-samples/payoff-modeling/daml/Util/Setup.daml
+++ b/docs/code-samples/payoff-modeling/daml/Util/Setup.daml
@@ -6,8 +6,8 @@ import Daml.Script
 
 -- INTERFACE DEPENDENCIES --
 import Daml.Finance.Interface.Claims.Types (C)
-import Daml.Finance.Interface.Instrument.Generic.Factory qualified as Generic (Create(..), F)
-import Daml.Finance.Interface.Instrument.Token.Factory qualified as Token.Factory (Create(..), F)
+import Daml.Finance.Interface.Instrument.Generic.Factory qualified as GenericFactory (Create(..), I)
+import Daml.Finance.Interface.Instrument.Token.Factory qualified as TokenFactory (Create(..), I)
 import Daml.Finance.Interface.Instrument.Token.Types (Token(..))
 import Daml.Finance.Interface.Types.Common.Types (HoldingStandard(..), Id(..), InstrumentKey(..))
 
@@ -31,7 +31,7 @@ setupUnderlyingInstruments instrumentProvider observers = do
 
   now <- getTime
 
-  tokenFactoryCid <- toInterfaceContractId @Token.Factory.F <$> submit instrumentProvider do
+  tokenFactoryCid <- toInterfaceContractId @TokenFactory.I <$> submit instrumentProvider do
     createCmd Token.Factory with provider = instrumentProvider; observers = empty
 
   let
@@ -39,7 +39,7 @@ setupUnderlyingInstruments instrumentProvider observers = do
     usdInstrument = buildInstrumentKey instrumentProvider instrumentProvider "USD" "0"
 
   submit instrumentProvider do
-    exerciseCmd tokenFactoryCid Token.Factory.Create with
+    exerciseCmd tokenFactoryCid TokenFactory.Create with
       token = Token with
         instrument = usdInstrument
         description = "USD Instrument"
@@ -47,7 +47,7 @@ setupUnderlyingInstruments instrumentProvider observers = do
       observers = fromList [("Investors", observers)]
 
   submit instrumentProvider do
-    exerciseCmd tokenFactoryCid Token.Factory.Create with
+    exerciseCmd tokenFactoryCid TokenFactory.Create with
       token = Token with
         instrument = eurInstrument
         description = "EUR Instrument"
@@ -64,7 +64,7 @@ setupGenericInstrument : Party -> Set Party -> Text -> Text -> Text -> Time -> C
   Script InstrumentKey
 setupGenericInstrument instrumentProvider observers id version description acquisitionTime claims =
   do
-    genericInstrumentFactoryCid <- toInterfaceContractId @Generic.F <$>
+    genericInstrumentFactoryCid <- toInterfaceContractId @GenericFactory.I <$>
       submit instrumentProvider do
         createCmd Generic.Factory with provider = instrumentProvider; observers = empty
 
@@ -72,7 +72,7 @@ setupGenericInstrument instrumentProvider observers id version description acqui
       claimInstrument = buildInstrumentKey instrumentProvider instrumentProvider id version
 
     submit instrumentProvider do
-      exerciseCmd genericInstrumentFactoryCid Generic.Create with
+      exerciseCmd genericInstrumentFactoryCid GenericFactory.Create with
         instrument = claimInstrument
         description
         claims

--- a/docs/code-samples/payoff-modeling/daml/Util/Setup.daml
+++ b/docs/code-samples/payoff-modeling/daml/Util/Setup.daml
@@ -7,7 +7,7 @@ import Daml.Script
 -- INTERFACE DEPENDENCIES --
 import Daml.Finance.Interface.Claims.Types (C)
 import Daml.Finance.Interface.Instrument.Generic.Factory qualified as Generic (Create(..), F)
-import Daml.Finance.Interface.Instrument.Token.Factory qualified as Token (Create(..), F)
+import Daml.Finance.Interface.Instrument.Token.Factory qualified as Token.Factory (Create(..), F)
 import Daml.Finance.Interface.Instrument.Token.Types (Token(..))
 import Daml.Finance.Interface.Types.Common.Types (HoldingStandard(..), Id(..), InstrumentKey(..))
 
@@ -31,7 +31,7 @@ setupUnderlyingInstruments instrumentProvider observers = do
 
   now <- getTime
 
-  tokenFactoryCid <- toInterfaceContractId @Token.F <$> submit instrumentProvider do
+  tokenFactoryCid <- toInterfaceContractId @Token.Factory.F <$> submit instrumentProvider do
     createCmd Token.Factory with provider = instrumentProvider; observers = empty
 
   let
@@ -39,7 +39,7 @@ setupUnderlyingInstruments instrumentProvider observers = do
     usdInstrument = buildInstrumentKey instrumentProvider instrumentProvider "USD" "0"
 
   submit instrumentProvider do
-    exerciseCmd tokenFactoryCid Token.Create with
+    exerciseCmd tokenFactoryCid Token.Factory.Create with
       token = Token with
         instrument = usdInstrument
         description = "USD Instrument"
@@ -47,7 +47,7 @@ setupUnderlyingInstruments instrumentProvider observers = do
       observers = fromList [("Investors", observers)]
 
   submit instrumentProvider do
-    exerciseCmd tokenFactoryCid Token.Create with
+    exerciseCmd tokenFactoryCid Token.Factory.Create with
       token = Token with
         instrument = eurInstrument
         description = "EUR Instrument"
@@ -60,22 +60,24 @@ setupUnderlyingInstruments instrumentProvider observers = do
     ]
 
 -- | Given a claim tree, create a generic instrument wrapping the tree.
-setupGenericInstrument : Party -> Set Party -> Text -> Text -> Text -> Time -> C -> Script InstrumentKey
-setupGenericInstrument instrumentProvider observers id version description acquisitionTime claims = do
+setupGenericInstrument : Party -> Set Party -> Text -> Text -> Text -> Time -> C ->
+  Script InstrumentKey
+setupGenericInstrument instrumentProvider observers id version description acquisitionTime claims =
+  do
+    genericInstrumentFactoryCid <- toInterfaceContractId @Generic.F <$>
+      submit instrumentProvider do
+        createCmd Generic.Factory with provider = instrumentProvider; observers = empty
 
-  genericInstrumentFactoryCid <- toInterfaceContractId @Generic.F <$> submit instrumentProvider do
-    createCmd Generic.Factory with provider = instrumentProvider; observers = empty
+    let
+      claimInstrument = buildInstrumentKey instrumentProvider instrumentProvider id version
 
-  let
-    claimInstrument = buildInstrumentKey instrumentProvider instrumentProvider id version
+    submit instrumentProvider do
+      exerciseCmd genericInstrumentFactoryCid Generic.Create with
+        instrument = claimInstrument
+        description
+        claims
+        acquisitionTime
+        lastEventTimestamp = acquisitionTime
+        observers = fromList [("Investors", observers)]
 
-  submit instrumentProvider do
-    exerciseCmd genericInstrumentFactoryCid Generic.Create with
-      instrument = claimInstrument
-      description
-      claims
-      acquisitionTime
-      lastEventTimestamp = acquisitionTime
-      observers = fromList [("Investors", observers)]
-
-  pure claimInstrument
+    pure claimInstrument

--- a/docs/code-samples/settlement/daml/Scripts/Intermediated.daml
+++ b/docs/code-samples/settlement/daml/Scripts/Intermediated.daml
@@ -6,10 +6,10 @@ import DA.Set qualified as Set (fromList, singleton)
 import Daml.Script
 
 -- INTERFACE DEPENDENCIES --
-import Daml.Finance.Interface.Account.Factory qualified as Account (F)
+import Daml.Finance.Interface.Account.Factory qualified as Account.Factory (F)
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
-import Daml.Finance.Interface.Settlement.Factory qualified as Settlement (F, Instruct(..))
+import Daml.Finance.Interface.Settlement.Factory qualified as Settlement.Factory (F, Instruct(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Settlement.RouteProvider qualified as RouteProvider (Discover(..), I)
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), RoutedStep(..), Step(..))
@@ -65,7 +65,7 @@ data SetupIntermediatedSettlement = SetupIntermediatedSettlement
       -- ^ Charlie's holding @Bank2.
     requestor : Party
       -- ^ The party who instructs and thereby creates settlement requests.
-    settlementFactoryCid : ContractId Settlement.F
+    settlementFactoryCid : ContractId Settlement.Factory.F
       -- ^ Settlement factory.
     all : [Party]
       -- ^ A list with all the parties above.
@@ -96,13 +96,13 @@ runSetupIntermediatedSettlement = do
 
   -- Setup a Settlement Factory facility.
   -- This is used to generate settlement instructions from a list of `RoutedStep`s.
-  settlementFactoryCid <- toInterfaceContractId @Settlement.F <$> submit requestor do
+  settlementFactoryCid <- toInterfaceContractId @Settlement.Factory.F <$> submit requestor do
     createCmd Settlement.Factory with
       provider = requestor
       observers = Set.fromList all
 
   -- Account Factory (used to create accounts @Bank2).
-  accountFactoryCid <- toInterfaceContractId @Account.F <$> submit bank2 do
+  accountFactoryCid <- toInterfaceContractId @Account.Factory.F <$> submit bank2 do
     createCmd Account.Factory with provider = bank2; observers = mempty
 
   -- Set up accounts @Bank2.
@@ -143,7 +143,7 @@ runSetupIntermediatedSettlement = do
 
   -- Set up accounts @Central Bank.
   -- Account Factory (used to create accounts @cb).
-  accountFactoryCid <- toInterfaceContractId @Account.F <$> submit cb do
+  accountFactoryCid <- toInterfaceContractId @Account.Factory.F <$> submit cb do
     createCmd Account.Factory with provider = cb; observers = mempty
   let controllersWithOwner = toControllers accountControllers cb
   holdingFactory <- createHoldingFactory
@@ -256,7 +256,7 @@ runWrappedTransfersSettlement = do
   -- WRAPPED_TRANSFERS_INSTRUCT_BEGIN
   (batchCid, [instructionCid1, instructionCid2]) <-
     submit requestor do
-      exerciseCmd settlementFactoryCid Settlement.Instruct with
+      exerciseCmd settlementFactoryCid Settlement.Factory.Instruct with
         instructor = requestor
         consenters = mempty
         settlers = Set.singleton requestor
@@ -376,7 +376,7 @@ runRouteProviderSettlement = do
   -- ROUTE_PROVIDER_INSTRUCT_BEGIN
   (batchCid, [instructionCid1, instructionCid2, instructionCid3, instructionCid4]) <-
     submit requestor do
-      exerciseCmd settlementFactoryCid Settlement.Instruct with
+      exerciseCmd settlementFactoryCid Settlement.Factory.Instruct with
         instructor = requestor
         consenters = mempty
         settlers = Set.singleton requestor

--- a/docs/code-samples/settlement/daml/Scripts/Intermediated.daml
+++ b/docs/code-samples/settlement/daml/Scripts/Intermediated.daml
@@ -6,10 +6,10 @@ import DA.Set qualified as Set (fromList, singleton)
 import Daml.Script
 
 -- INTERFACE DEPENDENCIES --
-import Daml.Finance.Interface.Account.Factory qualified as Account.Factory (F)
+import Daml.Finance.Interface.Account.Factory qualified as AccountFactory (I)
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
-import Daml.Finance.Interface.Settlement.Factory qualified as Settlement.Factory (F, Instruct(..))
+import Daml.Finance.Interface.Settlement.Factory qualified as SettlementFactory (I, Instruct(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Settlement.RouteProvider qualified as RouteProvider (Discover(..), I)
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), RoutedStep(..), Step(..))
@@ -65,7 +65,7 @@ data SetupIntermediatedSettlement = SetupIntermediatedSettlement
       -- ^ Charlie's holding @Bank2.
     requestor : Party
       -- ^ The party who instructs and thereby creates settlement requests.
-    settlementFactoryCid : ContractId Settlement.Factory.F
+    settlementFactoryCid : ContractId SettlementFactory.I
       -- ^ Settlement factory.
     all : [Party]
       -- ^ A list with all the parties above.
@@ -96,13 +96,13 @@ runSetupIntermediatedSettlement = do
 
   -- Setup a Settlement Factory facility.
   -- This is used to generate settlement instructions from a list of `RoutedStep`s.
-  settlementFactoryCid <- toInterfaceContractId @Settlement.Factory.F <$> submit requestor do
+  settlementFactoryCid <- toInterfaceContractId @SettlementFactory.I <$> submit requestor do
     createCmd Settlement.Factory with
       provider = requestor
       observers = Set.fromList all
 
   -- Account Factory (used to create accounts @Bank2).
-  accountFactoryCid <- toInterfaceContractId @Account.Factory.F <$> submit bank2 do
+  accountFactoryCid <- toInterfaceContractId @AccountFactory.I <$> submit bank2 do
     createCmd Account.Factory with provider = bank2; observers = mempty
 
   -- Set up accounts @Bank2.
@@ -143,7 +143,7 @@ runSetupIntermediatedSettlement = do
 
   -- Set up accounts @Central Bank.
   -- Account Factory (used to create accounts @cb).
-  accountFactoryCid <- toInterfaceContractId @Account.Factory.F <$> submit cb do
+  accountFactoryCid <- toInterfaceContractId @AccountFactory.I <$> submit cb do
     createCmd Account.Factory with provider = cb; observers = mempty
   let controllersWithOwner = toControllers accountControllers cb
   holdingFactory <- createHoldingFactory
@@ -256,7 +256,7 @@ runWrappedTransfersSettlement = do
   -- WRAPPED_TRANSFERS_INSTRUCT_BEGIN
   (batchCid, [instructionCid1, instructionCid2]) <-
     submit requestor do
-      exerciseCmd settlementFactoryCid Settlement.Factory.Instruct with
+      exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
         instructor = requestor
         consenters = mempty
         settlers = Set.singleton requestor
@@ -376,14 +376,14 @@ runRouteProviderSettlement = do
   -- ROUTE_PROVIDER_INSTRUCT_BEGIN
   (batchCid, [instructionCid1, instructionCid2, instructionCid3, instructionCid4]) <-
     submit requestor do
-      exerciseCmd settlementFactoryCid Settlement.Factory.Instruct with
+      exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
         instructor = requestor
         consenters = mempty
         settlers = Set.singleton requestor
         id = Id "1"
         description = "Transfer from Alice to Bob via intermediaries"
         contextId = None
-        routedSteps = routedSteps
+        routedSteps  -- This is equivalent to writing routedSteps = routedSteps
         settlementTime = None -- i.e., immediate settlement
   -- ROUTE_PROVIDER_INSTRUCT_END
 

--- a/docs/code-samples/settlement/daml/Scripts/Internal.daml
+++ b/docs/code-samples/settlement/daml/Scripts/Internal.daml
@@ -6,7 +6,7 @@ import Daml.Script
 -- INTERFACE DEPENDENCIES --
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
-import Daml.Finance.Interface.Settlement.Factory qualified as Settlement (F, Instruct(..))
+import Daml.Finance.Interface.Settlement.Factory qualified as Settlement.Factory (F, Instruct(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), RoutedStep(..))
 import Daml.Finance.Interface.Types.Common.Types (AccountKey, Id(..), InstrumentKey(..))
@@ -40,7 +40,7 @@ data SetupInternalSettlement = SetupInternalSettlement
       -- ^ Charlie's account @Bank.
     requestor : Party
       -- ^ The party who requests/instructs settlement.
-    settlementFactoryCid : ContractId Settlement.F
+    settlementFactoryCid : ContractId Settlement.Factory.F
       -- ^ Settlement factory.
     all : [Party]
       -- ^ A list with all the parties above.
@@ -73,7 +73,7 @@ runSetupInternalSettlement = do
 
   -- Setup a Settlement Factory facility (used to generate settlement instructions from a list of
   -- `RoutedStep`s).
-  settlementFactoryCid <- toInterfaceContractId @Settlement.F <$> submit requestor do
+  settlementFactoryCid <- toInterfaceContractId @Settlement.Factory.F <$> submit requestor do
     createCmd Settlement.Factory with
       provider = requestor
       observers = fromList all
@@ -125,7 +125,7 @@ runWrappedTransferSettlement = do
   -- Generate settlement instructions from a list of `RoutedStep`s.
   (batchCid, [instructionCid]) <-
     submit requestor do
-      exerciseCmd settlementFactoryCid Settlement.Instruct with
+      exerciseCmd settlementFactoryCid Settlement.Factory.Instruct with
         instructor = requestor
         consenters = mempty
         settlers = singleton requestor
@@ -208,7 +208,7 @@ runCreditDebitSettlement = do
   -- Generate settlement instructions from a list of `RoutedStep`s.
   (batchCid, [instructionCid1, instructionCid2]) <-
     submit requestor do
-      exerciseCmd settlementFactoryCid Settlement.Instruct with
+      exerciseCmd settlementFactoryCid Settlement.Factory.Instruct with
         instructor = requestor
         consenters = mempty
         settlers = singleton requestor
@@ -300,7 +300,7 @@ runPassThroughSettlement = do
   -- Generate settlement instructions from a list of `RoutedStep`s.
   (batchCid, [instructionCid1, instructionCid2]) <-
     submit requestor do
-      exerciseCmd settlementFactoryCid Settlement.Instruct with
+      exerciseCmd settlementFactoryCid Settlement.Factory.Instruct with
         instructor = requestor
         consenters = mempty
         settlers = singleton requestor

--- a/docs/code-samples/settlement/daml/Scripts/Internal.daml
+++ b/docs/code-samples/settlement/daml/Scripts/Internal.daml
@@ -6,7 +6,7 @@ import Daml.Script
 -- INTERFACE DEPENDENCIES --
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
-import Daml.Finance.Interface.Settlement.Factory qualified as Settlement.Factory (F, Instruct(..))
+import Daml.Finance.Interface.Settlement.Factory qualified as SettlementFactory (I, Instruct(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), RoutedStep(..))
 import Daml.Finance.Interface.Types.Common.Types (AccountKey, Id(..), InstrumentKey(..))
@@ -40,7 +40,7 @@ data SetupInternalSettlement = SetupInternalSettlement
       -- ^ Charlie's account @Bank.
     requestor : Party
       -- ^ The party who requests/instructs settlement.
-    settlementFactoryCid : ContractId Settlement.Factory.F
+    settlementFactoryCid : ContractId SettlementFactory.I
       -- ^ Settlement factory.
     all : [Party]
       -- ^ A list with all the parties above.
@@ -73,7 +73,7 @@ runSetupInternalSettlement = do
 
   -- Setup a Settlement Factory facility (used to generate settlement instructions from a list of
   -- `RoutedStep`s).
-  settlementFactoryCid <- toInterfaceContractId @Settlement.Factory.F <$> submit requestor do
+  settlementFactoryCid <- toInterfaceContractId @SettlementFactory.I <$> submit requestor do
     createCmd Settlement.Factory with
       provider = requestor
       observers = fromList all
@@ -125,7 +125,7 @@ runWrappedTransferSettlement = do
   -- Generate settlement instructions from a list of `RoutedStep`s.
   (batchCid, [instructionCid]) <-
     submit requestor do
-      exerciseCmd settlementFactoryCid Settlement.Factory.Instruct with
+      exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
         instructor = requestor
         consenters = mempty
         settlers = singleton requestor
@@ -208,7 +208,7 @@ runCreditDebitSettlement = do
   -- Generate settlement instructions from a list of `RoutedStep`s.
   (batchCid, [instructionCid1, instructionCid2]) <-
     submit requestor do
-      exerciseCmd settlementFactoryCid Settlement.Factory.Instruct with
+      exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
         instructor = requestor
         consenters = mempty
         settlers = singleton requestor
@@ -300,7 +300,7 @@ runPassThroughSettlement = do
   -- Generate settlement instructions from a list of `RoutedStep`s.
   (batchCid, [instructionCid1, instructionCid2]) <-
     submit requestor do
-      exerciseCmd settlementFactoryCid Settlement.Factory.Instruct with
+      exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
         instructor = requestor
         consenters = mempty
         settlers = singleton requestor

--- a/docs/code-samples/settlement/daml/Scripts/Setup.daml
+++ b/docs/code-samples/settlement/daml/Scripts/Setup.daml
@@ -6,11 +6,10 @@ import Daml.Script
 
 -- INTERFACE DEPENDENCIES --
 import Daml.Finance.Interface.Account.Account qualified as Account (Controllers(..))
-import Daml.Finance.Interface.Account.Factory qualified as Account (F)
-import Daml.Finance.Interface.Holding.Factory (Reference(..))
-import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (F)
+import Daml.Finance.Interface.Account.Factory qualified as Account.Factory (F)
+import Daml.Finance.Interface.Holding.Factory qualified as Holding.Factory (F, Reference(..))
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I)
-import Daml.Finance.Interface.Instrument.Token.Factory qualified as Token (F, Create(..))
+import Daml.Finance.Interface.Instrument.Token.Factory qualified as Token.Factory (F, Create(..))
 import Daml.Finance.Interface.Instrument.Token.Types (Token(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (I)
 import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), HoldingFactoryKey(..), HoldingStandard(..), Id(..), InstrumentKey(..))
@@ -34,8 +33,8 @@ data RequiredAuthorizers
   deriving (Eq, Show)
 
 -- | Describes the required authorizers for incoming and outgoing transfers.
-data AccountControllers =
-  AccountControllers with
+data AccountControllers = AccountControllers
+  with
     incoming : RequiredAuthorizers
     outgoing : RequiredAuthorizers
   deriving (Eq, Show)
@@ -101,7 +100,7 @@ runSetup accountControllers = do
     mapA createParty ["CentralBank", "Bank", "Bank2", "Alice", "Bob", "Charlie", "Requestor"]
 
   -- Account Factory (used to create accounts @Bank1).
-  accountFactoryCid <- toInterfaceContractId @Account.F <$> submit bank1 do
+  accountFactoryCid <- toInterfaceContractId @Account.Factory.F <$> submit bank1 do
     createCmd Account.Factory with provider = bank1; observers = mempty
 
   -- Holding Factory (used to create holdings with the desired implementation @Bank1).
@@ -148,11 +147,11 @@ runSetup accountControllers = do
       description = "Account of Charlie at Bank1"
       accountFactoryCid
       holdingFactory
-      observers = [alice, bob]  -- disclosing to all clients of Bank1
+      observers = [alice, bob] -- disclosing to all clients of Bank1
 
   -- Central Bank creates the cash instrument using a Token factory.
   now <- getTime
-  tokenFactoryCid <- toInterfaceContractId @Token.F <$> submit cb do
+  tokenFactoryCid <- toInterfaceContractId @Token.Factory.F <$> submit cb do
     createCmd Token.Factory with
       provider = cb
       observers = mempty
@@ -164,7 +163,7 @@ runSetup accountControllers = do
       version = "0"
       holdingStandard = TransferableFungible
   submit cb do
-    exerciseCmd tokenFactoryCid Token.Create with
+    exerciseCmd tokenFactoryCid Token.Factory.Create with
       token = Token with
         instrument
         description = "Instrument representing units of USD"
@@ -202,11 +201,11 @@ retrieveKey actor cid = script do
 -- https://docs.daml.com/daml-finance/reference/patterns.html#reference-pattern
 createHoldingFactory : Holding.Factory -> Script HoldingFactoryKey
 createHoldingFactory holdingFactory = do
-  cid <- toInterfaceContractId @HoldingFactory.F <$> submit holdingFactory.provider do
+  cid <- toInterfaceContractId @Holding.Factory.F <$> submit holdingFactory.provider do
     createCmd holdingFactory
   submit holdingFactory.provider do
-    createCmd Reference with
-      factoryView = view $ toInterface @HoldingFactory.F holdingFactory
+    createCmd Holding.Factory.Reference with
+      factoryView = view $ toInterface @Holding.Factory.F holdingFactory
       cid
       observers = holdingFactory.observers
   pure $ HoldingFactoryKey with provider = holdingFactory.provider; id = holdingFactory.id

--- a/docs/code-samples/settlement/daml/Scripts/Setup.daml
+++ b/docs/code-samples/settlement/daml/Scripts/Setup.daml
@@ -6,10 +6,10 @@ import Daml.Script
 
 -- INTERFACE DEPENDENCIES --
 import Daml.Finance.Interface.Account.Account qualified as Account (Controllers(..))
-import Daml.Finance.Interface.Account.Factory qualified as Account.Factory (F)
-import Daml.Finance.Interface.Holding.Factory qualified as Holding.Factory (F, Reference(..))
+import Daml.Finance.Interface.Account.Factory qualified as AccountFactory (I)
+import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (I, Reference(..))
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I)
-import Daml.Finance.Interface.Instrument.Token.Factory qualified as Token.Factory (F, Create(..))
+import Daml.Finance.Interface.Instrument.Token.Factory qualified as TokenFactory (Create(..), I)
 import Daml.Finance.Interface.Instrument.Token.Types (Token(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (I)
 import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), HoldingFactoryKey(..), HoldingStandard(..), Id(..), InstrumentKey(..))
@@ -100,7 +100,7 @@ runSetup accountControllers = do
     mapA createParty ["CentralBank", "Bank", "Bank2", "Alice", "Bob", "Charlie", "Requestor"]
 
   -- Account Factory (used to create accounts @Bank1).
-  accountFactoryCid <- toInterfaceContractId @Account.Factory.F <$> submit bank1 do
+  accountFactoryCid <- toInterfaceContractId @AccountFactory.I <$> submit bank1 do
     createCmd Account.Factory with provider = bank1; observers = mempty
 
   -- Holding Factory (used to create holdings with the desired implementation @Bank1).
@@ -151,7 +151,7 @@ runSetup accountControllers = do
 
   -- Central Bank creates the cash instrument using a Token factory.
   now <- getTime
-  tokenFactoryCid <- toInterfaceContractId @Token.Factory.F <$> submit cb do
+  tokenFactoryCid <- toInterfaceContractId @TokenFactory.I <$> submit cb do
     createCmd Token.Factory with
       provider = cb
       observers = mempty
@@ -163,7 +163,7 @@ runSetup accountControllers = do
       version = "0"
       holdingStandard = TransferableFungible
   submit cb do
-    exerciseCmd tokenFactoryCid Token.Factory.Create with
+    exerciseCmd tokenFactoryCid TokenFactory.Create with
       token = Token with
         instrument
         description = "Instrument representing units of USD"
@@ -201,11 +201,11 @@ retrieveKey actor cid = script do
 -- https://docs.daml.com/daml-finance/reference/patterns.html#reference-pattern
 createHoldingFactory : Holding.Factory -> Script HoldingFactoryKey
 createHoldingFactory holdingFactory = do
-  cid <- toInterfaceContractId @Holding.Factory.F <$> submit holdingFactory.provider do
+  cid <- toInterfaceContractId @HoldingFactory.I <$> submit holdingFactory.provider do
     createCmd holdingFactory
   submit holdingFactory.provider do
-    createCmd Holding.Factory.Reference with
-      factoryView = view $ toInterface @Holding.Factory.F holdingFactory
+    createCmd HoldingFactory.Reference with
+      factoryView = view $ toInterface @HoldingFactory.I holdingFactory
       cid
       observers = holdingFactory.observers
   pure $ HoldingFactoryKey with provider = holdingFactory.provider; id = holdingFactory.id

--- a/docs/code-samples/settlement/daml/Workflow/CreateAccount.daml
+++ b/docs/code-samples/settlement/daml/Workflow/CreateAccount.daml
@@ -5,7 +5,7 @@ import DA.Set qualified as Set (fromList)
 
 -- INTERFACE DEPENDENCIES --
 import Daml.Finance.Interface.Account.Account qualified as Account (Controllers(..))
-import Daml.Finance.Interface.Account.Factory qualified as Account (Create(..), F)
+import Daml.Finance.Interface.Account.Factory qualified as Account.Factory (Create(..), F)
 import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), HoldingFactoryKey, Id(..))
 
 -- | Initiate / Accept template to open an account.
@@ -31,7 +31,7 @@ template Request
           -- ^ A textual label.
         description : Text
           -- ^ An extended textual description.
-        accountFactoryCid : ContractId Account.F
+        accountFactoryCid : ContractId Account.Factory.F
           -- ^ The account factory. This is used to create the account template.
         holdingFactory : HoldingFactoryKey
           -- ^ The holding factory. This is used within an account to create holdings.
@@ -46,7 +46,7 @@ template Request
             id = Id label
           observersSet = Set.fromList observers
 
-        accountCid <- exercise accountFactoryCid Account.Create with
+        accountCid <- exercise accountFactoryCid Account.Factory.Create with
           account = accountKey
           description
           holdingFactory

--- a/docs/code-samples/settlement/daml/Workflow/CreateAccount.daml
+++ b/docs/code-samples/settlement/daml/Workflow/CreateAccount.daml
@@ -5,7 +5,7 @@ import DA.Set qualified as Set (fromList)
 
 -- INTERFACE DEPENDENCIES --
 import Daml.Finance.Interface.Account.Account qualified as Account (Controllers(..))
-import Daml.Finance.Interface.Account.Factory qualified as Account.Factory (Create(..), F)
+import Daml.Finance.Interface.Account.Factory qualified as AccountFactory (Create(..), I)
 import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), HoldingFactoryKey, Id(..))
 
 -- | Initiate / Accept template to open an account.
@@ -31,7 +31,7 @@ template Request
           -- ^ A textual label.
         description : Text
           -- ^ An extended textual description.
-        accountFactoryCid : ContractId Account.Factory.F
+        accountFactoryCid : ContractId AccountFactory.I
           -- ^ The account factory. This is used to create the account template.
         holdingFactory : HoldingFactoryKey
           -- ^ The holding factory. This is used within an account to create holdings.
@@ -46,7 +46,7 @@ template Request
             id = Id label
           observersSet = Set.fromList observers
 
-        accountCid <- exercise accountFactoryCid Account.Factory.Create with
+        accountCid <- exercise accountFactoryCid AccountFactory.Create with
           account = accountKey
           description
           holdingFactory

--- a/docs/code-samples/tutorials-config/2.8.0.conf
+++ b/docs/code-samples/tutorials-config/2.8.0.conf
@@ -11,7 +11,7 @@ https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Ins
 https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Instrument.Option/0.2.99.20231030.1/daml-finance-instrument-option-0.2.99.20231030.1.dar .lib/daml-finance-instrument-option.dar
 https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Instrument.StructuredProduct/0.0.99.20231030.1/daml-finance-instrument-structuredproduct-0.0.99.20231030.1.dar .lib/daml-finance-instrument-structuredproduct.dar
 https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Instrument.Swap/0.3.99.20231030.1/daml-finance-instrument-swap-0.3.99.20231030.1.dar .lib/daml-finance-instrument-swap.dar
-https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Instrument.Token/3.0.0/daml-finance-instrument-token-3.0.0.dar .lib/daml-finance-instrument-token.dar
+https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Instrument.Token/2.99.0.20231030.1/daml-finance-instrument-token-2.99.0.20231030.1.dar .lib/daml-finance-instrument-token.dar
 https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Interface.Account/2.99.0.20231030.1/daml-finance-interface-account-2.99.0.20231030.1.dar .lib/daml-finance-interface-account.dar
 https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Interface.Claims/2.99.0.20231030.1/daml-finance-interface-claims-2.99.0.20231030.1.dar .lib/daml-finance-interface-claims.dar
 https://github.com/digital-asset/daml-finance/releases/download/Daml.Finance.Interface.Data/3.0.0.99.20231030.1/daml-finance-interface-data-3.0.0.99.20231030.1.dar .lib/daml-finance-interface-data.dar

--- a/package/main/daml/Daml.Finance.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Claims/daml.yaml
@@ -4,21 +4,21 @@
 sdk-version: 2.7.0
 name: daml-finance-claims
 source: daml
-version: 2.1.0
+version: 2.0.99.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/2.0.0/contingent-claims-core-2.0.0.dar
   - .lib/daml-finance/ContingentClaims.Lifecycle/2.0.0/contingent-claims-lifecycle-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.99.0.20231030.1/daml-finance-interface-claims-2.99.0.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.99.0.20231030.1/daml-finance-interface-instrument-base-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/0.99.0.20231030.1/daml-finance-interface-instrument-types-0.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20231030.1/daml-finance-interface-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20231030.1/daml-finance-interface-types-date-2.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20231030.1/daml-finance-interface-util-2.0.99.20231030.1.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.0/daml-finance-lifecycle-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/2.99.0.20231030.1/daml-finance-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.99.20231030.1/daml-finance-util-3.0.99.20231030.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Data/daml.yaml
@@ -4,12 +4,12 @@
 sdk-version: 2.7.0
 name: daml-finance-data
 source: daml
-version: 2.0.1
+version: 2.0.0.99.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Data/3.0.0.99.20231030.1/daml-finance-interface-data-3.0.0.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/3.0.99.20231030.1/daml-finance-interface-data-3.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20231030.1/daml-finance-interface-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20231030.1/daml-finance-interface-types-date-2.0.99.20231030.1.dar

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -4,17 +4,17 @@
 sdk-version: 2.7.0
 name: daml-finance-instrument-bond
 source: daml
-version: 2.0.0
+version: 1.99.0.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/2.0.0/contingent-claims-core-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Claims/2.1.0/daml-finance-claims-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/2.0.0/daml-finance-interface-instrument-bond-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Claims/2.0.99.20231030.1/daml-finance-claims-2.0.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/2.0.0.99.20231030.1/daml-finance-data-2.0.0.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.99.0.20231030.1/daml-finance-interface-claims-2.99.0.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.99.0.20231030.1/daml-finance-interface-instrument-base-2.99.0.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/1.99.0.20231030.1/daml-finance-interface-instrument-bond-1.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/0.99.0.20231030.1/daml-finance-interface-instrument-types-0.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20231030.1/daml-finance-interface-types-date-2.0.99.20231030.1.dar

--- a/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
@@ -4,16 +4,16 @@
 sdk-version: 2.7.0
 name: daml-finance-instrument-equity
 source: daml
-version: 0.4.0
+version: 0.3.99.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.4.0/daml-finance-interface-instrument-equity-0.4.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.99.0.20231030.1/daml-finance-interface-instrument-base-2.99.0.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.3.99.20231030.1/daml-finance-interface-instrument-equity-0.3.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20231030.1/daml-finance-interface-util-2.0.99.20231030.1.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.0/daml-finance-lifecycle-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/2.99.0.20231030.1/daml-finance-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.99.20231030.1/daml-finance-util-3.0.99.20231030.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
@@ -4,19 +4,19 @@
 sdk-version: 2.7.0
 name: daml-finance-instrument-generic
 source: daml
-version: 3.0.0
+version: 2.99.0.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Claims/2.1.0/daml-finance-claims-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/3.0.0/daml-finance-interface-instrument-generic-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Claims/2.0.99.20231030.1/daml-finance-claims-2.0.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.99.0.20231030.1/daml-finance-interface-claims-2.99.0.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.99.0.20231030.1/daml-finance-interface-instrument-base-2.99.0.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/2.99.0.20231030.1/daml-finance-interface-instrument-generic-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20231030.1/daml-finance-interface-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20231030.1/daml-finance-interface-util-2.0.99.20231030.1.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.0/daml-finance-lifecycle-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/2.99.0.20231030.1/daml-finance-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.99.20231030.1/daml-finance-util-3.0.99.20231030.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
@@ -4,19 +4,19 @@
 sdk-version: 2.7.0
 name: daml-finance-instrument-option
 source: daml
-version: 0.3.0
+version: 0.2.99.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Claims/2.1.0/daml-finance-claims-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.3.0/daml-finance-interface-instrument-option-0.3.0.dar
+  - .lib/daml-finance/Daml.Finance.Claims/2.0.99.20231030.1/daml-finance-claims-2.0.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/2.0.0.99.20231030.1/daml-finance-data-2.0.0.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.99.0.20231030.1/daml-finance-interface-claims-2.99.0.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.99.0.20231030.1/daml-finance-interface-instrument-base-2.99.0.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.2.99.20231030.1/daml-finance-interface-instrument-option-0.2.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20231030.1/daml-finance-interface-util-2.0.99.20231030.1.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.0/daml-finance-lifecycle-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/2.99.0.20231030.1/daml-finance-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.99.20231030.1/daml-finance-util-3.0.99.20231030.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
@@ -4,17 +4,17 @@
 sdk-version: 2.7.0
 name: daml-finance-instrument-structuredproduct
 source: daml
-version: 0.1.0
+version: 0.0.99.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Claims/2.1.0/daml-finance-claims-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.3.0/daml-finance-interface-instrument-option-0.3.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.StructuredProduct/0.1.0/daml-finance-interface-instrument-structuredproduct-0.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Claims/2.0.99.20231030.1/daml-finance-claims-2.0.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/2.0.0.99.20231030.1/daml-finance-data-2.0.0.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.99.0.20231030.1/daml-finance-interface-claims-2.99.0.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.99.0.20231030.1/daml-finance-interface-instrument-base-2.99.0.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.2.99.20231030.1/daml-finance-interface-instrument-option-0.2.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.StructuredProduct/0.0.99.20231030.1/daml-finance-interface-instrument-structuredproduct-0.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20231030.1/daml-finance-interface-types-date-2.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20231030.1/daml-finance-interface-util-2.0.99.20231030.1.dar

--- a/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
@@ -4,17 +4,17 @@
 sdk-version: 2.7.0
 name: daml-finance-instrument-swap
 source: daml
-version: 0.4.0
+version: 0.3.99.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/2.0.0/contingent-claims-core-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Claims/2.1.0/daml-finance-claims-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.4.0/daml-finance-interface-instrument-swap-0.4.0.dar
+  - .lib/daml-finance/Daml.Finance.Claims/2.0.99.20231030.1/daml-finance-claims-2.0.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/2.0.0.99.20231030.1/daml-finance-data-2.0.0.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.99.0.20231030.1/daml-finance-interface-claims-2.99.0.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.99.0.20231030.1/daml-finance-interface-instrument-base-2.99.0.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.3.99.20231030.1/daml-finance-interface-instrument-swap-0.3.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/0.99.0.20231030.1/daml-finance-interface-instrument-types-0.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20231030.1/daml-finance-interface-types-date-2.0.99.20231030.1.dar

--- a/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
@@ -4,13 +4,13 @@
 sdk-version: 2.7.0
 name: daml-finance-instrument-token
 source: daml
-version: 3.0.0
+version: 2.99.0.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/3.0.0/daml-finance-interface-instrument-token-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.99.0.20231030.1/daml-finance-interface-instrument-base-2.99.0.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/2.99.0.20231030.1/daml-finance-interface-instrument-token-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20231030.1/daml-finance-interface-util-2.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.99.20231030.1/daml-finance-util-3.0.99.20231030.1.dar

--- a/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
@@ -4,13 +4,13 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-claims
 source: daml
-version: 3.0.0
+version: 2.99.0.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/2.0.0/contingent-claims-core-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.99.0.20231030.1/daml-finance-interface-instrument-base-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20231030.1/daml-finance-interface-util-2.0.99.20231030.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-data
 source: daml
-version: 3.0.0.99.20231030.1
+version: 3.0.99.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-instrument-base
 source: daml
-version: 3.0.0
+version: 2.99.0.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
@@ -4,13 +4,13 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-instrument-bond
 source: daml
-version: 2.0.0
+version: 1.99.0.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.99.0.20231030.1/daml-finance-interface-claims-2.99.0.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.99.0.20231030.1/daml-finance-interface-instrument-base-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/0.99.0.20231030.1/daml-finance-interface-instrument-types-0.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20231030.1/daml-finance-interface-types-date-2.0.99.20231030.1.dar

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
@@ -4,12 +4,12 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-instrument-equity
 source: daml
-version: 0.4.0
+version: 0.3.99.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.99.0.20231030.1/daml-finance-interface-instrument-base-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20231030.1/daml-finance-interface-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20231030.1/daml-finance-interface-util-2.0.99.20231030.1.dar

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
@@ -4,13 +4,13 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-instrument-generic
 source: daml
-version: 3.0.0
+version: 2.99.0.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.99.0.20231030.1/daml-finance-interface-claims-2.99.0.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.99.0.20231030.1/daml-finance-interface-instrument-base-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20231030.1/daml-finance-interface-util-2.0.99.20231030.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
@@ -4,13 +4,13 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-instrument-option
 source: daml
-version: 0.3.0
+version: 0.2.99.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.99.0.20231030.1/daml-finance-interface-claims-2.99.0.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.99.0.20231030.1/daml-finance-interface-instrument-base-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20231030.1/daml-finance-interface-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20231030.1/daml-finance-interface-util-2.0.99.20231030.1.dar

--- a/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
@@ -4,13 +4,13 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-instrument-structuredproduct
 source: daml
-version: 0.1.0
+version: 0.0.99.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.99.0.20231030.1/daml-finance-interface-claims-2.99.0.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.99.0.20231030.1/daml-finance-interface-instrument-base-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20231030.1/daml-finance-interface-types-date-2.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20231030.1/daml-finance-interface-util-2.0.99.20231030.1.dar

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
@@ -4,12 +4,12 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-instrument-swap
 source: daml
-version: 0.4.0
+version: 0.3.99.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.99.0.20231030.1/daml-finance-interface-instrument-base-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/0.99.0.20231030.1/daml-finance-interface-instrument-types-0.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20231030.1/daml-finance-interface-types-date-2.0.99.20231030.1.dar

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
@@ -4,12 +4,12 @@
 sdk-version: 2.7.0
 name: daml-finance-interface-instrument-token
 source: daml
-version: 3.0.0
+version: 2.99.0.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.99.0.20231030.1/daml-finance-interface-instrument-base-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20231030.1/daml-finance-interface-util-2.0.99.20231030.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
@@ -4,14 +4,14 @@
 sdk-version: 2.7.0
 name: daml-finance-lifecycle
 source: daml
-version: 3.0.0
+version: 2.99.0.20231030.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Account/2.99.0.20231030.1/daml-finance-interface-account-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.99.0.20231030.1/daml-finance-interface-holding-2.99.0.20231030.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.99.0.20231030.1/daml-finance-interface-instrument-base-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20231030.1/daml-finance-interface-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.0.99.20231030.1/daml-finance-interface-settlement-2.0.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar

--- a/package/test/daml/Daml.Finance.Data.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Data.Test/daml.yaml
@@ -10,8 +10,8 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Data/3.0.0.99.20231030.1/daml-finance-interface-data-3.0.0.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/2.0.0.99.20231030.1/daml-finance-data-2.0.0.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/3.0.99.20231030.1/daml-finance-interface-data-3.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20231030.1/daml-finance-interface-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20231030.1/daml-finance-interface-types-date-2.0.99.20231030.1.dar

--- a/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
@@ -10,10 +10,10 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Bond/2.0.0/daml-finance-instrument-bond-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/2.0.0/daml-finance-interface-instrument-bond-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Data/2.0.0.99.20231030.1/daml-finance-data-2.0.0.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Bond/1.99.0.20231030.1/daml-finance-instrument-bond-1.99.0.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.99.0.20231030.1/daml-finance-interface-claims-2.99.0.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/1.99.0.20231030.1/daml-finance-interface-instrument-bond-1.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/0.99.0.20231030.1/daml-finance-interface-instrument-types-0.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20231030.1/daml-finance-interface-types-date-2.0.99.20231030.1.dar

--- a/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
@@ -11,16 +11,16 @@ dependencies:
   - daml-script
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Holding/2.99.0.20231030.1/daml-finance-holding-2.99.0.20231030.1.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Equity/0.4.0/daml-finance-instrument-equity-0.4.0.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Equity/0.3.99.20231030.1/daml-finance-instrument-equity-0.3.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Instrument.Option.Test/0.1.0/daml-finance-instrument-option-test-0.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Option/0.3.0/daml-finance-instrument-option-0.3.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.4.0/daml-finance-interface-instrument-equity-0.4.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.3.0/daml-finance-interface-instrument-option-0.3.0.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Option/0.2.99.20231030.1/daml-finance-instrument-option-0.2.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.3.99.20231030.1/daml-finance-interface-instrument-equity-0.3.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.2.99.20231030.1/daml-finance-interface-instrument-option-0.2.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20231030.1/daml-finance-interface-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.0.99.20231030.1/daml-finance-interface-settlement-2.0.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20231030.1/daml-finance-interface-util-2.0.99.20231030.1.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.0/daml-finance-lifecycle-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/2.99.0.20231030.1/daml-finance-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Settlement/2.0.0.99.20231030.1/daml-finance-settlement-2.0.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options: null

--- a/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
@@ -11,20 +11,20 @@ dependencies:
   - daml-script
 data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/2.0.0/contingent-claims-core-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Claims/2.1.0/daml-finance-claims-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Claims/2.0.99.20231030.1/daml-finance-claims-2.0.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/2.0.0.99.20231030.1/daml-finance-data-2.0.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Holding/2.99.0.20231030.1/daml-finance-holding-2.99.0.20231030.1.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Generic/3.0.0/daml-finance-instrument-generic-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Generic/2.99.0.20231030.1/daml-finance-instrument-generic-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Account/2.99.0.20231030.1/daml-finance-interface-account-2.99.0.20231030.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/2.99.0.20231030.1/daml-finance-interface-claims-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.99.0.20231030.1/daml-finance-interface-holding-2.99.0.20231030.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/3.0.0/daml-finance-interface-instrument-generic-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/2.99.0.20231030.1/daml-finance-interface-instrument-generic-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20231030.1/daml-finance-interface-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Settlement/2.0.0.99.20231030.1/daml-finance-interface-settlement-2.0.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20231030.1/daml-finance-interface-types-date-2.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20231030.1/daml-finance-interface-util-2.0.99.20231030.1.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.0/daml-finance-lifecycle-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/2.99.0.20231030.1/daml-finance-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Settlement/2.0.0.99.20231030.1/daml-finance-settlement-2.0.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.99.20231030.1/daml-finance-util-3.0.99.20231030.1.dar

--- a/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
@@ -10,10 +10,10 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Claims/2.1.0/daml-finance-claims-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Option/0.3.0/daml-finance-instrument-option-0.3.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.3.0/daml-finance-interface-instrument-option-0.3.0.dar
+  - .lib/daml-finance/Daml.Finance.Claims/2.0.99.20231030.1/daml-finance-claims-2.0.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/2.0.0.99.20231030.1/daml-finance-data-2.0.0.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Option/0.2.99.20231030.1/daml-finance-instrument-option-0.2.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.2.99.20231030.1/daml-finance-interface-instrument-option-0.2.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20231030.1/daml-finance-interface-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20231030.1/daml-finance-interface-util-2.0.99.20231030.1.dar

--- a/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
@@ -10,9 +10,9 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.StructuredProduct/0.1.0/daml-finance-instrument-structuredproduct-0.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.StructuredProduct/0.1.0/daml-finance-interface-instrument-structuredproduct-0.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Data/2.0.0.99.20231030.1/daml-finance-data-2.0.0.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.StructuredProduct/0.0.99.20231030.1/daml-finance-instrument-structuredproduct-0.0.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.StructuredProduct/0.0.99.20231030.1/daml-finance-interface-instrument-structuredproduct-0.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20231030.1/daml-finance-interface-types-date-2.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20231030.1/daml-finance-interface-util-2.0.99.20231030.1.dar

--- a/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
@@ -10,9 +10,9 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Swap/0.4.0/daml-finance-instrument-swap-0.4.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.4.0/daml-finance-interface-instrument-swap-0.4.0.dar
+  - .lib/daml-finance/Daml.Finance.Data/2.0.0.99.20231030.1/daml-finance-data-2.0.0.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Swap/0.3.99.20231030.1/daml-finance-instrument-swap-0.3.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.3.99.20231030.1/daml-finance-interface-instrument-swap-0.3.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/0.99.0.20231030.1/daml-finance-interface-instrument-types-0.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20231030.1/daml-finance-interface-types-date-2.0.99.20231030.1.dar

--- a/package/test/daml/Daml.Finance.Test.Util/daml.yaml
+++ b/package/test/daml/Daml.Finance.Test.Util/daml.yaml
@@ -11,19 +11,19 @@ dependencies:
   - daml-script
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Account/2.99.0.20231030.1/daml-finance-account-2.99.0.20231030.1.dar
-  - .lib/daml-finance/Daml.Finance.Claims/2.1.0/daml-finance-claims-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Data/2.0.1/daml-finance-data-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Claims/2.0.99.20231030.1/daml-finance-claims-2.0.99.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/2.0.0.99.20231030.1/daml-finance-data-2.0.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Holding/2.99.0.20231030.1/daml-finance-holding-2.99.0.20231030.1.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Token/3.0.0/daml-finance-instrument-token-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Token/2.99.0.20231030.1/daml-finance-instrument-token-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Account/2.99.0.20231030.1/daml-finance-interface-account-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Holding/2.99.0.20231030.1/daml-finance-interface-holding-2.99.0.20231030.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/3.0.0/daml-finance-interface-instrument-token-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/2.99.0.20231030.1/daml-finance-interface-instrument-base-2.99.0.20231030.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/2.99.0.20231030.1/daml-finance-interface-instrument-token-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/2.99.0.20231030.1/daml-finance-interface-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/1.0.99.20231030.1/daml-finance-interface-types-common-1.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.0.99.20231030.1/daml-finance-interface-types-date-2.0.99.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.0.99.20231030.1/daml-finance-interface-util-2.0.99.20231030.1.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.0/daml-finance-lifecycle-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/2.99.0.20231030.1/daml-finance-lifecycle-2.99.0.20231030.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.0.99.20231030.1/daml-finance-util-3.0.99.20231030.1.dar
 build-options: null
 

--- a/src/main/daml/Daml/Finance/Account/Account.daml
+++ b/src/main/daml/Daml/Finance/Account/Account.daml
@@ -6,8 +6,8 @@ module Daml.Finance.Account.Account where
 import DA.Map qualified as M (empty)
 import DA.Set qualified as S (fromList, null, singleton)
 import Daml.Finance.Interface.Account.Account qualified as Account (Controllers(..), Credit(..), Debit(..), I, View(..), accountKey, createReference, disclosureUpdateReference)
-import Daml.Finance.Interface.Account.Factory qualified as AccountFactory (Create(..), F, View(..))
-import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (Create(..), F, exerciseInterfaceByKey)
+import Daml.Finance.Interface.Account.Factory qualified as AccountFactory (Create(..), I, View(..))
+import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (Create(..), I, exerciseInterfaceByKey)
 import Daml.Finance.Interface.Types.Common.Types (HoldingFactoryKey(..), Id, PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (AddObservers(..), I, RemoveObservers(..), View(..), flattenObservers)
 import Daml.Finance.Interface.Util.Lockable qualified as Lockable (Acquire(..), I, Lock, Release(..), View(..), getLockers, mustNotBeLocked)
@@ -48,7 +48,7 @@ template Account
       getKey = Account.accountKey this
       credit Account.Credit{quantity} = do
         Lockable.mustNotBeLocked this
-        HoldingFactory.exerciseInterfaceByKey @HoldingFactory.F
+        HoldingFactory.exerciseInterfaceByKey @HoldingFactory.I
           holdingFactory
           custodian
           HoldingFactory.Create with
@@ -101,7 +101,7 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance AccountFactory.F for Factory where
+    interface instance AccountFactory.I for Factory where
       view = AccountFactory.View with provider
       create' AccountFactory.Create {account; holdingFactory; controllers; observers; description} =
         do

--- a/src/main/daml/Daml/Finance/Data/Numeric/Observation.daml
+++ b/src/main/daml/Daml/Finance/Data/Numeric/Observation.daml
@@ -58,7 +58,7 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance ObservationFactory.F for Factory
+    interface instance ObservationFactory.I for Factory
       where
         view = ObservationFactory.View with provider; observers
         create' ObservationFactory.Create{id; observations; observers; provider} =

--- a/src/main/daml/Daml/Finance/Data/Reference/HolidayCalendar.daml
+++ b/src/main/daml/Daml/Finance/Data/Reference/HolidayCalendar.daml
@@ -70,7 +70,7 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance HolidayCalendarFactory.F for Factory
+    interface instance HolidayCalendarFactory.I for Factory
       where
         view = HolidayCalendarFactory.View with provider
         create' HolidayCalendarFactory.Create{calendar; observers; provider} =

--- a/src/main/daml/Daml/Finance/Holding/Factory.daml
+++ b/src/main/daml/Daml/Finance/Holding/Factory.daml
@@ -8,14 +8,15 @@ import Daml.Finance.Holding.BaseHolding (BaseHolding(..))
 import Daml.Finance.Holding.Fungible (Fungible(..))
 import Daml.Finance.Holding.Transferable (Transferable(..))
 import Daml.Finance.Holding.TransferableFungible (TransferableFungible(..))
-import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (Create(..), F, View(..), holdingFactoryKey)
+import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (Create(..), I, View(..), holdingFactoryKey)
 import Daml.Finance.Interface.Types.Common.Types (Id, PartiesMap)
 import Daml.Finance.Interface.Types.Common.Types qualified as HoldingStandard (HoldingStandard(..))
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Implementation of a factory template for holdings.
 template Factory
@@ -30,7 +31,7 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance HoldingFactory.F for Factory
+    interface instance HoldingFactory.I for Factory
       where
         view = HoldingFactory.View with provider; id
         getKey = HoldingFactory.holdingFactoryKey this

--- a/src/main/daml/Daml/Finance/Instrument/Bond/Callable/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/Callable/Factory.daml
@@ -4,17 +4,18 @@
 module Daml.Finance.Instrument.Bond.Callable.Factory where
 
 import DA.Set (singleton)
-import Daml.Finance.Instrument.Bond.Callable.Instrument qualified as Callable (Instrument(..))
+import Daml.Finance.Instrument.Bond.Callable.Instrument qualified as CallableBond (Instrument(..))
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (GetClaims(..), I, getClaims)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (createReference)
-import Daml.Finance.Interface.Instrument.Bond.Callable.Factory qualified as Callable (Create(..), Factory, View(..))
+import Daml.Finance.Interface.Instrument.Bond.Callable.Factory qualified as CallableBondFactory (Create(..), I, View(..))
 import Daml.Finance.Interface.Instrument.Bond.Callable.Types (Callable(..))
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory
@@ -27,14 +28,16 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance Callable.Factory for Factory where
-      view = Callable.View with provider
-      create' Callable.Create{callable = Callable{instrument; description; floatingRate;
-        couponRate; capRate; floorRate; couponSchedule; callSchedule; noticeDays;
-        holidayCalendarIds; calendarDataProvider; dayCountConvention; useAdjustedDatesForDcf;
-        currency; notional; lastEventTimestamp; prevEvents}; observers} = do
+    interface instance CallableBondFactory.I for Factory where
+      view = CallableBondFactory.View with provider
+      create' CallableBondFactory.Create{
+          callable = Callable{instrument; description; floatingRate; couponRate; capRate; floorRate;
+            couponSchedule; callSchedule; noticeDays; holidayCalendarIds; calendarDataProvider;
+            dayCountConvention; useAdjustedDatesForDcf; currency; notional; lastEventTimestamp;
+            prevEvents};
+          observers} = do
           let
-            callableInstrument = Callable.Instrument with
+            callableBondInstrument = CallableBond.Instrument with
               depository = instrument.depository
               issuer = instrument.issuer
               id = instrument.id
@@ -57,11 +60,11 @@ template Factory
               lastEventTimestamp
               prevEvents
               observers
-          cid <- toInterfaceContractId <$> create callableInstrument
+          cid <- toInterfaceContractId <$> create callableBondInstrument
           BaseInstrument.createReference instrument.depository $ toInterfaceContractId cid
           -- Get the claims in order to run the associated checks (e.g. verify that the schedules
           -- are valid).
-          Claim.getClaims (toInterface @Claim.I callableInstrument) $
+          Claim.getClaims (toInterface @Claim.I callableBondInstrument) $
             Claim.GetClaims with actor = instrument.issuer
           pure cid
 

--- a/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate/Factory.daml
@@ -4,17 +4,18 @@
 module Daml.Finance.Instrument.Bond.FixedRate.Factory where
 
 import DA.Set (singleton)
-import Daml.Finance.Instrument.Bond.FixedRate.Instrument qualified as FixedRate (Instrument(..))
+import Daml.Finance.Instrument.Bond.FixedRate.Instrument qualified as FixedRateBond (Instrument(..))
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (GetClaims(..), I, getClaims)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (createReference)
-import Daml.Finance.Interface.Instrument.Bond.FixedRate.Factory qualified as FixedRate (Create(..), Factory, View(..))
+import Daml.Finance.Interface.Instrument.Bond.FixedRate.Factory qualified as FixedRateBondFactory (Create(..), I, View(..))
 import Daml.Finance.Interface.Instrument.Bond.FixedRate.Types (FixedRate(..))
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory
@@ -27,13 +28,15 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance FixedRate.Factory for Factory where
-      view = FixedRate.View with provider
-      create' FixedRate.Create{fixedRate = FixedRate{instrument; description; couponRate;
-        periodicSchedule; holidayCalendarIds; calendarDataProvider; dayCountConvention; currency;
-        notional; lastEventTimestamp}; observers} = do
+    interface instance FixedRateBondFactory.I for Factory where
+      view = FixedRateBondFactory.View with provider
+      create' FixedRateBondFactory.Create{
+        fixedRate = FixedRate{instrument; description; couponRate; periodicSchedule;
+          holidayCalendarIds; calendarDataProvider; dayCountConvention; currency; notional;
+          lastEventTimestamp};
+        observers} = do
           let
-            fixedRateInstrument = FixedRate.Instrument with
+            fixedRateBondInstrument = FixedRateBond.Instrument with
               depository = instrument.depository
               issuer = instrument.issuer
               id = instrument.id
@@ -49,11 +52,11 @@ template Factory
               notional
               lastEventTimestamp
               observers
-          cid <- toInterfaceContractId <$> create fixedRateInstrument
+          cid <- toInterfaceContractId <$> create fixedRateBondInstrument
           BaseInstrument.createReference instrument.depository $ toInterfaceContractId cid
           -- Get the claims in order to run the associated checks (e.g. verify that the schedules
           -- are valid).
-          Claim.getClaims (toInterface @Claim.I fixedRateInstrument) $
+          Claim.getClaims (toInterface @Claim.I fixedRateBondInstrument) $
             Claim.GetClaims with actor = instrument.issuer
           pure cid
 

--- a/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate/Factory.daml
@@ -4,10 +4,10 @@
 module Daml.Finance.Instrument.Bond.FloatingRate.Factory where
 
 import DA.Set (singleton)
-import Daml.Finance.Instrument.Bond.FloatingRate.Instrument qualified as FloatingRate (Instrument(..))
+import Daml.Finance.Instrument.Bond.FloatingRate.Instrument qualified as FloatingRateBond (Instrument(..))
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (GetClaims(..), I, getClaims)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (createReference)
-import Daml.Finance.Interface.Instrument.Bond.FloatingRate.Factory qualified as FloatingRate (Create(..), Factory, View(..))
+import Daml.Finance.Interface.Instrument.Bond.FloatingRate.Factory qualified as FloatingRateBondFactory (Create(..), I, View(..))
 import Daml.Finance.Interface.Instrument.Bond.FloatingRate.Types (FloatingRate(..))
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
@@ -24,13 +24,15 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance FloatingRate.Factory for Factory where
-      view = FloatingRate.View with provider
-      create' FloatingRate.Create{floatingRate = FloatingRate{instrument; description;
-        floatingRate; couponSpread; periodicSchedule; holidayCalendarIds; calendarDataProvider;
-        dayCountConvention; currency; notional; lastEventTimestamp}; observers} = do
+    interface instance FloatingRateBondFactory.I for Factory where
+      view = FloatingRateBondFactory.View with provider
+      create' FloatingRateBondFactory.Create{
+        floatingRate = FloatingRate{instrument; description; floatingRate; couponSpread;
+          periodicSchedule; holidayCalendarIds; calendarDataProvider; dayCountConvention; currency;
+          notional; lastEventTimestamp};
+        observers} = do
           let
-            floatingRateInstrument = FloatingRate.Instrument with
+            floatingRateBondInstrument = FloatingRateBond.Instrument with
               depository = instrument.depository
               issuer = instrument.issuer
               id = instrument.id
@@ -47,11 +49,11 @@ template Factory
               notional
               lastEventTimestamp
               observers
-          cid <- toInterfaceContractId <$> create floatingRateInstrument
+          cid <- toInterfaceContractId <$> create floatingRateBondInstrument
           BaseInstrument.createReference instrument.depository $ toInterfaceContractId cid
           -- Get the claims in order to run the associated checks (e.g. verify that the schedules
           -- are valid).
-          Claim.getClaims (toInterface @Claim.I floatingRateInstrument) $
+          Claim.getClaims (toInterface @Claim.I floatingRateBondInstrument) $
             Claim.GetClaims with actor = instrument.issuer
           pure cid
 

--- a/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate/Instrument.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate/Instrument.daml
@@ -13,7 +13,7 @@ import Daml.Finance.Interface.Claims.Dynamic.Instrument qualified as DynamicInst
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (I, View(..), createReference, disclosureUpdateReference, instrumentKey)
 import Daml.Finance.Interface.Instrument.Bond.FloatingRate.Instrument qualified as FloatingRate (I, View(..))
 import Daml.Finance.Interface.Instrument.Bond.FloatingRate.Types (FloatingRate(..))
-import Daml.Finance.Interface.Instrument.Types.FloatingRate qualified as Types (FloatingRate)
+import Daml.Finance.Interface.Instrument.Types.FloatingRate qualified as FloatinRateTypes (FloatingRate)
 import Daml.Finance.Interface.Types.Common.Types (HoldingStandard(..), Id(..), InstrumentKey(..), PartiesMap)
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
 import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..))
@@ -43,7 +43,7 @@ template Instrument
       -- ^ The holding standard for holdings referencing this instrument.
     description : Text
       -- ^ A description of the instrument.
-    floatingRate : Types.FloatingRate
+    floatingRate : FloatinRateTypes.FloatingRate
       -- ^ A description of the floating rate to be used. This supports both Libor and SOFR style
       --   reference rates (using a compounded index, e.g. the SOFR Index).
 -- FLOATING_RATE_BOND_TEMPLATE_UNTIL_REFRATE_END

--- a/src/main/daml/Daml/Finance/Instrument/Bond/InflationLinked/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/InflationLinked/Factory.daml
@@ -4,17 +4,18 @@
 module Daml.Finance.Instrument.Bond.InflationLinked.Factory where
 
 import DA.Set (singleton)
-import Daml.Finance.Instrument.Bond.InflationLinked.Instrument qualified as InflationLinked (Instrument(..))
+import Daml.Finance.Instrument.Bond.InflationLinked.Instrument qualified as InflationLinkedBond (Instrument(..))
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (GetClaims(..), I, getClaims)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (createReference)
-import Daml.Finance.Interface.Instrument.Bond.InflationLinked.Factory qualified as InflationLinked (Create(..), Factory, View(..))
+import Daml.Finance.Interface.Instrument.Bond.InflationLinked.Factory qualified as InflationLinkedBondFactory (Create(..), I, View(..))
 import Daml.Finance.Interface.Instrument.Bond.InflationLinked.Types (InflationLinked(..))
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory
@@ -27,14 +28,15 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance InflationLinked.Factory for Factory where
-      view = InflationLinked.View with provider
-      create' InflationLinked.Create{inflationLinked = InflationLinked{instrument; description;
-        inflationIndexId; inflationIndexBaseValue; couponRate; periodicSchedule; holidayCalendarIds;
-        calendarDataProvider; dayCountConvention; currency; notional; lastEventTimestamp};
+    interface instance InflationLinkedBondFactory.I for Factory where
+      view = InflationLinkedBondFactory.View with provider
+      create' InflationLinkedBondFactory.Create{
+        inflationLinked = InflationLinked{instrument; description; inflationIndexId;
+          inflationIndexBaseValue; couponRate; periodicSchedule; holidayCalendarIds;
+          calendarDataProvider; dayCountConvention; currency; notional; lastEventTimestamp};
         observers} = do
           let
-            inflationLinkedInstrument = InflationLinked.Instrument with
+            inflationLinkeBondInstrument = InflationLinkedBond.Instrument with
               depository = instrument.depository
               issuer = instrument.issuer
               id = instrument.id
@@ -52,11 +54,11 @@ template Factory
               notional
               lastEventTimestamp
               observers
-          cid <- toInterfaceContractId <$> create inflationLinkedInstrument
+          cid <- toInterfaceContractId <$> create inflationLinkeBondInstrument
           BaseInstrument.createReference instrument.depository $ toInterfaceContractId cid
           -- Get the claims in order to run the associated checks (e.g. verify that the schedules
           -- are valid).
-          Claim.getClaims (toInterface @Claim.I inflationLinkedInstrument) $
+          Claim.getClaims (toInterface @Claim.I inflationLinkeBondInstrument) $
             Claim.GetClaims with actor = instrument.issuer
           pure cid
 

--- a/src/main/daml/Daml/Finance/Instrument/Bond/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/Util.daml
@@ -14,7 +14,7 @@ import Daml.Finance.Interface.Types.Date.Calendar (HolidayCalendarData)
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
 import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..), Schedule)
 import Daml.Finance.Util.Date.Calendar (addBusinessDays)
-import Prelude hiding (and, or, (<=))
+import Prelude hiding ((<=), and, or)
 import Prelude qualified as P (and)
 
 type O = Observation Date Decimal Observable

--- a/src/main/daml/Daml/Finance/Instrument/Bond/ZeroCoupon/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/ZeroCoupon/Factory.daml
@@ -4,17 +4,18 @@
 module Daml.Finance.Instrument.Bond.ZeroCoupon.Factory where
 
 import DA.Set (singleton)
-import Daml.Finance.Instrument.Bond.ZeroCoupon.Instrument qualified as ZeroCoupon (Instrument(..))
+import Daml.Finance.Instrument.Bond.ZeroCoupon.Instrument qualified as ZeroCouponBond (Instrument(..))
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (GetClaims(..), I, getClaims)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (createReference)
-import Daml.Finance.Interface.Instrument.Bond.ZeroCoupon.Factory qualified as ZeroCoupon (Create(..), Factory, View(..))
+import Daml.Finance.Interface.Instrument.Bond.ZeroCoupon.Factory qualified as ZeroCouponBondFactory (Create(..), I, View(..))
 import Daml.Finance.Interface.Instrument.Bond.ZeroCoupon.Types (ZeroCoupon(..))
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory
@@ -27,12 +28,14 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance ZeroCoupon.Factory for Factory where
-      view = ZeroCoupon.View with provider
-      create' ZeroCoupon.Create{zeroCoupon = ZeroCoupon{instrument; description; issueDate;
-        maturityDate; currency; notional; lastEventTimestamp}; observers} = do
+    interface instance ZeroCouponBondFactory.I for Factory where
+      view = ZeroCouponBondFactory.View with provider
+      create' ZeroCouponBondFactory.Create{
+        zeroCoupon = ZeroCoupon{instrument; description; issueDate; maturityDate; currency;
+          notional; lastEventTimestamp};
+        observers} = do
           let
-            zeroCouponInstrument = ZeroCoupon.Instrument with
+            zeroCouponBondInstrument = ZeroCouponBond.Instrument with
               depository = instrument.depository
               issuer = instrument.issuer
               id = instrument.id
@@ -45,10 +48,10 @@ template Factory
               notional
               lastEventTimestamp
               observers
-          cid <- toInterfaceContractId <$> create zeroCouponInstrument
+          cid <- toInterfaceContractId <$> create zeroCouponBondInstrument
           BaseInstrument.createReference instrument.depository $ toInterfaceContractId cid
           -- Get the claims in order to run the associated checks.
-          Claim.getClaims (toInterface @Claim.I zeroCouponInstrument) $
+          Claim.getClaims (toInterface @Claim.I zeroCouponBondInstrument) $
             Claim.GetClaims with actor = instrument.issuer
           pure cid
 

--- a/src/main/daml/Daml/Finance/Instrument/Equity/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Equity/Factory.daml
@@ -6,13 +6,14 @@ module Daml.Finance.Instrument.Equity.Factory where
 import DA.Set (singleton)
 import Daml.Finance.Instrument.Equity.Instrument (Instrument(..))
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (createReference)
-import Daml.Finance.Interface.Instrument.Equity.Factory qualified as EquityFactory (Create(..), F, View(..))
+import Daml.Finance.Interface.Instrument.Equity.Factory qualified as EquityFactory (Create(..), I, View(..))
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory
@@ -25,7 +26,7 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance EquityFactory.F for Factory where
+    interface instance EquityFactory.I for Factory where
       view = EquityFactory.View with provider
       create' EquityFactory.Create{instrument; description; validAsOf; observers} = do
         cid <- toInterfaceContractId <$>

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Factory.daml
@@ -6,13 +6,14 @@ module Daml.Finance.Instrument.Generic.Factory where
 import DA.Set (singleton)
 import Daml.Finance.Instrument.Generic.Instrument (Instrument(..))
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (createReference)
-import Daml.Finance.Interface.Instrument.Generic.Factory qualified as GenericFactory (Create(..), F, View(..))
+import Daml.Finance.Interface.Instrument.Generic.Factory qualified as GenericFactory (Create(..), I, View(..))
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Factory template for generic instrument creation.
 template Factory
@@ -25,7 +26,7 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance GenericFactory.F for Factory where
+    interface instance GenericFactory.I for Factory where
       view = GenericFactory.View with provider
       create' GenericFactory.Create
         {instrument; description; claims; acquisitionTime; lastEventTimestamp; observers} = do

--- a/src/main/daml/Daml/Finance/Instrument/Option/BarrierEuropeanCash/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Option/BarrierEuropeanCash/Factory.daml
@@ -4,17 +4,18 @@
 module Daml.Finance.Instrument.Option.BarrierEuropeanCash.Factory where
 
 import DA.Set (singleton)
-import Daml.Finance.Instrument.Option.BarrierEuropeanCash.Instrument qualified as BarrierEuropean (Instrument(..))
+import Daml.Finance.Instrument.Option.BarrierEuropeanCash.Instrument qualified as BarrierEuropeanCashOption (Instrument(..))
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (GetClaims(..), I, getClaims)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (createReference)
-import Daml.Finance.Interface.Instrument.Option.BarrierEuropeanCash.Factory qualified as BarrierEuropeanOption (Create(..), Factory, View(..))
+import Daml.Finance.Interface.Instrument.Option.BarrierEuropeanCash.Factory qualified as BarrierEuropeanCashOptionFactory (Create(..), I, View(..))
 import Daml.Finance.Interface.Instrument.Option.BarrierEuropeanCash.Types (BarrierEuropean(..))
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory
@@ -27,15 +28,15 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance BarrierEuropeanOption.Factory for Factory where
-      view = BarrierEuropeanOption.View with provider
-      create' BarrierEuropeanOption.Create{
+    interface instance BarrierEuropeanCashOptionFactory.I for Factory where
+      view = BarrierEuropeanCashOptionFactory.View with provider
+      create' BarrierEuropeanCashOptionFactory.Create{
         barrierEuropean = BarrierEuropean{instrument; description; referenceAssetId; ownerReceives;
           optionType; strike; barrier; barrierType; barrierStartDate; expiryDate; currency;
           lastEventTimestamp};
         observers} = do
           let
-            barrierEuropeanInstrument = BarrierEuropean.Instrument with
+            barrierEuropeanCashOptionInstrument = BarrierEuropeanCashOption.Instrument with
               depository = instrument.depository
               issuer = instrument.issuer
               ownerReceives
@@ -53,10 +54,10 @@ template Factory
               currency
               lastEventTimestamp
               observers
-          cid <- toInterfaceContractId <$> create barrierEuropeanInstrument
+          cid <- toInterfaceContractId <$> create barrierEuropeanCashOptionInstrument
           BaseInstrument.createReference instrument.depository $ toInterfaceContractId cid
           -- Get the claims in order to run the associated checks.
-          Claim.getClaims (toInterface @Claim.I barrierEuropeanInstrument) $
+          Claim.getClaims (toInterface @Claim.I barrierEuropeanCashOptionInstrument) $
             Claim.GetClaims with actor = instrument.issuer
           pure cid
 

--- a/src/main/daml/Daml/Finance/Instrument/Option/Dividend/Election.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Option/Dividend/Election.daml
@@ -4,7 +4,7 @@
 module Daml.Finance.Instrument.Option.Dividend.Election where
 
 import DA.Set (singleton)
-import Daml.Finance.Interface.Instrument.Option.Dividend.Election.Factory qualified as Factory (Create(..), F, View(..))
+import Daml.Finance.Interface.Instrument.Option.Dividend.Election.Factory qualified as DividendOptionElectionFactory (Create(..), I, View(..))
 import Daml.Finance.Interface.Instrument.Option.Dividend.Types (ElectionTypeEnum(..))
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
@@ -22,10 +22,10 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance Factory.F for Factory where
-      view = Factory.View with provider
-      create' Factory.Create{id; description; claimType; elector; counterparty; electorIsOwner;
-        electionTime; observers; amount; provider; instrument} =
+    interface instance DividendOptionElectionFactory.I for Factory where
+      view = DividendOptionElectionFactory.View with provider
+      create' DividendOptionElectionFactory.Create{id; description; claimType; elector;
+        counterparty; electorIsOwner; electionTime; observers; amount; provider; instrument} =
         toInterfaceContractId <$> create Election with
           id; description; elector; counterparty; electorIsOwner; electionTime
           observers; amount; provider; instrument

--- a/src/main/daml/Daml/Finance/Instrument/Option/Dividend/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Option/Dividend/Factory.daml
@@ -4,17 +4,18 @@
 module Daml.Finance.Instrument.Option.Dividend.Factory where
 
 import DA.Set (singleton)
-import Daml.Finance.Instrument.Option.Dividend.Instrument qualified as Dividend (Instrument(..))
+import Daml.Finance.Instrument.Option.Dividend.Instrument qualified as DividendOption (Instrument(..))
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (GetClaims(..), I, getClaims)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (createReference)
-import Daml.Finance.Interface.Instrument.Option.Dividend.Factory qualified as DividendOption (Create(..), Factory, View(..))
+import Daml.Finance.Interface.Instrument.Option.Dividend.Factory qualified as DividendOptionFactory (Create(..), I, View(..))
 import Daml.Finance.Interface.Instrument.Option.Dividend.Types (Dividend(..))
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory
@@ -27,32 +28,33 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance DividendOption.Factory for Factory where
-      view = DividendOption.View with provider
-      create' DividendOption.Create{dividend = Dividend{instrument; description; expiryDate;
-        cashQuantity; sharesQuantity; fxQuantity; lastEventTimestamp; prevEvents}; observers} =
-          do
-            let
-              dividendInstrument = Dividend.Instrument with
-                depository = instrument.depository
-                issuer = instrument.issuer
-                id = instrument.id
-                version = instrument.version
-                holdingStandard = instrument.holdingStandard
-                description
-                expiryDate
-                cashQuantity
-                sharesQuantity
-                fxQuantity
-                lastEventTimestamp
-                prevEvents
-                observers
-            cid <- toInterfaceContractId <$> create dividendInstrument
-            BaseInstrument.createReference instrument.depository $ toInterfaceContractId cid
-            -- Get the claims in order to run the associated checks.
-            Claim.getClaims (toInterface @Claim.I dividendInstrument) $
-              Claim.GetClaims with actor = instrument.issuer
-            pure cid
+    interface instance DividendOptionFactory.I for Factory where
+      view = DividendOptionFactory.View with provider
+      create' DividendOptionFactory.Create{
+        dividend = Dividend{instrument; description; expiryDate; cashQuantity; sharesQuantity;
+          fxQuantity; lastEventTimestamp; prevEvents};
+        observers} = do
+          let
+            dividendOptionInstrument = DividendOption.Instrument with
+              depository = instrument.depository
+              issuer = instrument.issuer
+              id = instrument.id
+              version = instrument.version
+              holdingStandard = instrument.holdingStandard
+              description
+              expiryDate
+              cashQuantity
+              sharesQuantity
+              fxQuantity
+              lastEventTimestamp
+              prevEvents
+              observers
+          cid <- toInterfaceContractId <$> create dividendOptionInstrument
+          BaseInstrument.createReference instrument.depository $ toInterfaceContractId cid
+          -- Get the claims in order to run the associated checks.
+          Claim.getClaims (toInterface @Claim.I dividendOptionInstrument) $
+            Claim.GetClaims with actor = instrument.issuer
+          pure cid
 
     interface instance Disclosure.I for Factory where
       view = Disclosure.View with disclosureControllers = singleton provider; observers

--- a/src/main/daml/Daml/Finance/Instrument/Option/EuropeanCash/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Option/EuropeanCash/Factory.daml
@@ -4,17 +4,18 @@
 module Daml.Finance.Instrument.Option.EuropeanCash.Factory where
 
 import DA.Set (singleton)
-import Daml.Finance.Instrument.Option.EuropeanCash.Instrument qualified as European (Instrument(..))
+import Daml.Finance.Instrument.Option.EuropeanCash.Instrument qualified as EuropeanCashOption (Instrument(..))
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (GetClaims(..), I, getClaims)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (createReference)
-import Daml.Finance.Interface.Instrument.Option.EuropeanCash.Factory qualified as EuropeanOption (Create(..), Factory, View(..))
+import Daml.Finance.Interface.Instrument.Option.EuropeanCash.Factory qualified as EuropeanCashOptionFactory (Create(..), I, View(..))
 import Daml.Finance.Interface.Instrument.Option.EuropeanCash.Types (European(..))
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory
@@ -27,14 +28,14 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance EuropeanOption.Factory for Factory where
-      view = EuropeanOption.View with provider
-      create' EuropeanOption.Create{
-        european = European{instrument; description; referenceAssetId; ownerReceives; optionType;
+    interface instance EuropeanCashOptionFactory.I for Factory where
+      view = EuropeanCashOptionFactory.View with provider
+      create' EuropeanCashOptionFactory.Create{
+        european = European{instrument; description; referenceAssetId;ownerReceives; optionType;
           strike; expiryDate; currency; lastEventTimestamp};
         observers} = do
           let
-            europeanInstrument = European.Instrument with
+            europeanCashOptionInstrument = EuropeanCashOption.Instrument with
               depository = instrument.depository
               issuer = instrument.issuer
               ownerReceives
@@ -49,10 +50,10 @@ template Factory
               currency
               lastEventTimestamp
               observers
-          cid <- toInterfaceContractId <$> create europeanInstrument
+          cid <- toInterfaceContractId <$> create europeanCashOptionInstrument
           BaseInstrument.createReference instrument.depository $ toInterfaceContractId cid
           -- Get the claims in order to run the associated checks.
-          Claim.getClaims (toInterface @Claim.I europeanInstrument) $
+          Claim.getClaims (toInterface @Claim.I europeanCashOptionInstrument) $
             Claim.GetClaims with actor = instrument.issuer
           pure cid
 

--- a/src/main/daml/Daml/Finance/Instrument/Option/EuropeanPhysical/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Option/EuropeanPhysical/Factory.daml
@@ -4,17 +4,18 @@
 module Daml.Finance.Instrument.Option.EuropeanPhysical.Factory where
 
 import DA.Set (singleton)
-import Daml.Finance.Instrument.Option.EuropeanPhysical.Instrument qualified as European (Instrument(..))
+import Daml.Finance.Instrument.Option.EuropeanPhysical.Instrument qualified as EuropeanPhysicalOption (Instrument(..))
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (GetClaims(..), I, getClaims)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (createReference)
-import Daml.Finance.Interface.Instrument.Option.EuropeanPhysical.Factory qualified as EuropeanOption (Create(..), Factory, View(..))
+import Daml.Finance.Interface.Instrument.Option.EuropeanPhysical.Factory qualified as EuropeanPhysicalOptionFactory (Create(..), I, View(..))
 import Daml.Finance.Interface.Instrument.Option.EuropeanPhysical.Types (European(..))
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory
@@ -27,13 +28,14 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance EuropeanOption.Factory for Factory where
-      view = EuropeanOption.View with provider
-      create' EuropeanOption.Create{european = European{instrument; description; referenceAsset;
-        ownerReceives; optionType; strike; expiryDate;
-        currency; lastEventTimestamp; prevEvents}; observers} = do
+    interface instance EuropeanPhysicalOptionFactory.I for Factory where
+      view = EuropeanPhysicalOptionFactory.View with provider
+      create' EuropeanPhysicalOptionFactory.Create{
+        european = European{instrument; description; referenceAsset; ownerReceives; optionType;
+          strike; expiryDate; currency; lastEventTimestamp; prevEvents};
+        observers} = do
           let
-            europeanInstrument = European.Instrument with
+            europeanPhysicalOptionInstrument = EuropeanPhysicalOption.Instrument with
               depository = instrument.depository
               issuer = instrument.issuer
               ownerReceives
@@ -49,10 +51,10 @@ template Factory
               lastEventTimestamp
               prevEvents
               observers
-          cid <- toInterfaceContractId <$> create europeanInstrument
+          cid <- toInterfaceContractId <$> create europeanPhysicalOptionInstrument
           BaseInstrument.createReference instrument.depository $ toInterfaceContractId cid
           -- Get the claims in order to run the associated checks.
-          Claim.getClaims (toInterface @Claim.I europeanInstrument) $
+          Claim.getClaims (toInterface @Claim.I europeanPhysicalOptionInstrument) $
             Claim.GetClaims with actor = instrument.issuer
           pure cid
 

--- a/src/main/daml/Daml/Finance/Instrument/StructuredProduct/BarrierReverseConvertible/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/StructuredProduct/BarrierReverseConvertible/Factory.daml
@@ -7,14 +7,15 @@ import DA.Set (singleton)
 import Daml.Finance.Instrument.StructuredProduct.BarrierReverseConvertible.Instrument qualified as BarrierReverseConvertible (Instrument(..))
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (GetClaims(..), I, getClaims)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (createReference)
-import Daml.Finance.Interface.Instrument.StructuredProduct.BarrierReverseConvertible.Factory qualified as BarrierReverseConvertible (Create(..), Factory, View(..))
+import Daml.Finance.Interface.Instrument.StructuredProduct.BarrierReverseConvertible.Factory qualified as BarrierReverseConvertibleFactory (Create(..), I, View(..))
 import Daml.Finance.Interface.Instrument.StructuredProduct.BarrierReverseConvertible.Types (BarrierReverseConvertible(..))
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory
@@ -27,9 +28,9 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance BarrierReverseConvertible.Factory for Factory where
-      view = BarrierReverseConvertible.View with provider
-      create' BarrierReverseConvertible.Create{
+    interface instance BarrierReverseConvertibleFactory.I for Factory where
+      view = BarrierReverseConvertibleFactory.View with provider
+      create' BarrierReverseConvertibleFactory.Create{
         barrierReverseConvertible = BarrierReverseConvertible{instrument; description;
           referenceAssetId; strike; barrier; barrierStartDate; expiryDate; currency;
           lastEventTimestamp; couponRate; periodicSchedule; holidayCalendarIds;

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Asset/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Asset/Factory.daml
@@ -4,17 +4,18 @@
 module Daml.Finance.Instrument.Swap.Asset.Factory where
 
 import DA.Set (singleton)
-import Daml.Finance.Instrument.Swap.Asset.Instrument qualified as Asset (Instrument(..))
+import Daml.Finance.Instrument.Swap.Asset.Instrument qualified as AssetSwap (Instrument(..))
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (GetClaims(..), I, getClaims)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (createReference)
-import Daml.Finance.Interface.Instrument.Swap.Asset.Factory qualified as AssetSwap (Create(..), Factory, View(..))
+import Daml.Finance.Interface.Instrument.Swap.Asset.Factory qualified as AssetSwapFactory (Create(..), I, View(..))
 import Daml.Finance.Interface.Instrument.Swap.Asset.Types (Asset(..))
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory
@@ -27,13 +28,15 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance AssetSwap.Factory for Factory where
-      view = AssetSwap.View with provider
-      create' AssetSwap.Create{asset = Asset{instrument; description; referenceAssetId;
-        ownerReceivesFix; fixRate; periodicSchedule; holidayCalendarIds; calendarDataProvider;
-        dayCountConvention; currency; lastEventTimestamp}; observers} = do
+    interface instance AssetSwapFactory.I for Factory where
+      view = AssetSwapFactory.View with provider
+      create' AssetSwapFactory.Create{
+        asset = Asset{instrument; description; referenceAssetId; ownerReceivesFix; fixRate;
+          periodicSchedule; holidayCalendarIds; calendarDataProvider; dayCountConvention; currency;
+          lastEventTimestamp};
+        observers} = do
           let
-            assetinstrument = Asset.Instrument with
+            assetSwapInstrument = AssetSwap.Instrument with
               depository = instrument.depository
               issuer = instrument.issuer
               ownerReceivesFix
@@ -50,11 +53,11 @@ template Factory
               currency
               lastEventTimestamp
               observers
-          cid <- toInterfaceContractId <$> create assetinstrument
+          cid <- toInterfaceContractId <$> create assetSwapInstrument
           BaseInstrument.createReference instrument.depository $ toInterfaceContractId cid
           -- Get the claims in order to run the associated checks (e.g. verify that the schedules
           -- are valid).
-          Claim.getClaims (toInterface @Claim.I assetinstrument) $
+          Claim.getClaims (toInterface @Claim.I assetSwapInstrument) $
             Claim.GetClaims with actor = instrument.issuer
           pure cid
 

--- a/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/CreditDefault/Factory.daml
@@ -7,7 +7,7 @@ import DA.Set (singleton)
 import Daml.Finance.Instrument.Swap.CreditDefault.Instrument qualified as CreditDefaultSwap (Instrument(..))
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (GetClaims(..), I, getClaims)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (createReference)
-import Daml.Finance.Interface.Instrument.Swap.CreditDefault.Factory qualified as CreditDefaultSwap (Create(..), Factory, View(..))
+import Daml.Finance.Interface.Instrument.Swap.CreditDefault.Factory qualified as CreditDefaultSwapFactory (Create(..), I, View(..))
 import Daml.Finance.Interface.Instrument.Swap.CreditDefault.Types (CreditDefault(..))
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
@@ -24,14 +24,15 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance CreditDefaultSwap.Factory for Factory where
-      view = CreditDefaultSwap.View with provider
-      create' CreditDefaultSwap.Create{creditDefault = CreditDefault{instrument; description;
-        defaultProbabilityReferenceId; recoveryRateReferenceId; ownerReceivesFix; fixRate;
-        periodicSchedule; holidayCalendarIds; calendarDataProvider; dayCountConvention; currency;
-        lastEventTimestamp}; observers} = do
+    interface instance CreditDefaultSwapFactory.I for Factory where
+      view = CreditDefaultSwapFactory.View with provider
+      create' CreditDefaultSwapFactory.Create{
+        creditDefault = CreditDefault{instrument; description; defaultProbabilityReferenceId;
+          recoveryRateReferenceId; ownerReceivesFix; fixRate; periodicSchedule; holidayCalendarIds;
+          calendarDataProvider; dayCountConvention; currency; lastEventTimestamp};
+        observers} = do
           let
-            cdsInstrument = CreditDefaultSwap.Instrument with
+            creditDefaultSwapInstrument = CreditDefaultSwap.Instrument with
               depository = instrument.depository
               issuer = instrument.issuer
               ownerReceivesFix
@@ -49,11 +50,11 @@ template Factory
               currency
               lastEventTimestamp
               observers
-          cid <- toInterfaceContractId <$> create cdsInstrument
+          cid <- toInterfaceContractId <$> create creditDefaultSwapInstrument
           BaseInstrument.createReference instrument.depository $ toInterfaceContractId cid
           -- Get the claims in order to run the associated checks (e.g. verify that the schedules
           -- are valid).
-          Claim.getClaims (toInterface @Claim.I cdsInstrument) $
+          Claim.getClaims (toInterface @Claim.I creditDefaultSwapInstrument) $
             Claim.GetClaims with actor = instrument.issuer
           pure cid
 

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Currency/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Currency/Factory.daml
@@ -7,14 +7,15 @@ import DA.Set (singleton)
 import Daml.Finance.Instrument.Swap.Currency.Instrument qualified as CurrencySwap (Instrument(..))
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (GetClaims(..), I, getClaims)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (createReference)
-import Daml.Finance.Interface.Instrument.Swap.Currency.Factory qualified as CurrencySwap (Create(..), Factory, View(..))
+import Daml.Finance.Interface.Instrument.Swap.Currency.Factory qualified as CurrencySwapFactory (Create(..), I, View(..))
 import Daml.Finance.Interface.Instrument.Swap.Currency.Types (CurrencySwap(..))
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory
@@ -27,12 +28,13 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance CurrencySwap.Factory for Factory where
-      view = CurrencySwap.View with provider
-      create' CurrencySwap.Create{currencySwap = CurrencySwap{instrument; description;
-        ownerReceivesBase; baseRate; foreignRate; periodicSchedule; holidayCalendarIds;
-        calendarDataProvider; dayCountConvention; baseCurrency; foreignCurrency; fxRate;
-        lastEventTimestamp}; observers} = do
+    interface instance CurrencySwapFactory.I for Factory where
+      view = CurrencySwapFactory.View with provider
+      create' CurrencySwapFactory.Create{
+        currencySwap = CurrencySwap{instrument; description; ownerReceivesBase; baseRate;
+          foreignRate; periodicSchedule; holidayCalendarIds; calendarDataProvider;
+          dayCountConvention; baseCurrency; foreignCurrency; fxRate; lastEventTimestamp};
+        observers} = do
           let
             currencySwapInstrument = CurrencySwap.Instrument with
               depository = instrument.depository

--- a/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange/Factory.daml
@@ -4,17 +4,18 @@
 module Daml.Finance.Instrument.Swap.ForeignExchange.Factory where
 
 import DA.Set (singleton)
-import Daml.Finance.Instrument.Swap.ForeignExchange.Instrument qualified as ForeignExchange (Instrument(..))
+import Daml.Finance.Instrument.Swap.ForeignExchange.Instrument qualified as ForeignExchangeSwap (Instrument(..))
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (GetClaims(..), I, getClaims)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (createReference)
-import Daml.Finance.Interface.Instrument.Swap.ForeignExchange.Factory qualified as ForeignExchange (Create(..), Factory, View(..))
+import Daml.Finance.Interface.Instrument.Swap.ForeignExchange.Factory qualified as ForeignExchangeSwapFactory (Create(..), I, View(..))
 import Daml.Finance.Interface.Instrument.Swap.ForeignExchange.Types (ForeignExchange(..))
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory
@@ -27,13 +28,15 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance ForeignExchange.Factory for Factory where
-      view = ForeignExchange.View with provider
-      create' ForeignExchange.Create{foreignExchange = ForeignExchange{instrument; description;
-        firstFxRate; finalFxRate; issueDate; firstPaymentDate; maturityDate; baseCurrency;
-        foreignCurrency; lastEventTimestamp}; observers} = do
+    interface instance ForeignExchangeSwapFactory.I for Factory where
+      view = ForeignExchangeSwapFactory.View with provider
+      create' ForeignExchangeSwapFactory.Create{
+        foreignExchange = ForeignExchange{instrument; description; firstFxRate; finalFxRate;
+          issueDate; firstPaymentDate; maturityDate; baseCurrency; foreignCurrency;
+          lastEventTimestamp};
+        observers} = do
           let
-            fxSwapInstrument = ForeignExchange.Instrument with
+            foreignExchangeSwapInstrument = ForeignExchangeSwap.Instrument with
               depository = instrument.depository
               issuer = instrument.issuer
               id = instrument.id
@@ -49,10 +52,10 @@ template Factory
               foreignCurrency
               lastEventTimestamp
               observers
-          cid <- toInterfaceContractId <$> create fxSwapInstrument
+          cid <- toInterfaceContractId <$> create foreignExchangeSwapInstrument
           BaseInstrument.createReference instrument.depository $ toInterfaceContractId cid
           -- Get the claims in order to run the associated checks.
-          Claim.getClaims (toInterface @Claim.I fxSwapInstrument) $
+          Claim.getClaims (toInterface @Claim.I foreignExchangeSwapInstrument) $
             Claim.GetClaims with actor = instrument.issuer
           pure cid
 

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Factory.daml
@@ -4,17 +4,18 @@
 module Daml.Finance.Instrument.Swap.Fpml.Factory where
 
 import DA.Set (singleton)
-import Daml.Finance.Instrument.Swap.Fpml.Instrument qualified as Fpml (Instrument(..))
+import Daml.Finance.Instrument.Swap.Fpml.Instrument qualified as FpmlSwap (Instrument(..))
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (GetClaims(..), I, getClaims)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (createReference)
-import Daml.Finance.Interface.Instrument.Swap.Fpml.Factory qualified as FpmlSwap (Create(..), Factory, View(..))
+import Daml.Finance.Interface.Instrument.Swap.Fpml.Factory qualified as FpmlSwapFactory (Create(..), I, View(..))
 import Daml.Finance.Interface.Instrument.Swap.Fpml.Types (Fpml(..))
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory
@@ -27,12 +28,14 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance FpmlSwap.Factory for Factory where
-      view = FpmlSwap.View with provider
-      create' FpmlSwap.Create{fpml = Fpml{instrument; description; issuerPartyRef; swapStreams;
-        calendarDataProvider; currencies; lastEventTimestamp}; observers} = do
+    interface instance FpmlSwapFactory.I for Factory where
+      view = FpmlSwapFactory.View with provider
+      create' FpmlSwapFactory.Create{
+        fpml = Fpml{instrument; description; issuerPartyRef; swapStreams; calendarDataProvider;
+          currencies; lastEventTimestamp};
+        observers} = do
           let
-            fpmlInstrument = Fpml.Instrument with
+            fpmlSwapInstrument = FpmlSwap.Instrument with
               depository = instrument.depository
               issuer = instrument.issuer
               id = instrument.id
@@ -45,11 +48,11 @@ template Factory
               currencies
               lastEventTimestamp
               observers
-          cid <- toInterfaceContractId <$> create fpmlInstrument
+          cid <- toInterfaceContractId <$> create fpmlSwapInstrument
           BaseInstrument.createReference instrument.depository $ toInterfaceContractId cid
           -- Get the claims in order to run the associated checks (e.g. verify that the schedules
           -- are valid).
-          Claim.getClaims (toInterface @Claim.I fpmlInstrument) $
+          Claim.getClaims (toInterface @Claim.I fpmlSwapInstrument) $
             Claim.GetClaims with actor = instrument.issuer
           pure cid
 

--- a/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate/Factory.daml
@@ -4,17 +4,18 @@
 module Daml.Finance.Instrument.Swap.InterestRate.Factory where
 
 import DA.Set (singleton)
-import Daml.Finance.Instrument.Swap.InterestRate.Instrument qualified as InterestRate (Instrument(..))
+import Daml.Finance.Instrument.Swap.InterestRate.Instrument qualified as InterestRateSwap (Instrument(..))
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (GetClaims(..), I, getClaims)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (createReference)
-import Daml.Finance.Interface.Instrument.Swap.InterestRate.Factory qualified as InterestRateSwap (Create(..), Factory, View(..))
+import Daml.Finance.Interface.Instrument.Swap.InterestRate.Factory qualified as InterestRateSwapFactory (Create(..), I, View(..))
 import Daml.Finance.Interface.Instrument.Swap.InterestRate.Types (InterestRate(..))
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory
@@ -27,13 +28,13 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance InterestRateSwap.Factory for Factory where
-      view = InterestRateSwap.View with provider
-      create' InterestRateSwap.Create{interestRate = InterestRate{instrument; description;
+    interface instance InterestRateSwapFactory.I for Factory where
+      view = InterestRateSwapFactory.View with provider
+      create' InterestRateSwapFactory.Create{interestRate = InterestRate{instrument; description;
         floatingRate; ownerReceivesFix; fixRate; periodicSchedule; holidayCalendarIds;
         calendarDataProvider; dayCountConvention; currency; lastEventTimestamp}; observers} = do
           let
-            interestRateInstrument = InterestRate.Instrument with
+            interestRateSwapInstrument = InterestRateSwap.Instrument with
               depository = instrument.depository
               issuer = instrument.issuer
               ownerReceivesFix
@@ -50,11 +51,11 @@ template Factory
               currency
               lastEventTimestamp
               observers
-          cid <- toInterfaceContractId <$> create interestRateInstrument
+          cid <- toInterfaceContractId <$> create interestRateSwapInstrument
           BaseInstrument.createReference instrument.depository $ toInterfaceContractId cid
           -- Get the claims in order to run the associated checks (e.g. verify that the schedules
           -- are valid).
-          Claim.getClaims (toInterface @Claim.I interestRateInstrument) $
+          Claim.getClaims (toInterface @Claim.I interestRateSwapInstrument) $
             Claim.GetClaims with actor = instrument.issuer
           pure cid
 

--- a/src/main/daml/Daml/Finance/Instrument/Token/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Token/Factory.daml
@@ -6,14 +6,15 @@ module Daml.Finance.Instrument.Token.Factory where
 import DA.Set (singleton)
 import Daml.Finance.Instrument.Token.Instrument qualified as Token (Instrument(..))
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (createReference)
-import Daml.Finance.Interface.Instrument.Token.Factory qualified as Token (Create(..), Factory, View(..))
+import Daml.Finance.Interface.Instrument.Token.Factory qualified as TokenFactory (Create(..), I, View(..))
 import Daml.Finance.Interface.Instrument.Token.Types (Token(..))
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory
@@ -26,9 +27,9 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance Token.Factory for Factory where
-      view = Token.View with provider
-      create' Token.Create{token = Token{instrument; validAsOf; description}; observers} = do
+    interface instance TokenFactory.I for Factory where
+      view = TokenFactory.View with provider
+      create' TokenFactory.Create{token = Token{instrument; validAsOf; description}; observers} = do
         cid <- toInterfaceContractId <$>
           create Token.Instrument with
             depository = instrument.depository

--- a/src/main/daml/Daml/Finance/Interface/Account/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Account/Factory.daml
@@ -7,8 +7,9 @@ import Daml.Finance.Interface.Account.Account qualified as Account (Controllers(
 import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), HoldingFactoryKey, PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Data/Numeric/Observation/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Data/Numeric/Observation/Factory.daml
@@ -8,8 +8,9 @@ import Daml.Finance.Interface.Data.Numeric.Observation qualified as Observation 
 import Daml.Finance.Interface.Types.Common.Types (Id, PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Data/Reference/HolidayCalendar/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Data/Reference/HolidayCalendar/Factory.daml
@@ -8,8 +8,9 @@ import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Types.Date.Calendar (HolidayCalendarData)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Holding/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Holding/Factory.daml
@@ -11,8 +11,9 @@ import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (AddObserv
 import Daml.Finance.Interface.Util.InterfaceKey (createReferenceHelper, disclosureUpdateReferenceHelper, exerciseInterfaceByKeyHelper)
 import Daml.Finance.Interface.Util.InterfaceKey qualified as InterfaceKey (HasInterfaceKey(..))
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `Reference`. This type is currently used as a work-around given the lack of
 -- interface keys.

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Bond/Callable/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Bond/Callable/Factory.daml
@@ -8,8 +8,9 @@ import Daml.Finance.Interface.Instrument.Bond.Callable.Types (Callable)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Bond/FixedRate/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Bond/FixedRate/Factory.daml
@@ -8,8 +8,9 @@ import Daml.Finance.Interface.Instrument.Bond.FixedRate.Types (FixedRate)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Bond/FloatingRate/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Bond/FloatingRate/Factory.daml
@@ -8,8 +8,9 @@ import Daml.Finance.Interface.Instrument.Bond.FloatingRate.Types (FloatingRate)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Bond/FloatingRate/Types.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Bond/FloatingRate/Types.daml
@@ -3,7 +3,7 @@
 
 module Daml.Finance.Interface.Instrument.Bond.FloatingRate.Types where
 
-import Daml.Finance.Interface.Instrument.Types.FloatingRate qualified as Types (FloatingRate)
+import Daml.Finance.Interface.Instrument.Types.FloatingRate qualified as FloatinRateTypes (FloatingRate)
 import Daml.Finance.Interface.Types.Common.Types (InstrumentKey(..))
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
 import Daml.Finance.Interface.Types.Date.Schedule (PeriodicSchedule(..))
@@ -15,7 +15,7 @@ data FloatingRate = FloatingRate
       -- ^ The instrument's key.
     description : Text
       -- ^ The description of the bond.
-    floatingRate : Types.FloatingRate
+    floatingRate : FloatinRateTypes.FloatingRate
       -- ^ A description of the floating rate to be used. This supports both Libor and SOFR style
       --   reference rates (using a compounded index, e.g. the SOFR Index).
     couponSpread : Decimal

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Bond/InflationLinked/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Bond/InflationLinked/Factory.daml
@@ -8,8 +8,9 @@ import Daml.Finance.Interface.Instrument.Bond.InflationLinked.Types (InflationLi
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Bond/ZeroCoupon/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Bond/ZeroCoupon/Factory.daml
@@ -8,8 +8,9 @@ import Daml.Finance.Interface.Instrument.Bond.ZeroCoupon.Types (ZeroCoupon)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Equity/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Equity/Factory.daml
@@ -7,8 +7,9 @@ import Daml.Finance.Interface.Instrument.Equity.Instrument qualified as Instrume
 import Daml.Finance.Interface.Types.Common.Types (InstrumentKey(..), PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Generic/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Generic/Factory.daml
@@ -8,8 +8,9 @@ import Daml.Finance.Interface.Instrument.Generic.Instrument qualified as Instrum
 import Daml.Finance.Interface.Types.Common.Types (InstrumentKey(..), PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Option/BarrierEuropeanCash/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Option/BarrierEuropeanCash/Factory.daml
@@ -8,8 +8,9 @@ import Daml.Finance.Interface.Instrument.Option.BarrierEuropeanCash.Types (Barri
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Option/Dividend/Election/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Option/Dividend/Election/Factory.daml
@@ -8,8 +8,9 @@ import Daml.Finance.Interface.Lifecycle.Election qualified as Election (I)
 import Daml.Finance.Interface.Types.Common.Types (Id, InstrumentKey(..), Parties, PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Option/Dividend/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Option/Dividend/Factory.daml
@@ -8,8 +8,9 @@ import Daml.Finance.Interface.Instrument.Option.Dividend.Types (Dividend)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Option/EuropeanCash/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Option/EuropeanCash/Factory.daml
@@ -8,8 +8,9 @@ import Daml.Finance.Interface.Instrument.Option.EuropeanCash.Types (European)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Option/EuropeanPhysical/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Option/EuropeanPhysical/Factory.daml
@@ -8,8 +8,9 @@ import Daml.Finance.Interface.Instrument.Option.EuropeanPhysical.Types (European
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/StructuredProduct/BarrierReverseConvertible/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/StructuredProduct/BarrierReverseConvertible/Factory.daml
@@ -8,8 +8,9 @@ import Daml.Finance.Interface.Instrument.StructuredProduct.BarrierReverseConvert
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Asset/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Asset/Factory.daml
@@ -8,8 +8,9 @@ import Daml.Finance.Interface.Instrument.Swap.Asset.Types (Asset)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/CreditDefault/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/CreditDefault/Factory.daml
@@ -8,8 +8,9 @@ import Daml.Finance.Interface.Instrument.Swap.CreditDefault.Types (CreditDefault
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Currency/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Currency/Factory.daml
@@ -8,8 +8,9 @@ import Daml.Finance.Interface.Instrument.Swap.Currency.Types (CurrencySwap)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/ForeignExchange/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/ForeignExchange/Factory.daml
@@ -8,8 +8,9 @@ import Daml.Finance.Interface.Instrument.Swap.ForeignExchange.Types (ForeignExch
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Fpml/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Fpml/Factory.daml
@@ -8,8 +8,9 @@ import Daml.Finance.Interface.Instrument.Swap.Fpml.Types (Fpml)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/InterestRate/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/InterestRate/Factory.daml
@@ -8,8 +8,9 @@ import Daml.Finance.Interface.Instrument.Swap.InterestRate.Types (InterestRate)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Token/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Token/Factory.daml
@@ -8,8 +8,9 @@ import Daml.Finance.Interface.Instrument.Token.Types (Token)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Election/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Election/Factory.daml
@@ -7,8 +7,9 @@ import Daml.Finance.Interface.Lifecycle.Election qualified as Election (I)
 import Daml.Finance.Interface.Types.Common.Types (Id, InstrumentKey(..), Parties, PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Rule/Claim.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Rule/Claim.daml
@@ -6,7 +6,7 @@ module Daml.Finance.Interface.Lifecycle.Rule.Claim where
 import Daml.Finance.Interface.Holding.Holding qualified as Holding (I)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (I)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (I)
-import Daml.Finance.Interface.Settlement.Factory qualified as Settlement (F)
+import Daml.Finance.Interface.Settlement.Factory qualified as SettlementFactory (I)
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (I)
 import Daml.Finance.Interface.Settlement.RouteProvider qualified as RouteProvider (I)
 import Daml.Finance.Interface.Types.Common.Types (Id, Parties)
@@ -29,7 +29,7 @@ data View = View
       -- ^ Any of the parties can trigger settlement of the resulting batch.
     routeProviderCid : ContractId RouteProvider.I
       -- ^ RouteProvider contract used to discover settlement routes.
-    settlementFactoryCid : ContractId Settlement.F
+    settlementFactoryCid : ContractId SettlementFactory.I
       -- ^ Settlement factory contract used to create a `Batch` of `Instruction`\s.
   deriving (Eq, Show)
 

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Factory.daml
@@ -8,11 +8,9 @@ import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (I
 import Daml.Finance.Interface.Settlement.Types (RoutedStep)
 import Daml.Finance.Interface.Types.Common.Types (Id, Parties)
 
--- | Type synonym for `Factory`.
+-- | Type synonyms for `Factory`.
 type I = Factory
-
--- | Type synonym for `Factory`.
-type F = Factory
+type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Lifecycle/Election.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Election.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Lifecycle.Election where
 
 import DA.Set (singleton)
 import Daml.Finance.Interface.Lifecycle.Election qualified as Election (Apply(..), ApplyElection(..), I, View(..))
-import Daml.Finance.Interface.Lifecycle.Election.Factory qualified as Factory (Create(..), F, View(..))
+import Daml.Finance.Interface.Lifecycle.Election.Factory qualified as ElectionFactory (Create(..), I, View(..))
 import Daml.Finance.Interface.Lifecycle.Event qualified as Event (I, View(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..), InstrumentKey, PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
@@ -80,9 +80,9 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance Factory.F for Factory where
-      view = Factory.View with provider
-      create' Factory.Create{id; description; claim; elector; counterparty; electorIsOwner;
+    interface instance ElectionFactory.I for Factory where
+      view = ElectionFactory.View with provider
+      create' ElectionFactory.Create{id; description; claim; elector; counterparty; electorIsOwner;
         electionTime; observers; amount; provider; instrument} =
         toInterfaceContractId <$> create Election with
           id; description; claim; elector; counterparty; electorIsOwner; electionTime

--- a/src/main/daml/Daml/Finance/Lifecycle/Rule/Claim.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Rule/Claim.daml
@@ -8,7 +8,7 @@ import Daml.Finance.Interface.Account.Util (getCustodian, getOwner)
 import Daml.Finance.Interface.Holding.Util (getAmount, getInstrument)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (Calculate(..), CalculationResult(..), GetView(..))
 import Daml.Finance.Interface.Lifecycle.Rule.Claim qualified as Claim (ClaimEffect(..), ClaimResult(..), I, View(..))
-import Daml.Finance.Interface.Settlement.Factory qualified as Settlement (F, Instruct(..))
+import Daml.Finance.Interface.Settlement.Factory qualified as SettlementFactory (I, Instruct(..))
 import Daml.Finance.Interface.Settlement.RouteProvider qualified as RouteProvider (Discover(..), I)
 import Daml.Finance.Interface.Settlement.Types (Step(..))
 import Daml.Finance.Interface.Types.Common.Types (Parties, Quantity(..))
@@ -29,7 +29,7 @@ template Rule
       -- ^ Any of the parties can trigger settlement of the resulting batch.
     routeProviderCid : ContractId RouteProvider.I
       -- ^ RouteProvider used to discover settlement routes.
-    settlementFactoryCid : ContractId Settlement.F
+    settlementFactoryCid : ContractId SettlementFactory.I
       -- ^ Settlement factory contract used to create a `Batch` of `Instruction`\s.
     netInstructions : Bool
       -- ^ Configure whether netting should be enabled for quantities having the same (instrument,
@@ -79,7 +79,7 @@ template Rule
           discoverors = singleton provider; contextId = None; steps
 
         -- Generate settlement instructions for other instruments
-        (batchCid, instructionCids) <- exercise settlementFactoryCid Settlement.Instruct with
+        (batchCid, instructionCids) <- exercise settlementFactoryCid SettlementFactory.Instruct with
           instructor = provider
           consenters = mempty
           settlers

--- a/src/main/daml/Daml/Finance/Settlement/Factory.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Factory.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Settlement.Factory where
 
 import DA.List (mapAccumL)
 import DA.Map qualified as M (fromList)
-import Daml.Finance.Interface.Settlement.Factory qualified as SettlementFactory (F, Instruct(..), View(..))
+import Daml.Finance.Interface.Settlement.Factory qualified as SettlementFactory (I, Instruct(..), View(..))
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..), Parties)
 import Daml.Finance.Settlement.Batch (Batch(..))
@@ -24,7 +24,7 @@ template Factory
     signatory provider
     observer observers
 
-    interface instance SettlementFactory.F for Factory where
+    interface instance SettlementFactory.I for Factory where
       view = SettlementFactory.View with provider; observers
       instruct SettlementFactory.Instruct {instructor; consenters; settlers; id; description;
         contextId; routedSteps; settlementTime} = do

--- a/src/test/daml/Daml/Finance/Data/Test/HolidayCalendar.daml
+++ b/src/test/daml/Daml/Finance/Data/Test/HolidayCalendar.daml
@@ -8,7 +8,7 @@ import DA.Map qualified as M (empty, fromList)
 import DA.Set (singleton)
 import Daml.Finance.Data.Reference.HolidayCalendar (Factory(..))
 import Daml.Finance.Interface.Data.Reference.HolidayCalendar (GetView(..), UpdateCalendar(..))
-import Daml.Finance.Interface.Data.Reference.HolidayCalendar.Factory qualified as Factory (Create(..), F)
+import Daml.Finance.Interface.Data.Reference.HolidayCalendar.Factory qualified as HolidayCalendarFactory (Create(..), I)
 import Daml.Finance.Interface.Types.Date.Calendar (HolidayCalendarData(..))
 import Daml.Finance.Test.Util.Common (createParties)
 import Daml.Script
@@ -27,11 +27,11 @@ testHolidayCalendar = script do
 
   -- Reuters defines the USNY holiday calendar
   -- Create calendar via factory
-  calendarFactoryCid <- toInterfaceContractId @Factory.F <$> submit reuters do
+  calendarFactoryCid <- toInterfaceContractId @HolidayCalendarFactory.I <$> submit reuters do
     createCmd Factory with provider = reuters; observers = M.empty
 
   usnyCalendarCid <- submit reuters do
-    exerciseCmd calendarFactoryCid Factory.Create with
+    exerciseCmd calendarFactoryCid HolidayCalendarFactory.Create with
       provider = reuters
       calendar
       observers = M.fromList observers

--- a/src/test/daml/Daml/Finance/Data/Test/Observation.daml
+++ b/src/test/daml/Daml/Finance/Data/Test/Observation.daml
@@ -10,7 +10,7 @@ import DA.Set (singleton)
 import DA.Time (time)
 import Daml.Finance.Data.Numeric.Observation (Factory(..))
 import Daml.Finance.Interface.Data.Numeric.Observation (GetView(..))
-import Daml.Finance.Interface.Data.Numeric.Observation.Factory qualified as Factory (Create(..), F)
+import Daml.Finance.Interface.Data.Numeric.Observation.Factory qualified as NumbericObservationFactory (Create(..), I)
 import Daml.Finance.Interface.Lifecycle.Observable.NumericObservable qualified as NumericObservable (I, Observe(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..))
 import Daml.Finance.Test.Util.Common (createParties)
@@ -30,10 +30,10 @@ testObservation = script do
     observers = M.fromList [("PublicParty", singleton publicParty)]
 
   -- Create observation via factory
-  observationFactoryCid <- toInterfaceContractId @Factory.F <$> submit reuters do
+  observationFactoryCid <- toInterfaceContractId @NumbericObservationFactory.I <$> submit reuters do
     createCmd Factory with provider = reuters; observers
   observationCid <- submit reuters do
-    exerciseCmd observationFactoryCid Factory.Create with
+    exerciseCmd observationFactoryCid NumbericObservationFactory.Create with
       provider = reuters
       observations
       observers

--- a/src/test/daml/Daml/Finance/Holding/Test/Common.daml
+++ b/src/test/daml/Daml/Finance/Holding/Test/Common.daml
@@ -3,8 +3,8 @@
 
 module Daml.Finance.Holding.Test.Common where
 
-import Daml.Finance.Interface.Account.Factory qualified as Account (F)
-import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (F)
+import Daml.Finance.Interface.Account.Factory qualified as AccountFactory (I)
+import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (I)
 import Daml.Finance.Interface.Holding.Holding qualified as Holding (I)
 import Daml.Finance.Interface.Types.Common.Types (AccountKey, HoldingFactoryKey, HoldingStandard, InstrumentKey, Parties)
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
@@ -42,7 +42,7 @@ data TestInitialState = TestInitialState
       -- ^ Key of the instrument.
     issuerHoldingCid : ContractId Holding.I
       -- ^ Initial holding of the issuer.
-    accountFactoryCid : ContractId Account.F
+    accountFactoryCid : ContractId AccountFactory.I
       -- ^ Account factory of the custodian.
     holdingFactory : HoldingFactoryKey
       -- ^ Holding factory of the custodian.
@@ -57,7 +57,7 @@ setupParties = do
 
 -- | Setup test initial state.
 setupInitialState :
-  ( HasToInterface a HoldingFactory.F
+  ( HasToInterface a HoldingFactory.I
   , HasSignatory a
   , HasObserver a
   , HasEnsure a

--- a/src/test/daml/Daml/Finance/Holding/Test/Transfer.daml
+++ b/src/test/daml/Daml/Finance/Holding/Test/Transfer.daml
@@ -63,10 +63,10 @@ testTransfer useReentrantLockTransferService = script do
           actors = S.fromList [issuer, investor, locker]; newOwnerAccount = investorAccount
 
       -- Unlock
-      lockableCid <- submitMulti [locker] [] do
+      lockableCid <- submit locker do
         exerciseCmd lockableCid Lockable.Release with
           context = "C1"
-      lockableCid <- submitMulti [locker] [] do
+      lockableCid <- submit locker do
         exerciseCmd lockableCid Lockable.Release with
           context = "C2"
 

--- a/src/test/daml/Daml/Finance/Holding/Test/Upgrade.daml
+++ b/src/test/daml/Daml/Finance/Holding/Test/Upgrade.daml
@@ -8,7 +8,7 @@ import DA.Set qualified as S (singleton)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
 import Daml.Finance.Holding.Test.Common (TestInitialState(..), TestParties(..), setupInitialState, setupParties)
 import Daml.Finance.Holding.Transferable qualified as Transferable (T)
-import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (F, Remove(..))
+import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (I, Remove(..))
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I, Transfer(..))
 import Daml.Finance.Interface.Types.Common.Types (HoldingStandard(..), Id(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..))
@@ -35,7 +35,7 @@ run = do
 
   -- The custodian decides to upgrade to a new implementation of the transferable holding.
   -- 1. The holding factory for the old version is archived.
-  submitExerciseInterfaceByKeyCmd @HoldingFactory.F [custodian] [] holdingFactory
+  submitExerciseInterfaceByKeyCmd @HoldingFactory.I [custodian] [] holdingFactory
     HoldingFactory.Remove
   -- 2. A holding factory for the new version is created (the key remains the same).
   createHoldingFactory $

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/Callable.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/Callable.daml
@@ -921,10 +921,10 @@ runFixCouponUnadjustedCallable6M = script do
       callScheduleEndDate rollDay
     -- CREATE_6M_FIXED_COUPON_CALLABLE_BOND_SCHEDULE_END
 
-  bondInstrument <- originateMultiScheduleCallableBond issuer issuer "BONDTEST1" TransferableFungible
-    "Callable Bond" pp now holidayCalendarIds calendarDataProvider dayCountConvention
-    useAdjustedDatesForDcf floatingRate couponRate capRate floorRate cashInstrument notional
-    couponSchedule callSchedule noticeDays publicParty
+  bondInstrument <- originateMultiScheduleCallableBond issuer issuer "BONDTEST1"
+    TransferableFungible "Callable Bond" pp now holidayCalendarIds calendarDataProvider
+    dayCountConvention useAdjustedDatesForDcf floatingRate couponRate capRate floorRate
+    cashInstrument notional couponSchedule callSchedule noticeDays publicParty
 
   let
     electorIsOwner = False

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
@@ -4,21 +4,21 @@
 module Daml.Finance.Instrument.Bond.Test.Util where
 
 import DA.Map qualified as M (empty, fromList)
-import Daml.Finance.Instrument.Bond.Callable.Factory qualified as Callable (Factory(..))
-import Daml.Finance.Instrument.Bond.FixedRate.Factory qualified as FixedRate (Factory(..))
-import Daml.Finance.Instrument.Bond.FloatingRate.Factory qualified as FloatingRate (Factory(..))
-import Daml.Finance.Instrument.Bond.InflationLinked.Factory qualified as InflationLinked (Factory(..))
-import Daml.Finance.Instrument.Bond.ZeroCoupon.Factory qualified as ZeroCoupon (Factory(..))
+import Daml.Finance.Instrument.Bond.Callable.Factory qualified as CallableBond (Factory(..))
+import Daml.Finance.Instrument.Bond.FixedRate.Factory qualified as FixedRateBond (Factory(..))
+import Daml.Finance.Instrument.Bond.FloatingRate.Factory qualified as FloatingRateBond (Factory(..))
+import Daml.Finance.Instrument.Bond.InflationLinked.Factory qualified as InflationLinkedBond (Factory(..))
+import Daml.Finance.Instrument.Bond.ZeroCoupon.Factory qualified as ZeroCouponBond (Factory(..))
 import Daml.Finance.Interface.Claims.Types (Deliverable)
-import Daml.Finance.Interface.Instrument.Bond.Callable.Factory qualified as Callable (Create(..), F(..))
+import Daml.Finance.Interface.Instrument.Bond.Callable.Factory qualified as CallableBondFactory (Create(..), I(..))
 import Daml.Finance.Interface.Instrument.Bond.Callable.Types (Callable(..))
-import Daml.Finance.Interface.Instrument.Bond.FixedRate.Factory qualified as FixedRate (Create(..), F(..))
+import Daml.Finance.Interface.Instrument.Bond.FixedRate.Factory qualified as FixedRateBondFactory (Create(..), I(..))
 import Daml.Finance.Interface.Instrument.Bond.FixedRate.Types (FixedRate(..))
-import Daml.Finance.Interface.Instrument.Bond.FloatingRate.Factory qualified as FloatingRate (Create(..), F(..))
-import Daml.Finance.Interface.Instrument.Bond.FloatingRate.Types qualified as FloatingRate (FloatingRate(..))
-import Daml.Finance.Interface.Instrument.Bond.InflationLinked.Factory qualified as InflationLinked (Create(..), F(..))
+import Daml.Finance.Interface.Instrument.Bond.FloatingRate.Factory qualified as FloatingRateBondFactory (Create(..), I(..))
+import Daml.Finance.Interface.Instrument.Bond.FloatingRate.Types qualified as FloatingRateBond (FloatingRate(..))
+import Daml.Finance.Interface.Instrument.Bond.InflationLinked.Factory qualified as InflationLinkedBondFactory (Create(..), I(..))
 import Daml.Finance.Interface.Instrument.Bond.InflationLinked.Types (InflationLinked(..))
-import Daml.Finance.Interface.Instrument.Bond.ZeroCoupon.Factory qualified as ZeroCoupon (Create(..), F(..))
+import Daml.Finance.Interface.Instrument.Bond.ZeroCoupon.Factory qualified as ZeroCouponBondFactory (Create(..), I(..))
 import Daml.Finance.Interface.Instrument.Bond.ZeroCoupon.Types (ZeroCoupon(..))
 import Daml.Finance.Interface.Instrument.Types.FloatingRate (FloatingRate)
 import Daml.Finance.Interface.Types.Common.Types (HoldingStandard(..), Id(..), InstrumentKey(..), Parties)
@@ -43,8 +43,8 @@ originateFixedRateBond depository issuer label holdingStandard description obser
         businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate
 
     -- Create a fixed rate bond factory
-    fixedRateBondFactoryCid <- toInterfaceContractId @FixedRate.F <$> submit issuer do
-      createCmd FixedRate.Factory with
+    fixedRateBondFactoryCid <- toInterfaceContractId @FixedRateBondFactory.I <$> submit issuer do
+      createCmd FixedRateBond.Factory with
         provider = issuer
         observers = M.empty
 
@@ -58,7 +58,7 @@ originateFixedRateBond depository issuer label holdingStandard description obser
         holdingStandard
 
     cid <- submitMulti [issuer] [publicParty] do
-      exerciseCmd fixedRateBondFactoryCid FixedRate.Create with
+      exerciseCmd fixedRateBondFactoryCid FixedRateBondFactory.Create with
         fixedRate = FixedRate with
           instrument
           description
@@ -91,8 +91,8 @@ originateCallableBond depository issuer label holdingStandard description observ
       callSchedule = couponSchedule
 
     -- Create a callable rate bond factory
-    callableBondFactoryCid <- toInterfaceContractId @Callable.F <$> submit issuer do
-      createCmd Callable.Factory with
+    callableBondFactoryCid <- toInterfaceContractId @CallableBondFactory.I <$> submit issuer do
+      createCmd CallableBond.Factory with
         provider = issuer
         observers = M.empty
 
@@ -106,7 +106,7 @@ originateCallableBond depository issuer label holdingStandard description observ
         holdingStandard
 
     cid <- submitMulti [issuer] [publicParty] do
-      exerciseCmd callableBondFactoryCid Callable.Create with
+      exerciseCmd callableBondFactoryCid CallableBondFactory.Create with
         callable = Callable with
           instrument
           description
@@ -146,8 +146,8 @@ originateCallableBondMustFail depository issuer label holdingStandard descriptio
       callSchedule = couponSchedule
 
     -- Create a callable rate bond factory
-    callableBondFactoryCid <- toInterfaceContractId @Callable.F <$> submit issuer do
-      createCmd Callable.Factory with
+    callableBondFactoryCid <- toInterfaceContractId @CallableBondFactory.I <$> submit issuer do
+      createCmd CallableBond.Factory with
         provider = issuer
         observers = M.empty
 
@@ -160,7 +160,7 @@ originateCallableBondMustFail depository issuer label holdingStandard descriptio
         holdingStandard
 
     submitMultiMustFail [issuer] [publicParty] do
-      exerciseCmd callableBondFactoryCid Callable.Create with
+      exerciseCmd callableBondFactoryCid CallableBondFactory.Create with
         callable = Callable with
           instrument
           description
@@ -192,8 +192,8 @@ originateMultiScheduleCallableBond depository issuer label holdingStandard descr
   useAdjustedDatesForDcf floatingRate couponRate capRate floorRate
   currency notional couponSchedule callSchedule noticeDays publicParty = do
       -- Create a callable rate bond factory
-    callableBondFactoryCid <- toInterfaceContractId @Callable.F <$> submit issuer do
-      createCmd Callable.Factory with
+    callableBondFactoryCid <- toInterfaceContractId @CallableBondFactory.I <$> submit issuer do
+      createCmd CallableBond.Factory with
         provider = issuer
         observers = M.empty
 
@@ -207,7 +207,7 @@ originateMultiScheduleCallableBond depository issuer label holdingStandard descr
         holdingStandard
 
     cid <- submitMulti [issuer] [publicParty] do
-      exerciseCmd callableBondFactoryCid Callable.Create with
+      exerciseCmd callableBondFactoryCid CallableBondFactory.Create with
         callable = Callable with
           instrument
           description
@@ -235,8 +235,8 @@ originateZeroCouponBond : Party -> Party -> Text -> HoldingStandard -> Text -> [
 originateZeroCouponBond depository issuer label holdingStandard description observers
   lastEventTimestamp issueDate maturityDate currency notional publicParty = do
     -- Create a zero coupon bond factory
-    zeroCouponBondFactoryCid <- toInterfaceContractId @ZeroCoupon.F <$> submit issuer do
-      createCmd ZeroCoupon.Factory with
+    zeroCouponBondFactoryCid <- toInterfaceContractId @ZeroCouponBondFactory.I <$> submit issuer do
+      createCmd ZeroCouponBond.Factory with
         provider = issuer
         observers = M.empty
 
@@ -250,7 +250,7 @@ originateZeroCouponBond depository issuer label holdingStandard description obse
         holdingStandard
 
     cid <- submitMulti [issuer] [publicParty] do
-      exerciseCmd zeroCouponBondFactoryCid ZeroCoupon.Create with
+      exerciseCmd zeroCouponBondFactoryCid ZeroCouponBondFactory.Create with
         zeroCoupon = ZeroCoupon with
           instrument
           description
@@ -276,10 +276,11 @@ originateFloatingRateBond depository issuer label holdingStandard description
         businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate
 
     -- Create a floating rate bond factory
-    floatingRateBondFactoryCid <- toInterfaceContractId @FloatingRate.F <$> submit issuer do
-      createCmd FloatingRate.Factory with
-        provider = issuer
-        observers = M.empty
+    floatingRateBondFactoryCid <- toInterfaceContractId @FloatingRateBondFactory.I <$>
+      submit issuer do
+        createCmd FloatingRateBond.Factory with
+          provider = issuer
+          observers = M.empty
 
     -- CREATE_FLOATING_RATE_BOND_INSTRUMENT_BEGIN
     let
@@ -291,8 +292,8 @@ originateFloatingRateBond depository issuer label holdingStandard description
         holdingStandard
 
     cid <- submitMulti [issuer] [publicParty] do
-      exerciseCmd floatingRateBondFactoryCid FloatingRate.Create with
-        floatingRate = FloatingRate.FloatingRate with
+      exerciseCmd floatingRateBondFactoryCid FloatingRateBondFactory.Create with
+        floatingRate = FloatingRateBond.FloatingRate with
           instrument
           description
           floatingRate
@@ -321,10 +322,11 @@ originateInflationLinkedBond depository issuer label holdingStandard description
         businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate
 
     -- Create an inflation linked bond factory
-    inflationLinkedBondFactoryCid <- toInterfaceContractId @InflationLinked.F <$> submit issuer do
-      createCmd InflationLinked.Factory with
-        provider = issuer
-        observers = M.empty
+    inflationLinkedBondFactoryCid <- toInterfaceContractId @InflationLinkedBondFactory.I <$>
+      submit issuer do
+        createCmd InflationLinkedBond.Factory with
+          provider = issuer
+          observers = M.empty
 
     -- CREATE_INFLATION_LINKED_BOND_INSTRUMENT_BEGIN
     let
@@ -336,7 +338,7 @@ originateInflationLinkedBond depository issuer label holdingStandard description
         holdingStandard
 
     cid <- submitMulti [issuer] [publicParty] do
-      exerciseCmd inflationLinkedBondFactoryCid InflationLinked.Create with
+      exerciseCmd inflationLinkedBondFactoryCid InflationLinkedBondFactory.Create with
         inflationLinked = InflationLinked with
           instrument
           description

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Util.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Instrument.Equity.Test.Util where
 
 import DA.Map qualified as M (empty, fromList)
 import Daml.Finance.Instrument.Equity.Factory (Factory(..))
-import Daml.Finance.Interface.Instrument.Equity.Factory qualified as Equity (Create(..), F)
+import Daml.Finance.Interface.Instrument.Equity.Factory qualified as EquityFactory (Create(..), I)
 import Daml.Finance.Interface.Types.Common.Types (HoldingStandard(..), Id(..), InstrumentKey(..), Parties)
 import Daml.Script
 
@@ -14,14 +14,14 @@ originateEquity : Party -> Party -> Text -> Text -> HoldingStandard -> Text -> [
   Time -> Script InstrumentKey
 originateEquity depository issuer label version holdingStandard description observers
   timestamp = do
-    factoryCid <- toInterfaceContractId @Equity.F <$> submit issuer do
-      createCmd Factory with provider = issuer, observers = M.empty
+    equityFactoryCid <- toInterfaceContractId @EquityFactory.I <$> submit issuer do
+      createCmd Factory with provider = issuer; observers = M.empty
     let
       instrument = InstrumentKey with depository; issuer; version; id = Id label; holdingStandard
     submitMulti [depository, issuer] [] do
-      exerciseCmd factoryCid Equity.Create with
+      exerciseCmd equityFactoryCid EquityFactory.Create with
         instrument; description
         observers = M.fromList observers
         validAsOf = timestamp
-    submitMulti [depository, issuer] [] do archiveCmd factoryCid
+    submitMulti [depository, issuer] [] do archiveCmd equityFactoryCid
     pure instrument

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/Election/Workflow.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/Election/Workflow.daml
@@ -17,7 +17,7 @@ import DA.Set qualified as S (fromList, singleton)
 import DA.Text (sha256)
 import Daml.Finance.Interface.Holding.Holding qualified as Holding (I)
 import Daml.Finance.Interface.Lifecycle.Election qualified as Election (I)
-import Daml.Finance.Interface.Lifecycle.Election.Factory qualified as Election (Create(..), F)
+import Daml.Finance.Interface.Lifecycle.Election.Factory qualified as ElectionFactory (Create(..), I)
 import Daml.Finance.Interface.Lifecycle.Observable.TimeObservable qualified as TimeObservable (GetTime(..), I)
 import Daml.Finance.Interface.Types.Common.Types (Id(..), InstrumentKey, Parties)
 import Daml.Finance.Interface.Util.Common (verify)
@@ -35,7 +35,7 @@ template ElectionOffer
       -- ^ The tag corresponding to the elected sub-tree.
     instrument : InstrumentKey
       -- ^ Key of the instrument to which the election applies.
-    factoryCid : ContractId Election.F
+    factoryCid : ContractId ElectionFactory.I
       -- ^ Election factory contract.
     observers : Parties
       -- ^ Observers of the contract.
@@ -91,7 +91,7 @@ template ElectionCandidate
       -- ^ The tag corresponding to the elected sub-tree.
     instrument : InstrumentKey
       -- ^ Key of the instrument to which the election applies.
-    factoryCid : ContractId Election.F
+    factoryCid : ContractId ElectionFactory.I
       -- ^ Election factory contract.
     electionTime : Time
       -- ^ Time at which the election is put forward.
@@ -116,7 +116,7 @@ template ElectionCandidate
           $ electionTime >= currentTime
 
         -- Create election
-        exercise factoryCid Election.Create with
+        exercise factoryCid ElectionFactory.Create with
           actors = S.fromList [elector, validator]
           id = Id . sha256 $ show id <> show claim <> show elector <> show electionTime
           description

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/Util.daml
@@ -9,7 +9,7 @@ import Daml.Finance.Claims.Util (toTime)
 import Daml.Finance.Data.Time.DateClock (dateToDateClockTime)
 import Daml.Finance.Instrument.Generic.Factory (Factory(..))
 import Daml.Finance.Interface.Claims.Types (C, Deliverable, Observable)
-import Daml.Finance.Interface.Instrument.Generic.Factory qualified as Generic (Create(..), F)
+import Daml.Finance.Interface.Instrument.Generic.Factory qualified as GenericFactory (Create(..), I)
 import Daml.Finance.Interface.Types.Common.Types (HoldingStandard(..), Id(..), InstrumentKey(..), Parties)
 import Daml.Script
 
@@ -24,7 +24,7 @@ originateGeneric depository issuer label holdingStandard description acquisition
   observers lastEventTimestamp = do
 
     -- Create a generic instrument factory
-    factoryCid <- toInterfaceContractId @Generic.F <$> submit issuer do
+    genericFactoryCid <- toInterfaceContractId @GenericFactory.I <$> submit issuer do
       createCmd Factory with
         provider = issuer
         observers = mempty
@@ -39,7 +39,7 @@ originateGeneric depository issuer label holdingStandard description acquisition
         holdingStandard
 
     submitMulti [issuer, depository] [] do
-      exerciseCmd factoryCid Generic.Create with
+      exerciseCmd genericFactoryCid GenericFactory.Create with
         instrument
         description
         claims

--- a/src/test/daml/Daml/Finance/Instrument/Option/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Option/Test/Util.daml
@@ -7,20 +7,20 @@ import DA.Map qualified as M (empty, fromList)
 import DA.Set qualified as S (fromList, singleton)
 import Daml.Finance.Claims.Lifecycle.Rule qualified as Lifecycle (Rule(..))
 import Daml.Finance.Data.Time.DateClock (dateToDateClockTime)
-import Daml.Finance.Instrument.Option.BarrierEuropeanCash.Factory qualified as BarrierEuropeanCash (Factory(..))
-import Daml.Finance.Instrument.Option.Dividend.Election qualified as DivOptionElection (Factory(..))
-import Daml.Finance.Instrument.Option.Dividend.Factory qualified as Dividend (Factory(..))
-import Daml.Finance.Instrument.Option.EuropeanCash.Factory qualified as EuropeanCash (Factory(..))
-import Daml.Finance.Instrument.Option.EuropeanPhysical.Factory qualified as EuropeanPhysical (Factory(..))
-import Daml.Finance.Interface.Instrument.Option.BarrierEuropeanCash.Factory qualified as BarrierEuropeanCash (Create(..), F(..))
+import Daml.Finance.Instrument.Option.BarrierEuropeanCash.Factory qualified as BarrierEuropeanCashOption (Factory(..))
+import Daml.Finance.Instrument.Option.Dividend.Election qualified as DividendOptionElection (Factory(..))
+import Daml.Finance.Instrument.Option.Dividend.Factory qualified as DividendOption (Factory(..))
+import Daml.Finance.Instrument.Option.EuropeanCash.Factory qualified as EuropeanCashOption (Factory(..))
+import Daml.Finance.Instrument.Option.EuropeanPhysical.Factory qualified as EuropeanPhysicalOption (Factory(..))
+import Daml.Finance.Interface.Instrument.Option.BarrierEuropeanCash.Factory qualified as BarrierEuropeanCashOptionFactory (Create(..), I(..))
 import Daml.Finance.Interface.Instrument.Option.BarrierEuropeanCash.Types (BarrierEuropean(..))
-import Daml.Finance.Interface.Instrument.Option.Dividend.Election.Factory qualified as DivOptionElection (Create(..), F)
-import Daml.Finance.Interface.Instrument.Option.Dividend.Factory qualified as Dividend (Create(..), F(..))
+import Daml.Finance.Interface.Instrument.Option.Dividend.Election.Factory qualified as DividendOptionElectionFactory (Create(..), I)
+import Daml.Finance.Interface.Instrument.Option.Dividend.Factory qualified as DividendOption (Create(..), I(..))
 import Daml.Finance.Interface.Instrument.Option.Dividend.Types (Dividend(..), ElectionTypeEnum(..))
-import Daml.Finance.Interface.Instrument.Option.EuropeanCash.Factory qualified as EuropeanCash (Create(..), F(..))
-import Daml.Finance.Interface.Instrument.Option.EuropeanCash.Types qualified as EuropeanCash (European(..))
-import Daml.Finance.Interface.Instrument.Option.EuropeanPhysical.Factory qualified as EuropeanPhysical (Create(..), F(..))
-import Daml.Finance.Interface.Instrument.Option.EuropeanPhysical.Types qualified as EuropeanPhysical (European(..))
+import Daml.Finance.Interface.Instrument.Option.EuropeanCash.Factory qualified as EuropeanCashOptionFactory (Create(..), I(..))
+import Daml.Finance.Interface.Instrument.Option.EuropeanCash.Types qualified as EuropeanCashOption (European(..))
+import Daml.Finance.Interface.Instrument.Option.EuropeanPhysical.Factory qualified as EuropeanPhysicalOptionFactory (Create(..), I(..))
+import Daml.Finance.Interface.Instrument.Option.EuropeanPhysical.Types qualified as EuropeanPhysicalOption (European(..))
 import Daml.Finance.Interface.Instrument.Option.Types (BarrierTypeEnum, OptionTypeEnum)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (I)
 import Daml.Finance.Interface.Types.Common.Types (HoldingStandard(..), Id(..), InstrumentKey(..), InstrumentQuantity, Parties)
@@ -35,10 +35,11 @@ originateEuropeanCashOption depository issuer label holdingStandard description
   observers lastEventTimestamp expiryDate optionType strike currency referenceAssetId ownerReceives
   publicParty = do
     -- Create a cash-settled European option factory
-    europeanCashOptionFactoryCid <- toInterfaceContractId @EuropeanCash.F <$> submit issuer do
-      createCmd EuropeanCash.Factory with
-        provider = issuer
-        observers = M.empty
+    europeanCashOptionFactoryCid <- toInterfaceContractId @EuropeanCashOptionFactory.I <$>
+      submit issuer do
+        createCmd EuropeanCashOption.Factory with
+          provider = issuer
+          observers = M.empty
 
   -- CREATE_EUROPEAN_OPTION_INSTRUMENT_BEGIN
     let
@@ -50,8 +51,8 @@ originateEuropeanCashOption depository issuer label holdingStandard description
         holdingStandard
 
     cid <- submitMulti [issuer] [publicParty] do
-      exerciseCmd europeanCashOptionFactoryCid EuropeanCash.Create with
-        european = EuropeanCash.European with
+      exerciseCmd europeanCashOptionFactoryCid EuropeanCashOptionFactory.Create with
+        european = EuropeanCashOption.European with
           instrument
           description
           expiryDate
@@ -73,10 +74,11 @@ originateBarrierEuropeanCashOption depository issuer label holdingStandard descr
   observers lastEventTimestamp expiryDate optionType strike barrier barrierType
   barrierStartDate currency referenceAssetId ownerReceives publicParty = do
     -- Create a barrier option factory
-    barrierOptionFactoryCid <- toInterfaceContractId @BarrierEuropeanCash.F <$> submit issuer do
-      createCmd BarrierEuropeanCash.Factory with
-        provider = issuer
-        observers = M.empty
+    barrierOptionFactoryCid <- toInterfaceContractId @BarrierEuropeanCashOptionFactory.I <$>
+      submit issuer do
+        createCmd BarrierEuropeanCashOption.Factory with
+          provider = issuer
+          observers = M.empty
 
     -- CREATE_BARRIER_EUROPEAN_OPTION_INSTRUMENT_BEGIN
     let
@@ -88,7 +90,7 @@ originateBarrierEuropeanCashOption depository issuer label holdingStandard descr
         holdingStandard
 
     cid <- submitMulti [issuer] [publicParty] do
-      exerciseCmd barrierOptionFactoryCid BarrierEuropeanCash.Create with
+      exerciseCmd barrierOptionFactoryCid BarrierEuropeanCashOptionFactory.Create with
         barrierEuropean = BarrierEuropean with
           instrument
           description
@@ -114,9 +116,9 @@ originateEuropeanPhysicalOption depository issuer label holdingStandard descript
   observers lastEventTimestamp expiryDate optionType strike currency
   referenceAsset ownerReceives publicParty = do
     -- Create a cash-settled European option factory
-    europeanPhysicalOptionFactoryCid <- toInterfaceContractId @EuropeanPhysical.F <$> submit issuer
-      do
-        createCmd EuropeanPhysical.Factory with
+    europeanPhysicalOptionFactoryCid <- toInterfaceContractId @EuropeanPhysicalOptionFactory.I <$>
+      submit issuer do
+        createCmd EuropeanPhysicalOption.Factory with
           provider = issuer
           observers = M.empty
 
@@ -130,8 +132,8 @@ originateEuropeanPhysicalOption depository issuer label holdingStandard descript
         holdingStandard
 
     cid <- submitMulti [issuer] [publicParty] do
-      exerciseCmd europeanPhysicalOptionFactoryCid EuropeanPhysical.Create with
-        european = EuropeanPhysical.European with
+      exerciseCmd europeanPhysicalOptionFactoryCid EuropeanPhysicalOptionFactory.Create with
+        european = EuropeanPhysicalOption.European with
           instrument
           description
           expiryDate
@@ -155,9 +157,9 @@ originateDividendOption depository issuer label holdingStandard description obse
   lastEventTimestamp expiryDate cashQuantity sharesQuantity fxQuantity
   publicParty = do
     -- Create a dividend option factory
-    dividendOptionFactoryCid <- toInterfaceContractId @Dividend.F <$> submit issuer
+    dividendOptionFactoryCid <- toInterfaceContractId @DividendOption.I <$> submit issuer
       do
-        createCmd Dividend.Factory with
+        createCmd DividendOption.Factory with
           provider = issuer
           observers = M.empty
 
@@ -171,7 +173,7 @@ originateDividendOption depository issuer label holdingStandard description obse
         holdingStandard
 
     cid <- submitMulti [issuer] [publicParty] do
-      exerciseCmd dividendOptionFactoryCid Dividend.Create with
+      exerciseCmd dividendOptionFactoryCid DividendOption.Create with
         dividend = Dividend with
           instrument
           description
@@ -193,9 +195,10 @@ electAndVerifyDivOptionPaymentEffects readAs today amount instrument issuer
   elector electedTag expectedConsumed expectedProduced = do
     -- Create election factory to allow holders to create elections
     electionFactoryCid <- submit issuer do
-      toInterfaceContractId @DivOptionElection.F <$> createCmd DivOptionElection.Factory with
-        provider = issuer
-        observers = M.fromList [("Observers", S.fromList [elector, issuer])]
+      toInterfaceContractId @DividendOptionElectionFactory.I <$>
+        createCmd DividendOptionElection.Factory with
+          provider = issuer
+          observers = M.fromList [("Observers", S.fromList [elector, issuer])]
 
     -- Create a lifecycle rule
     lifecycleRuleCid <- toInterfaceContractId <$> submit issuer do
@@ -213,7 +216,7 @@ electAndVerifyDivOptionPaymentEffects readAs today amount instrument issuer
       description = "election for physically settled option"
     electionCid <- submitMulti [elector] readAs
       do
-        exerciseCmd electionFactoryCid DivOptionElection.Create with
+        exerciseCmd electionFactoryCid DividendOptionElectionFactory.Create with
           actors = S.singleton elector
           id = Id "election id"
           description

--- a/src/test/daml/Daml/Finance/Instrument/StructuredProduct/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/StructuredProduct/Test/Util.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Instrument.StructuredProduct.Test.Util where
 
 import DA.Map qualified as M (empty, fromList)
 import Daml.Finance.Instrument.StructuredProduct.BarrierReverseConvertible.Factory qualified as BarrierReverseConvertible (Factory(..))
-import Daml.Finance.Interface.Instrument.StructuredProduct.BarrierReverseConvertible.Factory qualified as BarrierReverseConvertible (Create(..), F(..))
+import Daml.Finance.Interface.Instrument.StructuredProduct.BarrierReverseConvertible.Factory qualified as BarrierReverseConvertibleFactory (Create(..), I(..))
 import Daml.Finance.Interface.Instrument.StructuredProduct.BarrierReverseConvertible.Types (BarrierReverseConvertible(..))
 import Daml.Finance.Interface.Types.Common.Types (HoldingStandard(..), Id(..), InstrumentKey(..), Parties)
 import Daml.Finance.Interface.Types.Date.DayCount (DayCountConventionEnum)
@@ -22,7 +22,7 @@ originateBarrierReverseConvertible depository issuer label holdingStandard descr
   couponRate periodicSchedule holidayCalendarIds dayCountConvention notional
   calendarDataProvider publicParty = do
     -- Create a BRC factory
-    brcFactoryCid <- toInterfaceContractId @BarrierReverseConvertible.F <$> submit issuer do
+    brcFactoryCid <- toInterfaceContractId @BarrierReverseConvertibleFactory.I <$> submit issuer do
       createCmd BarrierReverseConvertible.Factory with
         provider = issuer
         observers = M.empty
@@ -37,7 +37,7 @@ originateBarrierReverseConvertible depository issuer label holdingStandard descr
         holdingStandard
 
     cid <- submitMulti [issuer] [publicParty] do
-      exerciseCmd brcFactoryCid BarrierReverseConvertible.Create with
+      exerciseCmd brcFactoryCid BarrierReverseConvertibleFactory.Create with
         barrierReverseConvertible = BarrierReverseConvertible with
           instrument
           description

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -951,8 +951,10 @@ runCurrencySwapSampleTrade = script do
   -- Distribute commercial-bank cash
   now <- getTime
   let observers = [("PublicParty", singleton publicParty)]
-  cashInstrumentEur <- originate custodian issuer "EUR" TransferableFungible "Euro" observers now
-  cashInstrumentUsd <- originate custodian issuer "USD" TransferableFungible "US Dollars" observers now
+  cashInstrumentEur <-
+    originate custodian issuer "EUR" TransferableFungible "Euro" observers now
+  cashInstrumentUsd <-
+    originate custodian issuer "USD" TransferableFungible "US Dollars" observers now
 
   -- Create and distribute swap
   -- Float vs float currency swap: Euribor 3M vs Libor 3M
@@ -3458,8 +3460,10 @@ runFpml6 = script do
   -- Distribute commercial-bank cash
   now <- getTime
   let observers = [("PublicParty", singleton publicParty)]
-  cashInstrumentUsd <- originate custodian issuer "USD" TransferableFungible "US Dollars" observers now
-  cashInstrumentJpyCid <- originate custodian issuer "JPY" TransferableFungible "Japanese yen" observers now
+  cashInstrumentUsd <-
+    originate custodian issuer "USD" TransferableFungible "US Dollars" observers now
+  cashInstrumentJpyCid <-
+    originate custodian issuer "JPY" TransferableFungible "Japanese yen" observers now
 
   -- Create and distribute swap
   -- Float vs float currency swap: Euribor 3M vs Libor 3M

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -4,24 +4,24 @@
 module Daml.Finance.Instrument.Swap.Test.Util where
 
 import DA.Map qualified as M (empty, fromList)
-import Daml.Finance.Instrument.Swap.Asset.Factory qualified as Asset (Factory(..))
-import Daml.Finance.Instrument.Swap.CreditDefault.Factory qualified as CreditDefault (Factory(..))
-import Daml.Finance.Instrument.Swap.Currency.Factory qualified as Currency (Factory(..))
-import Daml.Finance.Instrument.Swap.ForeignExchange.Factory qualified as ForeignExchange (Factory(..))
-import Daml.Finance.Instrument.Swap.Fpml.Factory qualified as Fpml (Factory(..))
-import Daml.Finance.Instrument.Swap.InterestRate.Factory qualified as InterestRate (Factory(..))
-import Daml.Finance.Interface.Instrument.Swap.Asset.Factory qualified as Asset (Create(..), F(..))
+import Daml.Finance.Instrument.Swap.Asset.Factory qualified as AssetSwap (Factory(..))
+import Daml.Finance.Instrument.Swap.CreditDefault.Factory qualified as CreditDefaultSwap (Factory(..))
+import Daml.Finance.Instrument.Swap.Currency.Factory qualified as CurrencySwap (Factory(..))
+import Daml.Finance.Instrument.Swap.ForeignExchange.Factory qualified as ForeignExchangeSwap (Factory(..))
+import Daml.Finance.Instrument.Swap.Fpml.Factory qualified as FpmlSwap (Factory(..))
+import Daml.Finance.Instrument.Swap.InterestRate.Factory qualified as InterestRateSwap (Factory(..))
+import Daml.Finance.Interface.Instrument.Swap.Asset.Factory qualified as AssetSwapFactory (Create(..), I(..))
 import Daml.Finance.Interface.Instrument.Swap.Asset.Types (Asset(..))
-import Daml.Finance.Interface.Instrument.Swap.CreditDefault.Factory qualified as CreditDefault (Create(..), F(..))
+import Daml.Finance.Interface.Instrument.Swap.CreditDefault.Factory qualified as CreditDefaultSwapFactory (Create(..), I(..))
 import Daml.Finance.Interface.Instrument.Swap.CreditDefault.Types (CreditDefault(..))
-import Daml.Finance.Interface.Instrument.Swap.Currency.Factory qualified as Currency (Create(..), F(..))
+import Daml.Finance.Interface.Instrument.Swap.Currency.Factory qualified as CurrencySwapFactory (Create(..), I(..))
 import Daml.Finance.Interface.Instrument.Swap.Currency.Types (CurrencySwap(..))
-import Daml.Finance.Interface.Instrument.Swap.ForeignExchange.Factory qualified as ForeignExchange (Create(..), F(..))
+import Daml.Finance.Interface.Instrument.Swap.ForeignExchange.Factory qualified as ForeignExchangeSwapFactory (Create(..), I(..))
 import Daml.Finance.Interface.Instrument.Swap.ForeignExchange.Types (ForeignExchange(..))
-import Daml.Finance.Interface.Instrument.Swap.Fpml.Factory qualified as Fpml (Create(..), F(..))
+import Daml.Finance.Interface.Instrument.Swap.Fpml.Factory qualified as FpmlSwapFactory (Create(..), I(..))
 import Daml.Finance.Interface.Instrument.Swap.Fpml.FpmlTypes (SwapStream(..))
 import Daml.Finance.Interface.Instrument.Swap.Fpml.Types (Fpml(..))
-import Daml.Finance.Interface.Instrument.Swap.InterestRate.Factory qualified as InterestRate (Create(..), F(..))
+import Daml.Finance.Interface.Instrument.Swap.InterestRate.Factory qualified as InterestRateSwapFactory (Create(..), I(..))
 import Daml.Finance.Interface.Instrument.Swap.InterestRate.Types (InterestRate(..))
 import Daml.Finance.Interface.Instrument.Types.FloatingRate (FloatingRate)
 import Daml.Finance.Interface.Types.Common.Types (HoldingStandard, Id(..), InstrumentKey(..), Parties)
@@ -45,10 +45,11 @@ originateInterestRateSwap depository issuer label holdingStandard description
         businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate
 
     -- Create an interest rate swap factory
-    interestRateSwapFactoryCid <- toInterfaceContractId @InterestRate.F <$> submit issuer do
-      createCmd InterestRate.Factory with
-        provider = issuer
-        observers = M.empty
+    interestRateSwapFactoryCid <- toInterfaceContractId @InterestRateSwapFactory.I <$>
+      submit issuer do
+        createCmd InterestRateSwap.Factory with
+          provider = issuer
+          observers = M.empty
 
     -- CREATE_INTEREST_RATE_SWAP_INSTRUMENT_BEGIN
     let
@@ -60,7 +61,7 @@ originateInterestRateSwap depository issuer label holdingStandard description
         holdingStandard
 
     cid <- submitMulti [issuer] [publicParty] do
-      exerciseCmd interestRateSwapFactoryCid InterestRate.Create with
+      exerciseCmd interestRateSwapFactoryCid InterestRateSwapFactory.Create with
         interestRate = InterestRate with
           instrument
           description
@@ -83,8 +84,8 @@ originateFpmlSwap : Party -> Party -> Text -> HoldingStandard -> Text -> [(Text,
 originateFpmlSwap depository issuer label holdingStandard description observers
   lastEventTimestamp swapStreams calendarDataProvider currencies issuerPartyRef publicParty = do
     -- Create an FpML swap factory
-    fpmlSwapFactoryCid <- toInterfaceContractId @Fpml.F <$> submit issuer do
-      createCmd Fpml.Factory with
+    fpmlSwapFactoryCid <- toInterfaceContractId @FpmlSwapFactory.I <$> submit issuer do
+      createCmd FpmlSwap.Factory with
         provider = issuer
         observers = M.empty
 
@@ -98,7 +99,7 @@ originateFpmlSwap depository issuer label holdingStandard description observers
         holdingStandard
 
     cid <- submitMulti [issuer] [publicParty] do
-      exerciseCmd fpmlSwapFactoryCid Fpml.Create with
+      exerciseCmd fpmlSwapFactoryCid FpmlSwapFactory.Create with
         fpml = Fpml with
           instrument
           description
@@ -125,8 +126,8 @@ originateAssetSwap depository issuer label holdingStandard description observers
         businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate
 
     -- Create an asset swap factory
-    assetSwapFactoryCid <- toInterfaceContractId @Asset.F <$> submit issuer do
-      createCmd Asset.Factory with
+    assetSwapFactoryCid <- toInterfaceContractId @AssetSwapFactory.I <$> submit issuer do
+      createCmd AssetSwap.Factory with
         provider = issuer
         observers = M.empty
 
@@ -140,7 +141,7 @@ originateAssetSwap depository issuer label holdingStandard description observers
         holdingStandard
 
     cid <- submitMulti [issuer] [publicParty] do
-      exerciseCmd assetSwapFactoryCid Asset.Create with
+      exerciseCmd assetSwapFactoryCid AssetSwapFactory.Create with
         asset = Asset with
           instrument
           description
@@ -171,10 +172,11 @@ originateCreditDefaultSwap depository issuer label holdingStandard description
         businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate
 
     -- Create a credit default swap factory
-    cdsFactoryCid <- toInterfaceContractId @CreditDefault.F <$> submit issuer do
-      createCmd CreditDefault.Factory with
-        provider = issuer
-        observers = M.empty
+    creditDefaultSwapFactoryCid <- toInterfaceContractId @CreditDefaultSwapFactory.I <$>
+      submit issuer do
+        createCmd CreditDefaultSwap.Factory with
+          provider = issuer
+          observers = M.empty
 
     -- CREATE_CREDIT_DEFAULT_SWAP_INSTRUMENT_BEGIN
     let
@@ -186,7 +188,7 @@ originateCreditDefaultSwap depository issuer label holdingStandard description
         holdingStandard
 
     cid <- submitMulti [issuer] [publicParty] do
-      exerciseCmd cdsFactoryCid CreditDefault.Create with
+      exerciseCmd creditDefaultSwapFactoryCid CreditDefaultSwapFactory.Create with
         creditDefault = CreditDefault with
           instrument
           description
@@ -218,8 +220,8 @@ originateCurrencySwap depository issuer label holdingStandard description observ
         businessDayConvention couponPeriod couponPeriodMultiplier issueDate maturityDate
 
     -- Create a currency swap factory
-    currencySwapFactoryCid <- toInterfaceContractId @Currency.F <$> submit issuer do
-      createCmd Currency.Factory with
+    currencySwapFactoryCid <- toInterfaceContractId @CurrencySwapFactory.I <$> submit issuer do
+      createCmd CurrencySwap.Factory with
         provider = issuer
         observers = M.empty
 
@@ -233,7 +235,7 @@ originateCurrencySwap depository issuer label holdingStandard description observ
         holdingStandard
 
     cid <- submitMulti [issuer] [publicParty] do
-      exerciseCmd currencySwapFactoryCid Currency.Create with
+      exerciseCmd currencySwapFactoryCid CurrencySwapFactory.Create with
         currencySwap = CurrencySwap with
           instrument
           description
@@ -260,10 +262,11 @@ originateForeignExchangeSwap depository issuer label holdingStandard description
   observers lastEventTimestamp issueDate firstPaymentDate maturityDate baseCurrency foreignCurrency
   firstFxRate finalFxRate publicParty = do
     -- Create an FX swap factory
-    fxSwapFactoryCid <- toInterfaceContractId @ForeignExchange.F <$> submit issuer do
-      createCmd ForeignExchange.Factory with
-        provider = issuer
-        observers = M.empty
+    foreignExchangeSwapFactoryCid <- toInterfaceContractId @ForeignExchangeSwapFactory.I <$>
+      submit issuer do
+        createCmd ForeignExchangeSwap.Factory with
+          provider = issuer
+          observers = M.empty
 
     -- CREATE_FOREIGN_EXCHANGE_SWAP_INSTRUMENT_BEGIN
     let
@@ -275,7 +278,7 @@ originateForeignExchangeSwap depository issuer label holdingStandard description
         holdingStandard
 
     cid <- submitMulti [issuer] [publicParty] do
-      exerciseCmd fxSwapFactoryCid ForeignExchange.Create with
+      exerciseCmd foreignExchangeSwapFactoryCid ForeignExchangeSwapFactory.Create with
         foreignExchange = ForeignExchange with
           instrument
           description

--- a/src/test/daml/Daml/Finance/Instrument/Token/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Token/Test/Util.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Instrument.Token.Test.Util where
 
 import DA.Map (fromList)
 import Daml.Finance.Instrument.Token.Factory (Factory(..))
-import Daml.Finance.Interface.Instrument.Token.Factory qualified as Token (Create(..), F)
+import Daml.Finance.Interface.Instrument.Token.Factory qualified as TokenFactory (Create(..), I)
 import Daml.Finance.Interface.Instrument.Token.Types (Token(..))
 import Daml.Finance.Interface.Types.Common.Types (HoldingStandard, Id(..), InstrumentKey(..), Parties)
 import Daml.Script
@@ -16,7 +16,7 @@ originateToken : Party -> Party -> Text -> HoldingStandard -> Text -> Time -> [(
 originateToken depository issuer label holdingStandard description validAsOf observers = do
 
     -- Create a token instrument factory
-    factoryCid <- toInterfaceContractId @Token.F <$> submit issuer do
+    tokenFactoryCid <- toInterfaceContractId @TokenFactory.I <$> submit issuer do
       createCmd Factory with provider = issuer; observers = mempty
 
     -- Create instrument
@@ -27,6 +27,6 @@ originateToken depository issuer label holdingStandard description validAsOf obs
         description
         validAsOf
     submitMulti [issuer, depository] [] do
-      exerciseCmd factoryCid Token.Create with token; observers = fromList observers
+      exerciseCmd tokenFactoryCid TokenFactory.Create with token; observers = fromList observers
 
     pure token.instrument

--- a/src/test/daml/Daml/Finance/Settlement/Test/Batch.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Batch.daml
@@ -7,7 +7,7 @@ import DA.Map qualified as M (fromList)
 import DA.Set qualified as S (fromList, singleton)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Cancel(..), Settle(..))
-import Daml.Finance.Interface.Settlement.Factory qualified as Settlement (F, Instruct(..))
+import Daml.Finance.Interface.Settlement.Factory qualified as SettlementFactory (I, Instruct(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..), Execute(..))
 import Daml.Finance.Interface.Settlement.RouteProvider qualified as RouteProvider (Discover(..), I)
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), Step(..))
@@ -101,7 +101,7 @@ run settleCashOnledger bankIsInstructor = script do
       discoverors = S.singleton bank; contextId = None; steps
 
   -- Setup settlement factory
-  settlementFactoryCid <- toInterfaceContractId @Settlement.F <$>
+  settlementFactoryCid <- toInterfaceContractId @SettlementFactory.I <$>
     submit bank do
       createCmd Factory with provider = bank; observers = S.singleton publicParty
 
@@ -111,7 +111,7 @@ run settleCashOnledger bankIsInstructor = script do
     consenters = if bankIsInstructor then [] else [seller]
     settlers = S.fromList [buyer, seller]
     instructCmd = submitMulti (instructor :: consenters) [publicParty] do
-      exerciseCmd settlementFactoryCid Settlement.Instruct with
+      exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
         instructor
         consenters = S.fromList consenters
         settlers

--- a/src/test/daml/Daml/Finance/Settlement/Test/BatchWithIntermediaries.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/BatchWithIntermediaries.daml
@@ -9,7 +9,7 @@ import DA.Set qualified as S (empty, fromList, singleton)
 import DA.Time (time)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
-import Daml.Finance.Interface.Settlement.Factory qualified as Settlement (F, Instruct(..))
+import Daml.Finance.Interface.Settlement.Factory qualified as SettlementFactory (I, Instruct(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
 import Daml.Finance.Interface.Settlement.RouteProvider qualified as RouteProvider (Discover(..), I)
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), Step(..))
@@ -132,11 +132,11 @@ run = script do
       discoverors = S.singleton buyer; contextId = None; steps
 
   -- Instruct settlement
-  settlementFactoryCid <- toInterfaceContractId @Settlement.F <$> submit buyer do
+  settlementFactoryCid <- toInterfaceContractId @SettlementFactory.I <$> submit buyer do
     createCmd Factory with provider = buyer; observers = S.empty
   (batchCid, [cashInstruction1Cid, cashInstruction2Cid, equityInstructionCid]) <-
     submitMulti [buyer, seller] [] do
-      exerciseCmd settlementFactoryCid Settlement.Instruct with
+      exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
         instructor = buyer
         consenters = S.singleton seller
         settlers = S.fromList [buyer, seller]

--- a/src/test/daml/Daml/Finance/Settlement/Test/Intermediated.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Intermediated.daml
@@ -12,7 +12,7 @@ import Daml.Finance.Holding.TransferableFungible qualified as TransferableFungib
 import Daml.Finance.Interface.Holding.Holding qualified as Holding (I)
 import Daml.Finance.Interface.Holding.Util (undisclose)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
-import Daml.Finance.Interface.Settlement.Factory qualified as Factory (F, Instruct(..))
+import Daml.Finance.Interface.Settlement.Factory qualified as SettlementFactory (I, Instruct(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..), I)
 import Daml.Finance.Interface.Settlement.RouteProvider qualified as RouteProvider (Discover(..), I)
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), Step(..))
@@ -168,12 +168,12 @@ run useDelegatee = script do
       discoverors = S.singleton agent; contextId = None; steps
 
   -- Instruct settlement
-  settlementFactoryCid <- toInterfaceContractId @Factory.F <$> submit agent do
+  settlementFactoryCid <- toInterfaceContractId @SettlementFactory.I <$> submit agent do
     createCmd Factory with provider = agent; observers = S.empty
   (batchCid, [sellerInstructionCid, custodian1InstructionCid, custodian2InstructionCid,
     buyerInstructionCid, bank1InstructionCid, bank2InstructionCid]) <-
     submit agent do
-      exerciseCmd settlementFactoryCid Factory.Instruct with
+      exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
         instructor = agent
         consenters = mempty
         settlers = S.singleton agent

--- a/src/test/daml/Daml/Finance/Settlement/Test/Transfer.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Transfer.daml
@@ -13,7 +13,7 @@ import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
 import Daml.Finance.Interface.Account.Account qualified as Account (I, getKey)
 import Daml.Finance.Interface.Holding.Fungible qualified as Fungible (I, Split(..))
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
-import Daml.Finance.Interface.Settlement.Factory qualified as Settlement (F, Instruct(..))
+import Daml.Finance.Interface.Settlement.Factory qualified as SettlementFactory (I, Instruct(..))
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..), I)
 import Daml.Finance.Interface.Settlement.RouteProvider qualified as RouteProvider (Discover(..), I)
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), InstructionKey(..), Step(..))
@@ -81,7 +81,7 @@ run = script do
   holdingCid <- Account.credit [] cashInstrument 200_000.0 senderAccount
 
   -- Create settlement factory
-  settlementFactoryCid <- toInterfaceContractId @Settlement.F <$>
+  settlementFactoryCid <- toInterfaceContractId @SettlementFactory.I <$>
     submit bank do createCmd Factory with provider = bank; observers = S.empty
 
   -- Settlement step
@@ -96,7 +96,7 @@ run = script do
 
   -- Instruct transfer
   (batchCid, [cashInstructionCid]) <- submit bank do
-    exerciseCmd settlementFactoryCid Settlement.Instruct with
+    exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
       instructor = bank
       consenters = mempty
       settlers = S.singleton bank
@@ -189,7 +189,7 @@ run2 = script do
   holdingCid3 <- Account.credit [] cashInstrument 300_000.0 senderAccount
 
   -- Create settlement factory
-  settlementFactoryCid <- toInterfaceContractId @Settlement.F <$>
+  settlementFactoryCid <- toInterfaceContractId @SettlementFactory.I <$>
     submit bank do createCmd Factory with provider = bank; observers = S.empty
 
   -- Settlement steps (to be settled independently)
@@ -216,7 +216,7 @@ run2 = script do
 
   -- Instruct settlement for transfer 1
   (batchCid1, [cashInstructionCid1]) <- submit bank do
-    exerciseCmd settlementFactoryCid Settlement.Instruct with
+    exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
       instructor = bank
       consenters = mempty
       settlers = S.singleton bank
@@ -227,7 +227,7 @@ run2 = script do
       settlementTime = None
   -- the id of the batch must be unique
   submitMustFail bank do
-    exerciseCmd settlementFactoryCid Settlement.Instruct with
+    exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
       instructor = bank
       consenters = mempty
       settlers = S.singleton bank
@@ -239,7 +239,7 @@ run2 = script do
 
   -- Instruct settlement for transfer 2
   (batchCid2, [cashInstructionCid2]) <- submit bank do
-    exerciseCmd settlementFactoryCid Settlement.Instruct with
+    exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
       instructor = bank
       consenters = mempty
       settlers = S.singleton bank
@@ -251,7 +251,7 @@ run2 = script do
 
   -- Instruct settlement for transfer 3
   (batchCid3, [cashInstructionCid3]) <- submit bank do
-    exerciseCmd settlementFactoryCid Settlement.Instruct with
+    exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
       instructor = bank
       consenters = mempty
       settlers = S.singleton bank
@@ -379,7 +379,7 @@ run3 = script do
   holdingCid <- Account.credit [] cashInstrument 200_000.0 senderAccount
 
   -- Create settlement factory
-  settlementFactoryCid <- toInterfaceContractId @Settlement.F <$> submit bank do
+  settlementFactoryCid <- toInterfaceContractId @SettlementFactory.I <$> submit bank do
     createCmd Factory with provider = bank; observers = S.singleton publicParty
 
   -- Discover settlement
@@ -392,7 +392,7 @@ run3 = script do
 
   -- Instruct transfer
   (batchCid, [cashInstructionCid]) <- submit bank do
-    exerciseCmd settlementFactoryCid Settlement.Instruct with
+    exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
       instructor = bank
       consenters = mempty
       settlers = S.fromList [sender, receiver]
@@ -457,7 +457,7 @@ run4 = script do
   holdingCid2 <- Account.credit [] cashInstrument1 100_000.0 senderAccount
 
   -- Create settlement factory
-  settlementFactoryCid <- toInterfaceContractId @Settlement.F <$> submit bank do
+  settlementFactoryCid <- toInterfaceContractId @SettlementFactory.I <$> submit bank do
     createCmd Factory with provider = bank; observers = S.singleton publicParty
 
   -- Settlement steps
@@ -474,7 +474,7 @@ run4 = script do
 
   -- Instruct transfer
   (batchCid, [cashInstructionCid1, cashInstructionCid2]) <- submit bank do
-    exerciseCmd settlementFactoryCid Settlement.Instruct with
+    exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
       instructor = bank
       consenters = mempty
       settlers = S.fromList [sender, receiver]
@@ -544,7 +544,7 @@ run5 = script do
   holdingCid <- Account.credit [] cashInstrument 200_000.0 senderAccount
 
   -- Create settlement factory
-  settlementFactoryCid <- toInterfaceContractId @Settlement.F <$>
+  settlementFactoryCid <- toInterfaceContractId @SettlementFactory.I <$>
     submit bank do createCmd Factory with provider = bank; observers = S.empty
 
   -- Settlement steps
@@ -563,7 +563,7 @@ run5 = script do
 
   -- Instruct transfer
   (batchCid, [instructionCid2, instructionCid1]) <- submit bank do
-    exerciseCmd settlementFactoryCid Settlement.Instruct with
+    exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
       instructor = bank
       consenters = mempty
       settlers = S.singleton settler

--- a/src/test/daml/Daml/Finance/Test/Util/Account.daml
+++ b/src/test/daml/Daml/Finance/Test/Util/Account.daml
@@ -11,7 +11,7 @@ import DA.Map qualified as M (fromList)
 import DA.Set qualified as S (empty, fromList, singleton)
 import Daml.Finance.Account.Account qualified as Account (Factory(..))
 import Daml.Finance.Interface.Account.Account qualified as Account (Controllers(..), Credit(..), Debit(..), GetCid(..), I, R)
-import Daml.Finance.Interface.Account.Factory qualified as Account (Create(..), F)
+import Daml.Finance.Interface.Account.Factory qualified as AccountFactory (Create(..), I)
 import Daml.Finance.Interface.Holding.Holding qualified as Holding (GetView(..), I)
 import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), HoldingFactoryKey, Id(..), InstrumentKey, Parties)
 import Daml.Finance.Interface.Util.Common (qty)
@@ -49,15 +49,15 @@ createFactory provider observers = submit provider do
   createCmd Account.Factory with provider; observers = M.fromList observers
 
 -- | Create `Account`.
-createAccount : Text -> [Party] -> ContractId Account.F -> HoldingFactoryKey ->
+createAccount : Text -> [Party] -> ContractId AccountFactory.I -> HoldingFactoryKey ->
   [(Text, Parties)] -> ControlledBy -> Party -> Party -> Script AccountKey
-createAccount description readAs factoryCid holdingFactory observers controlledBy custodian owner =
-  do
+createAccount description readAs accpountFactoryCid holdingFactory observers controlledBy custodian
+  owner = do
     let
       account = AccountKey with
         custodian; owner; id = Id $ show owner <> "@" <> show custodian <> "/" <> description
     submitMulti [custodian, owner] readAs do
-      exerciseCmd factoryCid Account.Create with
+      exerciseCmd accpountFactoryCid AccountFactory.Create with
         account; holdingFactory; controllers = toControllers custodian owner controlledBy
         observers = M.fromList observers; description
     pure account

--- a/src/test/daml/Daml/Finance/Test/Util/HoldingDuplicates/Factory.daml
+++ b/src/test/daml/Daml/Finance/Test/Util/HoldingDuplicates/Factory.daml
@@ -9,7 +9,7 @@ module Daml.Finance.Test.Util.HoldingDuplicates.Factory where
 -- holdings.
 
 import DA.Set (singleton)
-import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (Create(..), F, View(..), holdingFactoryKey)
+import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (Create(..), I, View(..), holdingFactoryKey)
 import Daml.Finance.Interface.Types.Common.Types (Id, PartiesMap)
 import Daml.Finance.Interface.Types.Common.Types qualified as HoldingStandard (HoldingStandard(..))
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
@@ -19,8 +19,9 @@ import Daml.Finance.Test.Util.HoldingDuplicates.Transferable (Transferable(..))
 import Daml.Finance.Test.Util.HoldingDuplicates.TransferableFungible (TransferableFungible(..))
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonym for `Factory`.
-type F = Factory
+-- | Type synonyms for `Factory`.
+type I = Factory
+type F = Factory -- to be deprecated
 
 -- | Implementation of a factory template for holdings.
 template Factory
@@ -35,7 +36,7 @@ template Factory
     signatory provider
     observer Disclosure.flattenObservers observers
 
-    interface instance HoldingFactory.F for Factory
+    interface instance HoldingFactory.I for Factory
       where
         view = HoldingFactory.View with provider; id
         getKey = HoldingFactory.holdingFactoryKey this

--- a/src/test/daml/Daml/Finance/Test/Util/HoldingFactory.daml
+++ b/src/test/daml/Daml/Finance/Test/Util/HoldingFactory.daml
@@ -6,8 +6,7 @@
 module Daml.Finance.Test.Util.HoldingFactory where
 
 import DA.List (head)
-import Daml.Finance.Interface.Holding.Factory (Reference(..))
-import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (F, GetCid(..), R, toKey)
+import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (GetCid(..), I, R, Reference(..), toKey)
 import Daml.Finance.Interface.Types.Common.Types (HoldingFactoryKey)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 import Daml.Finance.Test.Util.Common (submitExerciseInterfaceByKeyCmdHelper, submitMustFailExerciseInterfaceByKeyCmdHelper)
@@ -20,17 +19,17 @@ createHoldingFactory :
   , HasTemplateTypeRep t
   , HasToAnyTemplate t
   , HasFromAnyTemplate t
-  , HasToInterface t HoldingFactory.F
+  , HasToInterface t HoldingFactory.I
   )
   => t -> Script HoldingFactoryKey
 createHoldingFactory holdingFactory = do
   let
-    factory = toInterface @HoldingFactory.F holdingFactory
+    factory = toInterface @HoldingFactory.I holdingFactory
     factoryView = view factory
-  cid <- toInterfaceContractId @HoldingFactory.F <$> submit factoryView.provider do
+  cid <- toInterfaceContractId @HoldingFactory.I <$> submit factoryView.provider do
     createCmd holdingFactory
   submit factoryView.provider do
-    createCmd Reference with
+    createCmd HoldingFactory.Reference with
       factoryView; cid; observers = (view $ toInterface @Disclosure.I factory).observers
   pure $ HoldingFactory.toKey factoryView
 

--- a/src/test/daml/Daml/Finance/Test/Util/Instrument.daml
+++ b/src/test/daml/Daml/Finance/Test/Util/Instrument.daml
@@ -9,7 +9,7 @@ import DA.List (head)
 import DA.Map qualified as M (empty, fromList)
 import Daml.Finance.Instrument.Token.Factory qualified as Token (Factory(..))
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (GetCid(..), R)
-import Daml.Finance.Interface.Instrument.Token.Factory qualified as Token (Create(..), F)
+import Daml.Finance.Interface.Instrument.Token.Factory qualified as TokenFactory (Create(..), I)
 import Daml.Finance.Interface.Instrument.Token.Types (Token(..))
 import Daml.Finance.Interface.Types.Common.Types (HoldingStandard(..), Id(..), InstrumentKey(..), Parties)
 import Daml.Finance.Test.Util.Common (submitExerciseInterfaceByKeyCmdHelper)
@@ -19,7 +19,7 @@ import Daml.Script
 originate : Party -> Party -> Text -> HoldingStandard -> Text-> [(Text, Parties)] -> Time
   -> Script InstrumentKey
 originate depository issuer label holdingStandard description observers timestamp = do
-  factoryCid <- toInterfaceContractId @Token.F <$> submit issuer do
+  tokenFactoryCid <- toInterfaceContractId @TokenFactory.I <$> submit issuer do
     createCmd Token.Factory with provider = issuer; observers = M.empty
   let
     instrumentKey = InstrumentKey with
@@ -33,10 +33,10 @@ originate depository issuer label holdingStandard description observers timestam
       validAsOf = timestamp
       description
   submitMulti [depository, issuer] [] do
-    exerciseCmd factoryCid Token.Create with
+    exerciseCmd tokenFactoryCid TokenFactory.Create with
       token
       observers = M.fromList observers
-  submitMulti [depository, issuer] [] do archiveCmd factoryCid
+  submitMulti [depository, issuer] [] do archiveCmd tokenFactoryCid
   pure instrumentKey
 
 -- | Utility for exercising an interface by key.

--- a/src/test/daml/Daml/Finance/Test/Util/Lifecycle.daml
+++ b/src/test/daml/Daml/Finance/Test/Util/Lifecycle.daml
@@ -11,7 +11,7 @@ import Daml.Finance.Claims.Lifecycle.Rule qualified as Lifecycle (Rule(..))
 import Daml.Finance.Data.Time.DateClock (dateToDateClockTime)
 import Daml.Finance.Interface.Lifecycle.Effect qualified as Effect (GetView(..), I)
 import Daml.Finance.Interface.Lifecycle.Election qualified as Election (Apply(..), Exercisable, I)
-import Daml.Finance.Interface.Lifecycle.Election.Factory qualified as Election (Create(..), F)
+import Daml.Finance.Interface.Lifecycle.Election.Factory qualified as ElectionFactory (Create(..), I)
 import Daml.Finance.Interface.Lifecycle.Observable.NumericObservable qualified as NumericObservable (I)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (Evolve(..), I)
 import Daml.Finance.Interface.Types.Common.Types (Id(..), InstrumentKey, InstrumentQuantity)
@@ -97,7 +97,7 @@ createElectionAndLifecycleRule : Date -> Decimal -> InstrumentKey -> Bool -> Par
 createElectionAndLifecycleRule today amount instrument electorIsOwner issuer elector electedTag = do
   -- Create election factory to allow holders to create elections
   electionFactoryCid <- submit issuer do
-    toInterfaceContractId @Election.F <$> createCmd Election.Factory with
+    toInterfaceContractId @ElectionFactory.I <$> createCmd Election.Factory with
       provider = issuer
       observers = M.fromList [("Observers", S.fromList [elector, issuer])]
 
@@ -115,7 +115,7 @@ createElectionAndLifecycleRule today amount instrument electorIsOwner issuer ele
     counterparty = issuer
     description = "election for a callable bond"
   electionCid <- submit elector do
-    exerciseCmd electionFactoryCid Election.Create with
+    exerciseCmd electionFactoryCid ElectionFactory.Create with
       actors = S.singleton elector
       id = Id "election id"
       description


### PR DESCRIPTION
FIXES https://github.com/digital-asset/daml-finance/issues/1101

For better readability, the suggestion is to replace

`import Daml.Finance.Interface.Account.Factory qualified as Account (F)`

with

`import Daml.Finance.Interface.Account.Factory qualified as Account.Factory (F)`

and also `F` by an `I`, i.e.,  

`import Daml.Finance.Interface.Account.Factory qualified as Account.Factory (I)`

The implementation we could import as usual 

`import Daml.Finance.Account.Factory qualified as Account (Factory)`

and then use `Account.Factory.I` for the interface and `Account.Factory` for the implementation.