### PR TITLE
refactor import names

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -38,8 +38,8 @@ within this repository.
   and otherwise qualified imports:
 
   ```haskell
-  import DA.Map qualified as M (fromList)
-  import DA.Set qualified as S (fromList, null)
+  import DA.Map qualified as Map (fromList)
+  import DA.Set qualified as Set (fromList, null)
   ```
 
 ### Exports

--- a/docs/code-samples/getting-started/daml/Scripts/Holding.daml
+++ b/docs/code-samples/getting-started/daml/Scripts/Holding.daml
@@ -16,8 +16,8 @@ import Daml.Finance.Account.Account qualified as Account (Factory(..))
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
 import Daml.Finance.Instrument.Token.Factory qualified as Token (Factory(..))
 
-import Workflow.CreateAccount qualified as CreateAccount
-import Workflow.CreditAccount qualified as CreditAccount
+import Workflow.CreateAccount qualified as CreateAccount (Accept(..), Request(..))
+import Workflow.CreditAccount qualified as CreditAccount (Accept(..), Request(..))
 
 import Scripts.Util (createHoldingFactory, createParty)
 

--- a/docs/code-samples/getting-started/daml/Scripts/Settlement.daml
+++ b/docs/code-samples/getting-started/daml/Scripts/Settlement.daml
@@ -19,8 +19,8 @@ import Daml.Finance.Interface.Util.Common (qty)
 import Daml.Finance.Settlement.Factory qualified as Settlement (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 
-import Workflow.CreditAccount qualified as CreditAccount
-import Workflow.DvP qualified as DvP
+import Workflow.CreditAccount qualified as CreditAccount (Accept(..), Request(..))
+import Workflow.DvP qualified as DvP (Accept(..), Proposal(..))
 
 import Scripts.Transfer (TransferState(..), runTransfer)
 

--- a/docs/code-samples/getting-started/daml/Scripts/Transfer.daml
+++ b/docs/code-samples/getting-started/daml/Scripts/Transfer.daml
@@ -8,7 +8,7 @@ import Daml.Finance.Interface.Instrument.Token.Factory qualified as TokenFactory
 import Daml.Finance.Interface.Types.Common.Types (AccountKey, InstrumentKey(..))
 
 -- IMPLEMENTATION DEPENDENCIES --
-import Workflow.Transfer qualified as Transfer
+import Workflow.Transfer qualified as Transfer (Accept(..), Request(..))
 
 import Scripts.Holding (HoldingState(..), setupHolding)
 

--- a/docs/code-samples/lifecycling/daml/Scripts/CallableBond.daml
+++ b/docs/code-samples/lifecycling/daml/Scripts/CallableBond.daml
@@ -25,7 +25,7 @@ import Daml.Finance.Instrument.Bond.Callable.Factory qualified as CallableBond (
 import Daml.Finance.Lifecycle.Election qualified as Election (Factory(..))
 import Daml.Finance.Lifecycle.Rule.Claim qualified as Claim (Rule(..))
 
-import Workflow.CreditAccount qualified as CreditAccount
+import Workflow.CreditAccount qualified as CreditAccount (Accept(..), Request(..))
 
 import Scripts.FixedRateBond (FixedRateState(..), runFixedRateBond)
 

--- a/docs/code-samples/lifecycling/daml/Scripts/FixedRateBond.daml
+++ b/docs/code-samples/lifecycling/daml/Scripts/FixedRateBond.daml
@@ -37,8 +37,8 @@ import Daml.Finance.Lifecycle.Rule.Claim qualified as Claim (Rule(..))
 import Daml.Finance.Settlement.Factory qualified as Settlement (Factory(..))
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 
-import Workflow.CreateAccount qualified as CreateAccount
-import Workflow.CreditAccount qualified as CreditAccount
+import Workflow.CreateAccount qualified as CreateAccount (Accept(..), Request(..))
+import Workflow.CreditAccount qualified as CreditAccount (Accept(..), Request(..))
 
 import Scripts.Util (createHoldingFactory, createParty)
 

--- a/docs/code-samples/lifecycling/daml/Scripts/FloatingRateBond.daml
+++ b/docs/code-samples/lifecycling/daml/Scripts/FloatingRateBond.daml
@@ -25,7 +25,7 @@ import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Time.DateClock (dateToDateClockTime)
 import Daml.Finance.Instrument.Bond.FloatingRate.Factory qualified as FloatingRateBond (Factory(..))
 
-import Workflow.CreditAccount qualified as CreditAccount
+import Workflow.CreditAccount qualified as CreditAccount (Accept(..), Request(..))
 
 import Scripts.FixedRateBond (FixedRateState(..), runFixedRateBond)
 

--- a/docs/code-samples/payoff-modeling/daml/Examples/BasicCombinators.daml
+++ b/docs/code-samples/payoff-modeling/daml/Examples/BasicCombinators.daml
@@ -6,7 +6,7 @@ import Prelude hiding (and, or)
 
 -- CONTINGENT CLAIMS DEPENDENCIES --
 import ContingentClaims.Core.Claim (and, at, give, one, scale, when, zero)
-import ContingentClaims.Core.Observation
+import ContingentClaims.Core.Observation (Observation(Const, Observe, ObserveAt))
 
 import PayoffBuilder (createAndLifecycleInstrument)
 

--- a/docs/code-samples/payoff-modeling/daml/PayoffBuilder.daml
+++ b/docs/code-samples/payoff-modeling/daml/PayoffBuilder.daml
@@ -7,8 +7,8 @@ import Daml.Script
 import Prelude hiding (and, or)
 
 -- CONTINGENT CLAIMS DEPENDENCIES --
-import ContingentClaims.Core.Claim
-import ContingentClaims.Core.Observation
+import ContingentClaims.Core.Claim (Claim(..), one, scale)
+import ContingentClaims.Core.Observation (Observation(Const))
 
 import Util (dateToTime, mapClaim, printEffect)
 import Util.Lifecycle (createObservation, lifecycle)

--- a/docs/code-samples/payoff-modeling/daml/Util/Lifecycle.daml
+++ b/docs/code-samples/payoff-modeling/daml/Util/Lifecycle.daml
@@ -5,7 +5,7 @@ import DA.Assert ((===))
 import DA.Foldable (forA_)
 import DA.Map qualified as Map (fromList)
 import DA.Optional (fromSome)
-import DA.Set qualified as Set (singleton)
+import DA.Set (singleton)
 import Daml.Script
 
 -- INTERFACE DEPENDENCIES --
@@ -46,8 +46,8 @@ lifecycle instrument observableCids dates = do
   -- and calculate lifecycle effects
   lifecycleRuleCid <- toInterfaceContractId @Lifecycle.I <$> submit instrumentProvider do
     createCmd Lifecycle.Rule with
-      providers = Set.singleton instrument.issuer
-      observers= mempty
+      providers = singleton instrument.issuer
+      observers = mempty
       lifecycler = instrument.issuer
       id = Id "LifecycleRule"
       description = "Rule to lifecycle a generic instrument"
@@ -87,7 +87,7 @@ dateToEvent provider date =
     createCmd DateClockUpdateEvent with
       date
       id = Id $ show date
-      providers = Set.singleton provider
+      providers = singleton provider
       description = show date
       observers = mempty
       eventTime = dateToTime date

--- a/docs/code-samples/settlement/daml/Scripts/Intermediated.daml
+++ b/docs/code-samples/settlement/daml/Scripts/Intermediated.daml
@@ -23,8 +23,8 @@ import Daml.Finance.Settlement.Factory qualified as Settlement (Factory(..))
 import Daml.Finance.Settlement.Hierarchy (Hierarchy(..))
 import Daml.Finance.Settlement.RouteProvider.IntermediatedStatic (IntermediatedStatic(..))
 
-import Workflow.CreateAccount qualified as CreateAccount
-import Workflow.CreditAccount qualified as CreditAccount
+import Workflow.CreateAccount qualified as CreateAccount (Accept(..), Request(..))
+import Workflow.CreditAccount qualified as CreditAccount (Accept(..), Request(..))
 
 import Scripts.Setup (AccountControllers(..), RequiredAuthorizers(..), Setup(..), createHoldingFactory, retrieveKey, runSetup, toControllers)
 

--- a/docs/code-samples/settlement/daml/Scripts/Setup.daml
+++ b/docs/code-samples/settlement/daml/Scripts/Setup.daml
@@ -21,8 +21,8 @@ import Daml.Finance.Instrument.Token.Factory qualified as Token (Factory(..))
 import Daml.Finance.Interface.Settlement.Types (InstructionKey(..))
 import Daml.Finance.Settlement.Instruction qualified as Instruction (T)
 
-import Workflow.CreateAccount qualified as CreateAccount
-import Workflow.CreditAccount qualified as CreditAccount
+import Workflow.CreateAccount qualified as CreateAccount (Accept(..), Request(..))
+import Workflow.CreditAccount qualified as CreditAccount (Accept(..), Request(..))
 
 -- | Outlines the required authorizers for an action.
 data RequiredAuthorizers

--- a/src/main/daml/Daml/Finance/Account/Account.daml
+++ b/src/main/daml/Daml/Finance/Account/Account.daml
@@ -3,8 +3,7 @@
 
 module Daml.Finance.Account.Account where
 
-import DA.Map qualified as M (empty)
-import DA.Set qualified as S (fromList, null, singleton)
+import DA.Set qualified as Set (fromList, null, singleton)
 import Daml.Finance.Interface.Account.Account qualified as Account (Controllers(..), Credit(..), Debit(..), I, View(..), accountKey, createReference, disclosureUpdateReference)
 import Daml.Finance.Interface.Account.Factory qualified as AccountFactory (Create(..), I, View(..))
 import Daml.Finance.Interface.Holding.Factory qualified as HoldingFactory (Create(..), I, exerciseInterfaceByKey)
@@ -41,7 +40,7 @@ template Account
     observer Disclosure.flattenObservers observers
 
     -- Outgoing controllers must be non-empty.
-    ensure isValidLock lock && (not . S.null $ controllers.outgoing)
+    ensure isValidLock lock && (not . Set.null $ controllers.outgoing)
 
     interface instance Account.I for Account where
       view = Account.View with custodian; id; owner; description; controllers
@@ -55,7 +54,7 @@ template Account
             instrument = quantity.unit
             account = Account.accountKey this
             amount = quantity.amount
-            observers = M.empty
+            observers = mempty
       debit Account.Debit{holdingCid} = do
         Lockable.mustNotBeLocked this
         holding <- fetch holdingCid
@@ -63,14 +62,14 @@ template Account
         archive holdingCid
 
     interface instance Lockable.I for Account where
-      view = Lockable.View with lock; controllers = S.singleton custodian
+      view = Lockable.View with lock; controllers = Set.singleton custodian
       acquire lockable@Lockable.Acquire{newLockers; context; lockType} = do
         newLockableCid <- toInterfaceContractId @Disclosure.I <$>
           acquireImpl this.lock (\lock -> this with lock) lockable
         -- adding lockers as observers to Account.R
         fromInterfaceContractId @Lockable.I <$>
           exercise newLockableCid Disclosure.AddObservers with
-            disclosers = S.fromList $ signatory this
+            disclosers = Set.fromList $ signatory this
             observersToAdd = (context, newLockers)
       release lockable@Lockable.Release{context} = do
         newLockableCid <- releaseImpl this.lock (\lock -> this with lock) lockable
@@ -78,11 +77,11 @@ template Account
         optional newLockableCid fromInterfaceContractId <$>
           exercise (toInterfaceContractId @Disclosure.I newLockableCid)
             Disclosure.RemoveObservers with
-              disclosers = S.fromList $ signatory this
+              disclosers = Set.fromList $ signatory this
               observersToRemove = (context, Lockable.getLockers this)
 
     interface instance Disclosure.I for Account where
-      view = Disclosure.View with disclosureControllers = S.fromList [custodian, owner]; observers
+      view = Disclosure.View with disclosureControllers = Set.fromList [custodian, owner]; observers
       setObservers = setObserversImpl this . Some . Account.disclosureUpdateReference $
         Account.accountKey this
       addObservers = addObserversImpl this . Some . Account.disclosureUpdateReference $
@@ -112,7 +111,7 @@ template Factory
           pure cid
 
     interface instance Disclosure.I for Factory where
-      view = Disclosure.View with disclosureControllers = S.singleton provider; observers
+      view = Disclosure.View with disclosureControllers = Set.singleton provider; observers
       setObservers = setObserversImpl @Factory @Disclosure.I this None
       addObservers = addObserversImpl @Factory @Disclosure.I this None
       removeObservers = removeObserversImpl @Factory @Disclosure.I this None

--- a/src/main/daml/Daml/Finance/Claims/Util/Lifecycle.daml
+++ b/src/main/daml/Daml/Finance/Claims/Util/Lifecycle.daml
@@ -14,7 +14,7 @@ import ContingentClaims.Lifecycle.Lifecycle qualified as CC (exercise, lifecycle
 import DA.Action (foldlA)
 import DA.Either (partitionEithers)
 import DA.List (head, sort)
-import DA.Map as M (fromList, lookup)
+import DA.Map qualified as Map (fromList, lookup)
 import Daml.Finance.Interface.Claims.Claim qualified as Claim (GetClaims(..), I, getAcquisitionTime, getClaims)
 import Daml.Finance.Interface.Claims.Types (EventData(..), Observable, Pending(..), TaggedClaim(..))
 import Daml.Finance.Interface.Lifecycle.Observable.NumericObservable qualified as NumericObservable (I, observe)
@@ -105,10 +105,10 @@ lifecycle actor observableCids instrument events = do
 collectObservables : [ContractId NumericObservable.I] -> Update
   (Observable -> Time -> Update Decimal)
 collectObservables observableCids = do
-  os <- M.fromList <$> forA observableCids \cid -> do
+  os <- Map.fromList <$> forA observableCids \cid -> do
     observation <- fetch cid
     pure (show (view observation).id, observation)
-  pure \key t -> case M.lookup key os of
+  pure \key t -> case Map.lookup key os of
     Some o -> NumericObservable.observe o t
     None -> do abort $ "Missing observable" <> show key <> " at time " <> show t
 

--- a/src/main/daml/Daml/Finance/Data/Numeric/Observation.daml
+++ b/src/main/daml/Daml/Finance/Data/Numeric/Observation.daml
@@ -3,7 +3,8 @@
 
 module Daml.Finance.Data.Numeric.Observation where
 
-import DA.Map as M (Map, lookup)
+import DA.Map (Map)
+import DA.Map qualified as Map (lookup)
 import DA.Set (singleton)
 import Daml.Finance.Interface.Data.Numeric.Observation qualified as Observation (I, View(..))
 import Daml.Finance.Interface.Data.Numeric.Observation.Factory qualified as ObservationFactory
@@ -34,7 +35,7 @@ template Observation
     interface instance NumericObservable.I for Observation where
       view = NumericObservable.View with provider; id
       observe t =
-        case M.lookup t observations of
+        case Map.lookup t observations of
           Some obs -> pure obs
           None -> fail $ "Missing observation for " <> show id <>" at t = " <> show t
 

--- a/src/main/daml/Daml/Finance/Holding/Util.daml
+++ b/src/main/daml/Daml/Finance/Holding/Util.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Holding.Util where
 
 import DA.Action (foldlA)
 import DA.Foldable qualified as F (all)
-import DA.Set qualified as S (fromList, isSubsetOf)
+import DA.Set (fromList, isSubsetOf)
 import DA.Traversable qualified as T (forA)
 import Daml.Finance.Interface.Account.Account qualified as Account (Credit(..), Debit(..), I, R, exerciseInterfaceByKey)
 import Daml.Finance.Interface.Account.Util (fetchAccount)
@@ -29,9 +29,9 @@ transferImpl this self Transferable.Transfer{actors; newOwnerAccount} = do
   vNewAccount <- view <$> fetchInterfaceByKey @Account.R @Account.I newOwnerAccount
   -- Verify
   assertMsg "Actors must contain all transfer outgoing of the sender account"
-    $ vAccount.controllers.outgoing `S.isSubsetOf` actors
+    $ vAccount.controllers.outgoing `isSubsetOf` actors
   assertMsg "Actors must contain all transfer incoming of the receiving account"
-    $ vNewAccount.controllers.incoming `S.isSubsetOf` actors
+    $ vNewAccount.controllers.incoming `isSubsetOf` actors
   assertMsg "Custodians must be the same" $ vAccount.custodian == vNewAccount.custodian
   -- Debit
   Account.exerciseInterfaceByKey @Account.I
@@ -78,7 +78,7 @@ mergeImpl this getAmount setAmount Fungible.Merge{fungibleCids} = do
   Lockable.mustNotBeLocked this
   assertMsg "List of fungibles must be non-empty" . not . null $ fungibleCids
   let
-    currentSignatories = S.fromList . signatory . setAmount $ vHolding.amount
+    currentSignatories = fromList . signatory . setAmount $ vHolding.amount
     current = view . toInterface @Holding.I . toInterface @Fungible.I . setAmount $ vHolding.amount
     aggregate aggregatedAmount fungibleCid = do
       Some (otherHoldingCid, otherHolding) <- fetchFromInterface @t fungibleCid
@@ -87,7 +87,7 @@ mergeImpl this getAmount setAmount Fungible.Merge{fungibleCids} = do
         other = view otherBase
       assertMsg "Instrument must match" $ other.instrument == current.instrument
       assertMsg "Account must match" $ other.account == current.account
-      assertMsg "Signatories must match" $ S.fromList (signatory otherHolding) == currentSignatories
+      assertMsg "Signatories must match" $ fromList (signatory otherHolding) == currentSignatories
       Lockable.mustNotBeLocked otherBase
       archive otherHoldingCid
       pure $ aggregatedAmount + getAmount otherHolding

--- a/src/main/daml/Daml/Finance/Interface/Util/Disclosure.daml
+++ b/src/main/daml/Daml/Finance/Interface/Util/Disclosure.daml
@@ -3,7 +3,7 @@
 
 module Daml.Finance.Interface.Util.Disclosure where
 
-import DA.Map qualified as M (values)
+import DA.Map (values)
 import Daml.Finance.Interface.Types.Common.Types (Parties, PartiesMap)
 
 -- | Type synonym for `Disclosure`.
@@ -93,4 +93,4 @@ interface Disclosure where
 -- observer $ flattenObservers observers
 -- ```
 flattenObservers : PartiesMap -> Parties
-flattenObservers = mconcat . M.values
+flattenObservers = mconcat . values

--- a/src/main/daml/Daml/Finance/Lifecycle/Rule/Distribution.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Rule/Distribution.daml
@@ -3,7 +3,7 @@
 
 module Daml.Finance.Lifecycle.Rule.Distribution where
 
-import DA.Map qualified as M (fromList)
+import DA.Map (fromList)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (GetView(..), I, exerciseInterfaceByKey)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (Evolve(..), I, View(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..), Parties)
@@ -55,5 +55,5 @@ template Rule
             otherConsumed = []
             otherProduced = distribution.perUnitDistribution
             settlementTime = Some distribution.effectiveTime
-            observers = M.fromList [("RuleObservers", observers)]
+            observers = fromList [("RuleObservers", observers)]
         pure (Some distribution.newInstrument, [effectCid])

--- a/src/main/daml/Daml/Finance/Lifecycle/Rule/Replacement.daml
+++ b/src/main/daml/Daml/Finance/Lifecycle/Rule/Replacement.daml
@@ -3,7 +3,7 @@
 
 module Daml.Finance.Lifecycle.Rule.Replacement where
 
-import DA.Map qualified as M (fromList)
+import DA.Map (fromList)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as BaseInstrument (GetView(..), I, exerciseInterfaceByKey)
 import Daml.Finance.Interface.Lifecycle.Rule.Lifecycle qualified as Lifecycle (Evolve(..), I, View(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..), Parties)
@@ -52,5 +52,5 @@ template Rule
             otherConsumed = []
             otherProduced = replacement.perUnitReplacement
             settlementTime = Some replacement.effectiveTime
-            observers = M.fromList [("RuleObservers", observers)]
+            observers = fromList [("RuleObservers", observers)]
         pure (None, [effectCid])

--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -4,10 +4,10 @@
 module Daml.Finance.Settlement.Batch where
 
 import DA.Action (foldlA)
-import DA.Map qualified as M (fromList, lookup)
+import DA.Map qualified as Map (fromList, lookup)
 import DA.Optional (catOptionals, fromSomeNote)
 import DA.Set (Set)
-import DA.Set qualified as S (empty, insert, intersection, member, null, singleton)
+import DA.Set qualified as Set (insert, intersection, member, null, singleton)
 import DA.Traversable qualified as T
 import Daml.Finance.Interface.Holding.Util (undisclose)
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Cancel(..), I, Settle(..), View(..))
@@ -48,7 +48,7 @@ template Batch
         routedSteps = routedSteps this.routedStepsWithInstructionId; settlementTime
       settle Batch.Settle{actors} = do
         assertMsg "Actors must intersect with settlers." $
-          not $ S.null $ actors `S.intersection` settlers
+          not $ Set.null $ actors `Set.intersection` settlers
         -- order instructions (such that they can be executed with passthroughs)
         orderedInstructions <-
           orderPassThroughChains . fmap (fmap (buildKey this)) $ routedStepsWithInstructionId
@@ -61,7 +61,7 @@ template Batch
             -- execute instruction and get used holding standards for the instrument
             (instructionCid, instruction) <- fetchByKey @Instruction instructionKey
             settledCid <- exercise (toInterfaceContractId @Instruction.I instructionCid)
-              Instruction.Execute with actors = actors <> S.singleton instructor <> consenters
+              Instruction.Execute with actors = actors <> Set.singleton instructor <> consenters
             join <$> T.mapA (undisclose (context, settlers) actors) settledCid
         -- execute instructions
         orderedSettledCids <- mapA settleInstruction orderedInstructions
@@ -70,7 +70,7 @@ template Batch
           orderedInstructionIdsAndSettleCids =
             zip ((.id) <$> orderedInstructions) orderedSettledCids
           settledCids = fromSomeNote "All keys must exist in the map." .
-            (`M.lookup` (M.fromList orderedInstructionIdsAndSettleCids)) <$>
+            (`Map.lookup` (Map.fromList orderedInstructionIdsAndSettleCids)) <$>
             instructionIds this.routedStepsWithInstructionId
         pure $ catOptionals settledCids
       cancel Batch.Cancel{actors} = do
@@ -80,7 +80,7 @@ template Batch
             instructionCid <- fst <$> fetchByKey @Instruction instruction
             exercise (toInterfaceContractId @Instruction.I instructionCid)
               Instruction.Cancel with actors
-        allMustAuthorize $ S.singleton instructor <> consenters
+        allMustAuthorize $ Set.singleton instructor <> consenters
         -- cancel instructions
         catOptionals <$> mapA (cancelInstruction . buildKey this . snd) routedStepsWithInstructionId
 
@@ -103,7 +103,7 @@ orderPassThroughChains : [(RoutedStep, InstructionKey)] -> Update [InstructionKe
 orderPassThroughChains routedStepsWithInstructions =
   reverse . fst <$> foldlA
     (\(ordered, used) (routedStep, current) ->
-      if S.member current used
+      if Set.member current used
       then
         -- instruction has already been visited, do not re-insert in list
         pure (ordered, used)
@@ -112,14 +112,14 @@ orderPassThroughChains routedStepsWithInstructions =
         assertMsg "Routed step must match." $ routedStep == currentInstruction.routedStep
         let
           ordered' = current :: ordered
-          used' = S.insert current used
+          used' = Set.insert current used
         case currentInstruction.allocation of
           -- a Pledge might be the start of a pass-through chain, try to follow the chain
           Pledge _ -> collectPassThroughChain ordered' used' currentInstruction
           -- A PassThroughFrom will be visited as part of a chain, do not insert in list
           PassThroughFrom _ -> pure (ordered, used)
           _ -> pure (ordered', used')
-    ) ([], S.empty) routedStepsWithInstructions
+    ) ([], mempty) routedStepsWithInstructions
 
 -- | HIDE
 -- Follows the pass-through chain and collects the corresponding instructions in an ordered list.
@@ -132,6 +132,6 @@ collectPassThroughChain
     case currentInstruction.approval of
       PassThroughTo (_, next) -> do
         nextInstruction <- snd <$> fetchByKey @Instruction next
-        assertMsg "Next instruction must not have been used before." . not $ S.member next used
-        collectPassThroughChain (next :: ordered) (S.insert next used) nextInstruction
+        assertMsg "Next instruction must not have been used before." . not $ Set.member next used
+        collectPassThroughChain (next :: ordered) (Set.insert next used) nextInstruction
       _ -> pure (ordered, used)

--- a/src/main/daml/Daml/Finance/Settlement/Factory.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Factory.daml
@@ -4,7 +4,7 @@
 module Daml.Finance.Settlement.Factory where
 
 import DA.List (mapAccumL)
-import DA.Map qualified as M (fromList)
+import DA.Map (fromList)
 import Daml.Finance.Interface.Settlement.Factory qualified as SettlementFactory (I, Instruct(..), View(..))
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..), Parties)
@@ -43,7 +43,7 @@ template Factory
                   approval = Unapproved
                   signedSenders = mempty
                   signedReceivers = mempty
-                  observers = M.fromList [(show id, settlers)]
+                  observers = fromList [(show id, settlers)]
               )
             instructions = snd $ mapAccumL createInstruction 0 routedSteps
             instructionIds = map (.id) instructions

--- a/src/main/daml/Daml/Finance/Settlement/Instruction.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Instruction.daml
@@ -4,7 +4,8 @@
 module Daml.Finance.Settlement.Instruction where
 
 import DA.List qualified as L (head)
-import DA.Set qualified as S (Set, empty, fromList, insert, intersection, isSubsetOf, null, singleton, toList, union)
+import DA.Set (Set)
+import DA.Set qualified as Set (fromList, insert, intersection, isSubsetOf, null, singleton, toList, union)
 import Daml.Finance.Interface.Account.Account qualified as Account (Credit(..), Debit(..), I, R, disclose, exerciseInterfaceByKey, undisclose)
 import Daml.Finance.Interface.Account.Util (getAccount)
 import Daml.Finance.Interface.Holding.Holding qualified as Holding (I)
@@ -59,7 +60,7 @@ template Instruction
 
     interface instance Disclosure.I for Instruction where
       view = Disclosure.View with
-        disclosureControllers = S.fromList [routedStep.sender, routedStep.receiver]; observers
+        disclosureControllers = Set.fromList [routedStep.sender, routedStep.receiver]; observers
       setObservers = setObserversImpl @Instruction @Disclosure.I this None
       addObservers = addObserversImpl @Instruction @Disclosure.I this None
       removeObservers = removeObserversImpl @Instruction @Disclosure.I this None
@@ -72,7 +73,7 @@ template Instruction
         let
           allMustAuthorize = mustAuthorizeHelper True actors
           atLeastOneMustAuthorize = mustAuthorizeHelper False actors
-        atLeastOneMustAuthorize $ S.fromList [routedStep.custodian, routedStep.sender]
+        atLeastOneMustAuthorize $ Set.fromList [routedStep.custodian, routedStep.sender]
         assertMsg ("Allocation must be new. " <> context this) $ allocation /= this.allocation
         releasedCid <- releasePreviousAllocation this actors
         -- allocate
@@ -94,7 +95,7 @@ template Instruction
             holdingCid <- fromInterfaceContractId @Holding.I <$>
               exercise (toInterfaceContractId @Lockable.I holdingCid)
                 Lockable.Acquire with
-                  newLockers = S.singleton instructor <> senderAccount.controllers.outgoing
+                  newLockers = Set.singleton instructor <> senderAccount.controllers.outgoing
                   context = context this
                   lockType = Lockable.Semaphore
             pure $ Pledge holdingCid
@@ -113,22 +114,22 @@ template Instruction
             mustBe this Sender fromInstruction.routedStep.receiver
             pure allocation
           CreditReceiver -> do
-            allMustAuthorize $ S.singleton routedStep.custodian
+            allMustAuthorize $ Set.singleton routedStep.custodian
             pure allocation
           SettleOffledger -> do
-            allMustAuthorize $ S.fromList [routedStep.custodian, routedStep.sender]
+            allMustAuthorize $ Set.fromList [routedStep.custodian, routedStep.sender]
             pure allocation
           Unallocated ->
             pure allocation
         newInstructionCid <- toInterfaceContractId <$> create this with
           allocation = newAllocation
-          signedSenders = if newAllocation == Unallocated then S.empty else actors
+          signedSenders = if newAllocation == Unallocated then mempty else actors
         pure (newInstructionCid, releasedCid)
       approve Instruction.Approve{actors; approval} = do
         let
           allMustAuthorize = mustAuthorizeHelper True actors
           atLeastOneMustAuthorize = mustAuthorizeHelper False actors
-        atLeastOneMustAuthorize $ S.fromList [routedStep.custodian, routedStep.receiver]
+        atLeastOneMustAuthorize $ Set.fromList [routedStep.custodian, routedStep.receiver]
         assertMsg ("Approval must be new. " <> context this) $ approval /= this.approval
         releasePreviousApproval this actors
         -- approve
@@ -154,19 +155,19 @@ template Instruction
             mustBe this Custodian toInstruction.routedStep.custodian
             mustBe this Receiver toInstruction.routedStep.sender
           DebitSender -> do
-            allMustAuthorize $ S.singleton routedStep.custodian
+            allMustAuthorize $ Set.singleton routedStep.custodian
             mustBe this Custodian routedStep.receiver
           SettleOffledgerAcknowledge ->
-            allMustAuthorize $ S.fromList [routedStep.custodian, routedStep.receiver]
+            allMustAuthorize $ Set.fromList [routedStep.custodian, routedStep.receiver]
           Unapproved -> pure ()
         toInterfaceContractId <$> create this with
           approval
-          signedReceivers = if approval == Unapproved then S.empty else actors
+          signedReceivers = if approval == Unapproved then mempty else actors
       execute Instruction.Execute{actors} = do
         let allMustAuthorize = mustAuthorizeHelper True actors
-        allMustAuthorize $ S.insert instructor consenters
+        allMustAuthorize $ Set.insert instructor consenters
         assertMsg ("Actors must intersect with settlers. " <> context this) $
-          not $ S.null $ actors `S.intersection` settlers
+          not $ Set.null $ actors `Set.intersection` settlers
         let
           abortUnapproved = abort $ "Instruction must be approved. " <> context this
           abortOnOffledgerMix =
@@ -249,7 +250,7 @@ template Instruction
               _ -> abortOnOffledgerMix
       cancel Instruction.Cancel{actors} = do
         let allMustAuthorize = mustAuthorizeHelper True actors
-        allMustAuthorize $ S.insert instructor consenters
+        allMustAuthorize $ Set.insert instructor consenters
         releasePreviousApproval this actors
         releasePreviousAllocation this actors
 
@@ -270,28 +271,28 @@ mustBe Instruction{routedStep} role party = do
     party == roleParty
 
 -- | HIDE
-addSignatories : HasSignatory t => t -> S.Set Party -> S.Set Party
-addSignatories this parties = parties `S.union` S.fromList (signatory this)
+addSignatories : HasSignatory t => t -> Set Party -> Set Party
+addSignatories this parties = parties `Set.union` Set.fromList (signatory this)
 
 -- | HIDE
-discloseAccount : Instruction -> AccountKey -> S.Set Party -> Update (ContractId Account.I)
+discloseAccount : Instruction -> AccountKey -> Set Party -> Update (ContractId Account.I)
 discloseAccount this@Instruction {settlers} accountKey actors = discloseAccountHelper
   Account.disclose (context this, settlers) accountKey $ addSignatories this actors
 
 -- | HIDE
-undiscloseAccount : Instruction -> AccountKey -> S.Set Party ->
+undiscloseAccount : Instruction -> AccountKey -> Set Party ->
   Update (Optional (ContractId Account.I))
 undiscloseAccount this@Instruction {settlers} accountKey actors =
   discloseAccountHelper Account.undisclose (context this, settlers) accountKey $
     addSignatories this actors
 
 -- | HIDE
-disclosePledge : Instruction -> ContractId Holding.I -> S.Set Party -> Update (ContractId Holding.I)
+disclosePledge : Instruction -> ContractId Holding.I -> Set Party -> Update (ContractId Holding.I)
 disclosePledge this@Instruction {settlers} holdingCid actors = Holding.disclose @Holding.I
   (context this, settlers) (addSignatories this actors) holdingCid
 
 -- | HIDE
-undisclosePledge : Instruction -> ContractId Holding.I -> S.Set Party ->
+undisclosePledge : Instruction -> ContractId Holding.I -> Set Party ->
   Update (Optional (ContractId Holding.I))
 undisclosePledge this@Instruction {settlers} holdingCid actors = Holding.undisclose @Holding.I
   (context this, settlers) (addSignatories this actors) holdingCid
@@ -339,14 +340,14 @@ mustAuthorizeHelper : Bool -> Parties -> Parties -> Update ()
 mustAuthorizeHelper requireAllToAuthorize authorizers parties =
   if requireAllToAuthorize then
     assertMsg ("All parties in " <> show parties <> " must be in the authorizing set " <>
-      show authorizers <> ")") $ parties `S.isSubsetOf` authorizers
+      show authorizers <> ")") $ parties `Set.isSubsetOf` authorizers
   else
     assertMsg ("At least one party from " <> show parties <> " must be in the authorizing set "
-      <> show authorizers <> ".") . not . S.null $ parties  `S.intersection` authorizers
+      <> show authorizers <> ".") . not . Set.null $ parties  `Set.intersection` authorizers
 
 -- | HIDE
 discloseAccountHelper : ((Text, Parties) -> Party -> Parties -> AccountKey -> Update a) ->
   (Text, Parties) -> AccountKey -> Parties -> Update a
 discloseAccountHelper discloseAction (context, settlers) accountKey actors = do
   account <- fetchInterfaceByKey @Account.R @Account.I accountKey
-  discloseAction (context, settlers) (L.head . S.toList $ actors) actors accountKey
+  discloseAction (context, settlers) (L.head . Set.toList $ actors) actors accountKey

--- a/src/main/daml/Daml/Finance/Settlement/RouteProvider/IntermediatedStatic.daml
+++ b/src/main/daml/Daml/Finance/Settlement/RouteProvider/IntermediatedStatic.daml
@@ -4,7 +4,8 @@
 module Daml.Finance.Settlement.RouteProvider.IntermediatedStatic where
 
 import DA.List (head)
-import DA.Map qualified as M (Map, lookup)
+import DA.Map (Map)
+import DA.Map as Map (lookup)
 import DA.Optional (fromSomeNote)
 import Daml.Finance.Interface.Settlement.RouteProvider qualified as RouteProvider (Discover(..), I, View(..))
 import Daml.Finance.Interface.Types.Common.Types (Parties)
@@ -21,7 +22,7 @@ template IntermediatedStatic
       -- ^ Party providing the facility.
     observers : Parties
       -- ^ Observers.
-    paths : M.Map Text Hierarchy
+    paths : Map Text Hierarchy
       -- ^ Hierarchical paths used to settle holding transfers. A path is specified for each
       --   instrument label.
   where
@@ -36,7 +37,7 @@ template IntermediatedStatic
           -- according to the corresponding settlement route.
           routedSteps = mconcat $ fromSomeNote "Could not find path or route." $ mapA (\steps -> do
             let k = show (head steps).quantity.unit.id
-            route <- M.lookup k paths
+            route <- Map.lookup k paths
             mconcat <$> mapA (unfoldStep route) steps
             ) $ sortAndGroupOn (.quantity.unit) steps
         in

--- a/src/main/daml/Daml/Finance/Util/Disclosure.daml
+++ b/src/main/daml/Daml/Finance/Util/Disclosure.daml
@@ -6,10 +6,10 @@
 module Daml.Finance.Util.Disclosure where
 
 import DA.Foldable qualified as F (mapA_)
-import DA.Map qualified as M (delete, insert, lookup)
+import DA.Map qualified as Map (delete, insert, lookup)
 import DA.Optional (fromOptional)
 import DA.Set (Set)
-import DA.Set qualified as S (difference, empty, intersection, null, union)
+import DA.Set qualified as Set (difference, intersection, null, union)
 import DA.Traversable qualified as T (mapA)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (AddObservers(..), I, RemoveObservers(..), SetObservers(..))
@@ -59,9 +59,9 @@ addObserversImpl this refUpdate Disclosure.AddObservers{disclosers; observersToA
   let
     v = view $ toInterface @Disclosure.I this
     context = fst observersToAdd
-    contextParties = fromOptional S.empty $ M.lookup context v.observers
+    contextParties = fromOptional mempty $ Map.lookup context v.observers
     value = contextParties <> snd observersToAdd
-    newObservers = M.insert context value v.observers
+    newObservers = Map.insert context value v.observers
   assertMsg
     ("controller (" <> show disclosers <> ") must be authorized to SetObservers") $
     mustIntersect disclosers v.disclosureControllers
@@ -90,27 +90,27 @@ removeObserversImpl this refUpdate self
     let
       v = view $ toInterface @Disclosure.I this
       context = fst observersToRemove
-      contextParties = fromOptional S.empty $ M.lookup context v.observers
+      contextParties = fromOptional mempty $ Map.lookup context v.observers
     assertMsg "disclosers must be authorized to RemoveObservers when removing other parties" $
-      mustIntersect disclosers (v.disclosureControllers `S.union` contextParties)
+      mustIntersect disclosers (v.disclosureControllers `Set.union` contextParties)
     fromOptional None <$>
       T.mapA
         (\viewers -> do
-          let updatedViewers = viewers `S.difference` snd observersToRemove
+          let updatedViewers = viewers `Set.difference` snd observersToRemove
           if updatedViewers == viewers then
             pure None
           else do
             archive self
             let
-              newObservers = if S.null updatedViewers
-                             then M.delete context v.observers
-                             else M.insert context updatedViewers v.observers
+              newObservers = if Set.null updatedViewers
+                             then Map.delete context v.observers
+                             else Map.insert context updatedViewers v.observers
             cid <- toInterfaceContractId @i <$> create this with observers = newObservers
             F.mapA_ (\f -> f newObservers cid) refUpdate
             pure $ Some (toInterfaceContractId @Disclosure.I cid)
         )
-      (M.lookup context v.observers)
+      (Map.lookup context v.observers)
 
 -- | HIDE
 mustIntersect : Ord k => Set k -> Set k -> Bool
-mustIntersect a b = not . S.null $ a `S.intersection` b
+mustIntersect a b = not . Set.null $ a `Set.intersection` b

--- a/src/main/daml/Daml/Finance/Util/Lockable.daml
+++ b/src/main/daml/Daml/Finance/Util/Lockable.daml
@@ -4,7 +4,7 @@
 module Daml.Finance.Util.Lockable where
 
 import DA.Optional (isSome)
-import DA.Set qualified as S (delete, fromList, insert, isSubsetOf, notMember, null, singleton)
+import DA.Set qualified as Set (delete, fromList, insert, isSubsetOf, notMember, null, singleton)
 import Daml.Finance.Interface.Util.Lockable (Acquire(..), Lock(..), LockType(..), Lockable, Release(..))
 
 -- | Default implementation of `acquire` from the `Lockable` interface.
@@ -15,9 +15,9 @@ acquireImpl :
   , HasToInterface t Lockable
   ) => Optional Lock -> (Optional Lock -> t) -> Acquire ->  Update (ContractId Lockable)
 acquireImpl currentLock setLock Acquire{newLockers; context; lockType} = do
-  assertMsg "New lockers must be non-empty" (not $ S.null newLockers)
+  assertMsg "New lockers must be non-empty" (not $ Set.null newLockers)
   newLock <- Some <$> case currentLock of
-    None -> pure Lock with lockers = newLockers; context = S.singleton context; lockType
+    None -> pure Lock with lockers = newLockers; context = Set.singleton context; lockType
     Some existingLock -> do
       case lockType of
         Reentrant -> do
@@ -26,14 +26,14 @@ acquireImpl currentLock setLock Acquire{newLockers; context; lockType} = do
           assertMsg "New lock type must match the existing lock type"
             $ existingLock.lockType == lockType
           assertMsg "Contract must not be already locked for the provided context"
-            $ S.notMember context existingLock.context
+            $ Set.notMember context existingLock.context
           pure existingLock with
-            context = context `S.insert` existingLock.context
+            context = context `Set.insert` existingLock.context
         Semaphore ->
           abort "A Semaphore lock can not be locked multiple times."
   let newLockable = setLock newLock
   assertMsg "New lockers must be signatories of the new lockable"
-    $ newLockers `S.isSubsetOf` S.fromList (signatory newLockable)
+    $ newLockers `Set.isSubsetOf` Set.fromList (signatory newLockable)
   toInterfaceContractId <$> create newLockable
 
 -- | Default implementation of `release` from the `Lockable` interface.
@@ -46,8 +46,8 @@ releaseImpl currentLock setLock Release{context} = do
   assertMsg "Must be locked" $ isSome currentLock
   let
     release lock = do
-      let newContext = context `S.delete` lock.context
-      case (lock.lockType, S.null newContext) of
+      let newContext = context `Set.delete` lock.context
+      case (lock.lockType, Set.null newContext) of
         (Reentrant, False) -> Some lock with context = newContext
         _ -> None
     releasedLock = currentLock >>= release
@@ -56,4 +56,4 @@ releaseImpl currentLock setLock Release{context} = do
 -- | Check validity of lock.
 -- The lockers field must be non-empty if set.
 isValidLock : Optional Lock -> Bool
-isValidLock lock = optional True (not . S.null . (.lockers)) lock
+isValidLock lock = optional True (not . Set.null . (.lockers)) lock

--- a/src/test/daml/Daml/Finance/Account/Test/Controllers.daml
+++ b/src/test/daml/Daml/Finance/Account/Test/Controllers.daml
@@ -3,8 +3,8 @@
 
 module Daml.Finance.Account.Test.Controllers where
 
-import DA.Map qualified as M (fromList, toList)
-import DA.Set qualified as S (fromList, singleton)
+import DA.Map qualified as Map (fromList, toList)
+import DA.Set qualified as Set (fromList, singleton)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
 import Daml.Finance.Holding.Test.Common (TestInitialState(..), TestParties(..), setupInitialState, setupParties)
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I, Transfer(..))
@@ -17,7 +17,7 @@ custodianControlled : Script ()
 custodianControlled = script do
   -- Create parties
   tp@TestParties{custodian; issuer; investor; publicParty} <- setupParties
-  let pp = M.fromList [("PublicParty", S.singleton publicParty)]
+  let pp = Map.fromList [("PublicParty", Set.singleton publicParty)]
 
   -- Initialize state
   TestInitialState {issuerAccount; investorAccount; issuerHoldingCid} <- setupInitialState
@@ -31,12 +31,12 @@ custodianControlled = script do
   -- Owners can't transfer
   submitMultiMustFail [issuer, investor] [publicParty] do
     exerciseCmd (fromInterfaceContractId @Transferable.I issuerHoldingCid)
-      Transferable.Transfer with actors = S.singleton issuer; newOwnerAccount = investorAccount
+      Transferable.Transfer with actors = Set.singleton issuer; newOwnerAccount = investorAccount
 
   -- Custodian can transfer
   submitMulti [custodian] [publicParty] do
     exerciseCmd (fromInterfaceContractId @Transferable.I issuerHoldingCid)
-      Transferable.Transfer with actors = S.singleton custodian; newOwnerAccount = investorAccount
+      Transferable.Transfer with actors = Set.singleton custodian; newOwnerAccount = investorAccount
 
   pure ()
 
@@ -45,7 +45,7 @@ ownerControlled : Script ()
 ownerControlled = script do
   -- Create parties
   tp@TestParties{custodian; issuer; investor; publicParty} <- setupParties
-  let pp = M.fromList [("PublicParty", S.singleton publicParty)]
+  let pp = Map.fromList [("PublicParty", Set.singleton publicParty)]
 
   -- Initialize state
   TestInitialState {issuerAccount; investorAccount; issuerHoldingCid} <- setupInitialState
@@ -58,13 +58,13 @@ ownerControlled = script do
   -- Custodian can't transfer.
   submitMultiMustFail [custodian] [publicParty] do
     exerciseCmd (fromInterfaceContractId @Transferable.I issuerHoldingCid)
-      Transferable.Transfer with actors = S.singleton custodian; newOwnerAccount = investorAccount
+      Transferable.Transfer with actors = Set.singleton custodian; newOwnerAccount = investorAccount
 
   -- Owners can transfer.
   submitMulti [issuer, investor] [publicParty] do
     exerciseCmd (fromInterfaceContractId @Transferable.I issuerHoldingCid)
       Transferable.Transfer with
-        actors = S.fromList [issuer, investor]; newOwnerAccount = investorAccount
+        actors = Set.fromList [issuer, investor]; newOwnerAccount = investorAccount
 
   pure ()
 
@@ -73,7 +73,7 @@ ownerAndCustodianControlled : Script ()
 ownerAndCustodianControlled = script do
   -- Create parties
   tp@TestParties{custodian; issuer; investor; publicParty} <- setupParties
-  let pp = M.fromList [("PublicParty", S.singleton publicParty)]
+  let pp = Map.fromList [("PublicParty", Set.singleton publicParty)]
 
   -- Initialize state
   TestInitialState {issuerAccount; investorAccount; issuerHoldingCid} <- setupInitialState
@@ -87,18 +87,18 @@ ownerAndCustodianControlled = script do
   submitMultiMustFail [issuer, investor] [publicParty] do
     exerciseCmd (fromInterfaceContractId @Transferable.I issuerHoldingCid)
       Transferable.Transfer with
-        actors = S.fromList [issuer, investor]; newOwnerAccount = investorAccount
+        actors = Set.fromList [issuer, investor]; newOwnerAccount = investorAccount
 
   -- Custodian can't transfer.
   submitMultiMustFail [custodian] [publicParty] do
     exerciseCmd (fromInterfaceContractId @Transferable.I issuerHoldingCid)
-      Transferable.Transfer with actors = S.singleton custodian; newOwnerAccount = investorAccount
+      Transferable.Transfer with actors = Set.singleton custodian; newOwnerAccount = investorAccount
 
   -- Owners and Custodian can transfer.
   submitMulti [custodian, issuer, investor] [publicParty] do
     exerciseCmd (fromInterfaceContractId @Transferable.I issuerHoldingCid)
       Transferable.Transfer with
-        actors = S.fromList [custodian, issuer, investor]; newOwnerAccount = investorAccount
+        actors = Set.fromList [custodian, issuer, investor]; newOwnerAccount = investorAccount
 
   pure ()
 
@@ -107,24 +107,24 @@ ownerControlledWithAutoApproval : Script ()
 ownerControlledWithAutoApproval = script do
   -- Create parties
   tp@TestParties{custodian; issuer; investor; publicParty} <- setupParties
-  let pp = M.fromList [("PublicParty", S.singleton publicParty)]
+  let pp = Map.fromList [("PublicParty", Set.singleton publicParty)]
 
   -- Initialize state
   TestInitialState {issuerAccount; investorAccount; issuerHoldingCid} <- setupInitialState
     tp
     Holding.Factory with provider = custodian; id = Id "Holding Factory"; observers = pp
     TransferableFungible
-    (M.toList pp)
+    (Map.toList pp)
     OwnerWithAutoApproval
 
   -- Custodian can't transfer.
   submitMultiMustFail [custodian] [publicParty] do
     exerciseCmd (fromInterfaceContractId @Transferable.I issuerHoldingCid)
-      Transferable.Transfer with actors = S.singleton custodian; newOwnerAccount = investorAccount
+      Transferable.Transfer with actors = Set.singleton custodian; newOwnerAccount = investorAccount
 
   -- Owner can transfer.
   submitMulti [issuer] [publicParty] do
     exerciseCmd (fromInterfaceContractId @Transferable.I issuerHoldingCid)
-      Transferable.Transfer with actors = S.singleton issuer; newOwnerAccount = investorAccount
+      Transferable.Transfer with actors = Set.singleton issuer; newOwnerAccount = investorAccount
 
   pure ()

--- a/src/test/daml/Daml/Finance/Account/Test/Lock.daml
+++ b/src/test/daml/Daml/Finance/Account/Test/Lock.daml
@@ -3,7 +3,7 @@
 
 module Daml.Finance.Account.Test.Lock where
 
-import DA.Set qualified as S (empty, fromList, insert, singleton, toList)
+import DA.Set (fromList, insert, singleton, toList)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
 import Daml.Finance.Holding.Test.Common (TestInitialState(..), TestParties(..), setupInitialState, setupParties)
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I, Transfer(..))
@@ -34,23 +34,23 @@ lockWith f lockOutgoingAccount = script do
     ControlledBy.Custodian
   let
     lockers = case f of
-      CustodianOnly -> S.singleton custodian
-      RegulatorOnly -> S.singleton regulator
-      CustodianAndRegulator -> S.fromList [custodian, regulator]
-    custodianAndLockers = S.toList . S.insert custodian $ lockers
+      CustodianOnly -> singleton custodian
+      RegulatorOnly -> singleton regulator
+      CustodianAndRegulator -> fromList [custodian, regulator]
+    custodianAndLockers = toList . insert custodian $ lockers
     accountToBeFrozen = if lockOutgoingAccount then issuerAccount else investorAccount
     context = "Frozen"
 
   -- Can't acquire lock with no new lockers.
   Account.submitMustFailExerciseInterfaceByKeyCmd @Lockable.I [custodian] [] issuerAccount $
     Lockable.Acquire with
-      newLockers = S.empty; context; lockType = Lockable.Semaphore
+      newLockers = mempty; context; lockType = Lockable.Semaphore
 
   -- A third party (here the regulator) can't acquire the lock for itself (even if they would see
   -- it).
   Account.submitMustFailExerciseInterfaceByKeyCmd @Lockable.I [regulator] [custodian] issuerAccount
     $ Lockable.Acquire with
-        newLockers = S.singleton regulator; context; lockType = Lockable.Semaphore
+        newLockers = singleton regulator; context; lockType = Lockable.Semaphore
 
   -- Custodian and the lockers can lock the account to the lockers.
   Account.submitExerciseInterfaceByKeyCmd @Lockable.I custodianAndLockers []
@@ -66,17 +66,17 @@ lockWith f lockOutgoingAccount = script do
   submitMustFail custodian do
     exerciseCmd (coerceInterfaceContractId @Transferable.I issuerHoldingCid)
       Transferable.Transfer with
-        actors = S.singleton custodian
+        actors = singleton custodian
         newOwnerAccount = investorAccount
 
   -- Lockers can release the lock.
-  Account.submitExerciseInterfaceByKeyCmd @Lockable.I (S.toList lockers) [] accountToBeFrozen $
+  Account.submitExerciseInterfaceByKeyCmd @Lockable.I (toList lockers) [] accountToBeFrozen $
     Lockable.Release with context
 
   -- Custodian can transfer (as account is unlocked).
   submit custodian do
     exerciseCmd (coerceInterfaceContractId @Transferable.I issuerHoldingCid)
-      Transferable.Transfer with actors = S.singleton custodian; newOwnerAccount = investorAccount
+      Transferable.Transfer with actors = singleton custodian; newOwnerAccount = investorAccount
 
   pure ()
 

--- a/src/test/daml/Daml/Finance/Data/Test/DateClock.daml
+++ b/src/test/daml/Daml/Finance/Data/Test/DateClock.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Data.Test.DateClock where
 
 import DA.Assert ((===))
 import DA.Date (addDays, toDateUTC)
-import DA.Set qualified as S (singleton)
+import DA.Set (singleton)
 import Daml.Finance.Data.Time.DateClock qualified as DateClock (DateClock(..), T)
 import Daml.Finance.Data.Time.DateClock.Types (Unit(..))
 import Daml.Finance.Interface.Data.Reference.Time qualified as Time (Advance(..), I, Rewind(..))
@@ -20,7 +20,7 @@ testDateClock = script do
   let
     dateNow = toDateUTC now
     dateClock = DateClock.DateClock with
-      providers = S.singleton bank
+      providers = singleton bank
       date = Unit dateNow
       id = Id "CLOCK"
       description = "Clock"

--- a/src/test/daml/Daml/Finance/Data/Test/HolidayCalendar.daml
+++ b/src/test/daml/Daml/Finance/Data/Test/HolidayCalendar.daml
@@ -4,7 +4,7 @@
 module Daml.Finance.Data.Test.HolidayCalendar where
 
 import DA.Date (DayOfWeek(..), Month(..), date)
-import DA.Map qualified as M (empty, fromList)
+import DA.Map qualified as Map (fromList)
 import DA.Set (singleton)
 import Daml.Finance.Data.Reference.HolidayCalendar (Factory(..))
 import Daml.Finance.Interface.Data.Reference.HolidayCalendar (GetView(..), UpdateCalendar(..))
@@ -28,13 +28,13 @@ testHolidayCalendar = script do
   -- Reuters defines the USNY holiday calendar
   -- Create calendar via factory
   calendarFactoryCid <- toInterfaceContractId @HolidayCalendarFactory.I <$> submit reuters do
-    createCmd Factory with provider = reuters; observers = M.empty
+    createCmd Factory with provider = reuters; observers = mempty
 
   usnyCalendarCid <- submit reuters do
     exerciseCmd calendarFactoryCid HolidayCalendarFactory.Create with
       provider = reuters
       calendar
-      observers = M.fromList observers
+      observers = Map.fromList observers
 
   -- Retrieve the calendar view from the ledger
   usnyCalendarView <- submit reuters do exerciseCmd usnyCalendarCid GetView with viewer = reuters

--- a/src/test/daml/Daml/Finance/Data/Test/Observation.daml
+++ b/src/test/daml/Daml/Finance/Data/Test/Observation.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Data.Test.Observation where
 
 import DA.Assert ((===))
 import DA.Date (Month(..), date)
-import DA.Map qualified as M (fromList)
+import DA.Map qualified as Map (fromList)
 import DA.Set (singleton)
 import DA.Time (time)
 import Daml.Finance.Data.Numeric.Observation (Factory(..))
@@ -23,11 +23,11 @@ testObservation = script do
 
   let
     toTime d = time d 0 0 0
-    observations = M.fromList $ fmap (\(d, v) -> (toTime d, v))
+    observations = Map.fromList $ fmap (\(d, v) -> (toTime d, v))
       [ (date 2019 Jan 16, -0.00311)
       , (date 2019 Feb 16, -0.00266)
       ]
-    observers = M.fromList [("PublicParty", singleton publicParty)]
+    observers = Map.fromList [("PublicParty", singleton publicParty)]
 
   -- Create observation via factory
   observationFactoryCid <- toInterfaceContractId @NumbericObservationFactory.I <$> submit reuters do

--- a/src/test/daml/Daml/Finance/Holding/Test/Holding.daml
+++ b/src/test/daml/Daml/Finance/Holding/Test/Holding.daml
@@ -4,8 +4,7 @@
 module Daml.Finance.Holding.Test.Holding where
 
 import DA.Assert ((===))
-import DA.Map qualified as M (empty)
-import DA.Set qualified as S (empty, fromList, singleton)
+import DA.Set (fromList, singleton)
 import Daml.Finance.Account.Account qualified as Account (T)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
 import Daml.Finance.Holding.Test.Common (TestInitialState(..), TestParties(..), setupInitialState, setupParties)
@@ -26,7 +25,7 @@ run = script do
   -- Initialize state
   TestInitialState {investorAccount; issuerAccount; issuerHoldingCid} <- setupInitialState
     tp
-    Holding.Factory with provider = custodian; id = Id "Holding Factory"; observers = M.empty
+    Holding.Factory with provider = custodian; id = Id "Holding Factory"; observers = mempty
     BaseHolding
     []
     Account.Owner
@@ -40,29 +39,29 @@ run = script do
   submitMultiMustFail [issuer, investor] [] do
     exerciseCmd (fromInterfaceContractId @Transferable.I issuerHoldingCid)
       Transferable.Transfer with
-        actors = S.fromList [issuer, investor]; newOwnerAccount = investorAccount
+        actors = fromList [issuer, investor]; newOwnerAccount = investorAccount
 
   -- Cannot lock with empty lockers
   submitMustFail issuer do
     exerciseCmd (toInterfaceContractId @Lockable.I issuerHoldingCid)
       Lockable.Acquire with
-        newLockers = S.empty; context = "Test Lock"; lockType = Lockable.Semaphore
+        newLockers = mempty; context = "Test Lock"; lockType = Lockable.Semaphore
 
   -- Lock asset with a one time lock
   lockableCid <- submitMulti [issuer, locker] [] do
     exerciseCmd (toInterfaceContractId @Lockable.I issuerHoldingCid)
       Lockable.Acquire with
-        newLockers = S.singleton locker; context = "Test Lock"; lockType = Lockable.Semaphore
+        newLockers = singleton locker; context = "Test Lock"; lockType = Lockable.Semaphore
 
   -- Same Locker attempts locks asset again
   submitMultiMustFail [issuer, locker] [] do
     exerciseCmd lockableCid Lockable.Acquire with
-      newLockers = S.singleton locker; context = "Second attempt"; lockType =Lockable.Semaphore
+      newLockers = singleton locker; context = "Second attempt"; lockType =Lockable.Semaphore
 
   -- Another locker attempts to lock this asset
   submitMultiMustFail [issuer, locker2] [] do
     exerciseCmd lockableCid Lockable.Acquire with
-      newLockers = S.singleton locker2; context = "Steal lock"; lockType =Lockable.Semaphore
+      newLockers = singleton locker2; context = "Steal lock"; lockType =Lockable.Semaphore
 
   -- Cannot debit
   Account.submitMustFailExerciseInterfaceByKeyCmd @Account.I [custodian, issuer] [] issuerAccount $
@@ -75,25 +74,25 @@ run = script do
   -- Lock asset with a reentrant lock
   lockableCid <- submitMulti [issuer, locker] [] do
     exerciseCmd lockableCid Lockable.Acquire with
-      newLockers = S.singleton locker; context = "Lock 1"; lockType = Lockable.Reentrant
+      newLockers = singleton locker; context = "Lock 1"; lockType = Lockable.Reentrant
 
   -- Same Locker locks asset again for the same context
   submitMultiMustFail [issuer, locker] [] do
     exerciseCmd lockableCid Lockable.Acquire with
-      newLockers = S.singleton locker; context = "Lock 1"; lockType = Lockable.Reentrant
+      newLockers = singleton locker; context = "Lock 1"; lockType = Lockable.Reentrant
 
   -- Lock asset with a reentrant lock for another context
   lockableCid <- submitMulti [issuer, locker] [] do
     exerciseCmd lockableCid Lockable.Acquire with
-      newLockers = S.singleton locker; context = "Lock 2"; lockType = Lockable.Reentrant
+      newLockers = singleton locker; context = "Lock 2"; lockType = Lockable.Reentrant
 
   -- Another locker attempts to lock this asset
   submitMultiMustFail [issuer, locker2] [] do
     exerciseCmd lockableCid Lockable.Acquire with
-       newLockers = S.singleton locker2; context = "Steal lock"; lockType = Lockable.Semaphore
+       newLockers = singleton locker2; context = "Steal lock"; lockType = Lockable.Semaphore
   submitMultiMustFail [issuer, locker2] [] do
     exerciseCmd lockableCid Lockable.Acquire with
-      newLockers = S.singleton locker2; context = "Steal lock"; lockType = Lockable.Reentrant
+      newLockers = singleton locker2; context = "Steal lock"; lockType = Lockable.Reentrant
 
   -- Unlock one lock
   lockableCid <- submit locker do exerciseCmd lockableCid Lockable.Release with context = "Lock 2"
@@ -107,7 +106,7 @@ run = script do
 
   -- Make sure the issuer account has no observers
   [(accountCid, account)] <- query @Account.T issuer
-  account.observers === M.empty
+  account.observers === mempty
 
   -- Debit asset
   Account.submitExerciseInterfaceByKeyCmd @Account.I [custodian, issuer] [] issuerAccount $

--- a/src/test/daml/Daml/Finance/Holding/Test/Transfer.daml
+++ b/src/test/daml/Daml/Finance/Holding/Test/Transfer.daml
@@ -5,8 +5,8 @@ module Daml.Finance.Holding.Test.Transfer where
 
 import DA.Action (foldlA)
 import DA.Assert ((===))
-import DA.Map qualified as M (fromList)
-import DA.Set qualified as S (fromList, singleton, toList)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (fromList, singleton, toList)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
 import Daml.Finance.Holding.Test.Common (TestInitialState(..), TestParties(..), setupInitialState, setupParties)
 import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I, Transfer(..))
@@ -22,7 +22,7 @@ testTransfer useReentrantLockTransferService = script do
   tp@TestParties{custodian; issuer; investor; locker; publicParty} <- setupParties
 
   -- Initialize state
-  let pp = M.fromList [("PublicParty", S.singleton publicParty)]
+  let pp = Map.fromList [("PublicParty", Set.singleton publicParty)]
   TestInitialState {issuerAccount; issuerHoldingCid; investorAccount} <- setupInitialState
     tp
     Holding.Factory with provider = custodian; id = Id "Holding Factory"; observers = pp
@@ -33,10 +33,10 @@ testTransfer useReentrantLockTransferService = script do
   -- Lock asset (with 2 contexts)
   lockableCid <- submitMulti [issuer, locker] [] do
     exerciseCmd (toInterfaceContractId @Lockable.I issuerHoldingCid) Lockable.Acquire with
-      newLockers = S.singleton locker; context = "C1"; lockType = Lockable.Reentrant
+      newLockers = Set.singleton locker; context = "C1"; lockType = Lockable.Reentrant
   lockableCid <- submitMulti [issuer, locker] [] do
     exerciseCmd lockableCid Lockable.Acquire with
-      newLockers = S.singleton locker; context = "C2"; lockType = Lockable.Reentrant
+      newLockers = Set.singleton locker; context = "C2"; lockType = Lockable.Reentrant
 
   lockableCid <- if useReentrantLockTransferService then
     do
@@ -60,7 +60,7 @@ testTransfer useReentrantLockTransferService = script do
       -- Transfer
       submitMultiMustFail [issuer, investor, locker] [publicParty] do
         exerciseCmd (fromInterfaceContractId @Transferable.I lockableCid) Transferable.Transfer with
-          actors = S.fromList [issuer, investor, locker]; newOwnerAccount = investorAccount
+          actors = Set.fromList [issuer, investor, locker]; newOwnerAccount = investorAccount
 
       -- Unlock
       lockableCid <- submit locker do
@@ -73,21 +73,21 @@ testTransfer useReentrantLockTransferService = script do
       -- Transfer
       newTransferableCid <- submitMulti [issuer, investor] [publicParty] do
         exerciseCmd (fromInterfaceContractId @Transferable.I lockableCid) Transferable.Transfer with
-          actors = S.fromList [issuer, investor]; newOwnerAccount = investorAccount
+          actors = Set.fromList [issuer, investor]; newOwnerAccount = investorAccount
 
       -- Lock asset (using same contexts)
       lockableCid <- submitMulti [investor, locker] [] do
         exerciseCmd (toInterfaceContractId @Lockable.I newTransferableCid) Lockable.Acquire with
-          newLockers = S.singleton locker; context = "C1"; lockType = Lockable.Reentrant
+          newLockers = Set.singleton locker; context = "C1"; lockType = Lockable.Reentrant
       submitMulti [investor, locker] [] do
         exerciseCmd lockableCid Lockable.Acquire with
-          newLockers = S.singleton locker; context = "C2"; lockType = Lockable.Reentrant
+          newLockers = Set.singleton locker; context = "C2"; lockType = Lockable.Reentrant
 
   -- Verify lock is maintained
   Some lock <- (.lock) <$> submit locker do
     exerciseCmd lockableCid Lockable.GetView with viewer = locker
-  lock.lockers === S.singleton locker
-  lock.context === S.fromList ["C1", "C2"]
+  lock.lockers === Set.singleton locker
+  lock.context === Set.fromList ["C1", "C2"]
   lock.lockType === Lockable.Reentrant
 
   pure ()
@@ -115,14 +115,15 @@ template ReentrantLockTransferService
         let
           releaseAll cid lock =
             foldlA (\acc context -> exercise acc Lockable.Release with context) cid
-              (S.toList lock.context)
+              (Set.toList lock.context)
         transferableCid <- fromInterfaceContractId @Transferable.I <$>
           optional (pure lockableCid) (releaseAll lockableCid) vLockable.lock
         -- Transfer
         newLockableCid <- toInterfaceContractId @Lockable.I <$>
           exercise transferableCid
             Transferable.Transfer with
-              actors = S.fromList [sender, receiverAccount.owner]; newOwnerAccount = receiverAccount
+              actors = Set.fromList [sender, receiverAccount.owner]
+              newOwnerAccount = receiverAccount
         -- Reapply locks
         let
           reapplyLocks cid lock =
@@ -130,7 +131,7 @@ template ReentrantLockTransferService
               (\acc context -> exercise acc Lockable.Acquire with
                   newLockers = lock.lockers; context; lockType = lock.lockType
               )
-              cid (S.toList lock.context)
+              cid (Set.toList lock.context)
         fromInterfaceContractId @Transferable.I <$>
           optional (pure newLockableCid) (reapplyLocks newLockableCid) vLockable.lock
 

--- a/src/test/daml/Daml/Finance/Holding/Test/Transferable.daml
+++ b/src/test/daml/Daml/Finance/Holding/Test/Transferable.daml
@@ -3,8 +3,8 @@
 
 module Daml.Finance.Holding.Test.Transferable where
 
-import DA.Map qualified as M (fromList)
-import DA.Set qualified as S (fromList, singleton)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (fromList, singleton)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
 import Daml.Finance.Holding.Test.Common (TestInitialState(..), TestParties(..), setupInitialState, setupParties)
 import Daml.Finance.Interface.Account.Account qualified as Account (Debit(..), I)
@@ -20,7 +20,7 @@ run : Script ()
 run = script do
   -- Create parties
   tp@TestParties{custodian; issuer; investor; locker; publicParty} <- setupParties
-  let observers = M.fromList [("PublicParty", S.singleton publicParty)]
+  let observers = Map.fromList [("PublicParty", Set.singleton publicParty)]
 
   -- Initialize state
   TestInitialState {investorAccount; issuerAccount; issuerHoldingCid} <- setupInitialState
@@ -39,12 +39,12 @@ run = script do
   lockableCid <- submitMulti [issuer, locker] [] do
     exerciseCmd (toInterfaceContractId @Lockable.I issuerHoldingCid)
       Lockable.Acquire with
-        newLockers = S.singleton locker; context = "Test Lock"; lockType = Lockable.Semaphore
+        newLockers = Set.singleton locker; context = "Test Lock"; lockType = Lockable.Semaphore
 
   -- Cannot transfer
   submitMultiMustFail [issuer, investor] [] do
     exerciseCmd (fromInterfaceContractId @Transferable.I lockableCid)
-      Transferable.Transfer with actors = S.singleton investor; newOwnerAccount = investorAccount
+      Transferable.Transfer with actors = Set.singleton investor; newOwnerAccount = investorAccount
 
   -- Cannot debit
   Account.submitMustFailExerciseInterfaceByKeyCmd @Account.I [custodian, issuer] [] issuerAccount $
@@ -58,7 +58,7 @@ run = script do
   transferableCid <- submitMulti [issuer, investor] [publicParty] do
     exerciseCmd (fromInterfaceContractId @Transferable.I lockableCid)
       Transferable.Transfer with
-        actors = S.fromList [issuer, investor]; newOwnerAccount = investorAccount
+        actors = Set.fromList [issuer, investor]; newOwnerAccount = investorAccount
 
   -- Assert state
   Holding.verifyOwnerOfHolding [(investor, transferableCid)]

--- a/src/test/daml/Daml/Finance/Holding/Test/TransferableFungible.daml
+++ b/src/test/daml/Daml/Finance/Holding/Test/TransferableFungible.daml
@@ -4,9 +4,9 @@
 module Daml.Finance.Holding.Test.TransferableFungible where
 
 import DA.Assert ((===))
-import DA.Map qualified as M (fromList)
+import DA.Map qualified as Map (fromList)
 import DA.Optional (fromSome)
-import DA.Set qualified as S (fromList, singleton)
+import DA.Set qualified as Set (fromList, singleton)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
 import Daml.Finance.Holding.Test.Common (TestInitialState(..), TestParties(..), setupInitialState, setupParties)
 import Daml.Finance.Holding.TransferableFungible qualified as TransferableFungible (T)
@@ -35,7 +35,7 @@ run = script do
     Holding.Factory with
       provider = custodian
       id = Id "Holding Factory"
-      observers = M.fromList [("PublicParty", S.singleton publicParty)]
+      observers = Map.fromList [("PublicParty", Set.singleton publicParty)]
     TransferableFungible
     []
     Account.Owner
@@ -44,7 +44,7 @@ run = script do
   lockableCid <- submitMulti [issuer, locker] [] do
     exerciseCmd (toInterfaceContractId @Lockable.I issuerHoldingCid)
       Lockable.Acquire with
-        newLockers = S.singleton locker; context = "Test Lock"; lockType = Lockable.Semaphore
+        newLockers = Set.singleton locker; context = "Test Lock"; lockType = Lockable.Semaphore
 
   -- Cannot split
   submitMustFail issuer do
@@ -55,7 +55,7 @@ run = script do
   submitMultiMustFail [issuer, investor] [] do
     exerciseCmd (fromInterfaceContractId @Transferable.I lockableCid)
       Transferable.Transfer with
-        actors = S.fromList [issuer, investor]; newOwnerAccount = investorAccount
+        actors = Set.fromList [issuer, investor]; newOwnerAccount = investorAccount
 
   -- Cannot debit
   Account.submitMustFailExerciseInterfaceByKeyCmd @Account.I [custodian, issuer] [] issuerAccount $
@@ -171,7 +171,7 @@ run = script do
   transferableCid <- submitMulti [issuer, investor] [publicParty] do
     exerciseCmd transferableCid
       Transferable.Transfer with
-        actors = S.fromList [issuer, investor]; newOwnerAccount = investorAccount
+        actors = Set.fromList [issuer, investor]; newOwnerAccount = investorAccount
 
   -- Assert state
   Holding.verifyOwnerOfHolding [(investor, transferableCid)]

--- a/src/test/daml/Daml/Finance/Holding/Test/Upgrade.daml
+++ b/src/test/daml/Daml/Finance/Holding/Test/Upgrade.daml
@@ -3,8 +3,8 @@
 
 module Daml.Finance.Holding.Test.Upgrade where
 
-import DA.Map qualified as M (fromList)
-import DA.Set qualified as S (singleton)
+import DA.Map qualified as Map (fromList)
+import DA.Set (singleton)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
 import Daml.Finance.Holding.Test.Common (TestInitialState(..), TestParties(..), setupInitialState, setupParties)
 import Daml.Finance.Holding.Transferable qualified as Transferable (T)
@@ -21,7 +21,7 @@ run : Script ()
 run = do
   -- Create parties
   tp@TestParties{custodian; issuer; investor; locker; publicParty} <- setupParties
-  let observers = M.fromList [("PublicParty", S.singleton publicParty)]
+  let observers = Map.fromList [("PublicParty", singleton publicParty)]
 
   -- Initialize state
   TestInitialState {investorAccount; issuerAccount; issuerHoldingCid; accountFactoryCid;
@@ -46,7 +46,7 @@ run = do
     submitMulti [issuer] [publicParty] do
       exerciseCmd (fromInterfaceContractId @Transferable.I issuerHoldingCid)
         Transferable.Transfer with
-          actors = S.singleton issuer; newOwnerAccount = issuerAccount
+          actors = singleton issuer; newOwnerAccount = issuerAccount
   Some _ <- queryContractId custodian $ fromInterfaceContractId @TransferableNew.T transferableCid
 
   pure ()

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/Callable.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/Callable.daml
@@ -4,8 +4,8 @@
 module Daml.Finance.Instrument.Bond.Test.Callable where
 
 import DA.Date (DayOfWeek(..), Month(..), date, subtractDays)
-import DA.Map qualified as M (empty, fromList)
-import DA.Set qualified as S (singleton)
+import DA.Map qualified as Map (fromList)
+import DA.Set (singleton)
 import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Reference.HolidayCalendar (HolidayCalendar(..))
 import Daml.Finance.Data.Time.DateClock (dateToDateClockTime)
@@ -30,7 +30,7 @@ run = script do
     createParties ["Custodian", "Issuer", "Investor", "Calendar Data Provider", "PublicParty"]
 
   -- Account and holding factory
-  let pp = [("FactoryProvider", S.singleton publicParty)]
+  let pp = [("FactoryProvider", singleton publicParty)]
 
   -- Originate commercial-bank cash
   now <- getTime
@@ -69,7 +69,7 @@ run = script do
     createCmd HolidayCalendar with
       provider = calendarDataProvider
       calendar
-      observers = M.fromList pp
+      observers = Map.fromList pp
 
   bondInstrument <- originateCallableBond issuer issuer "BONDTEST1" TransferableFungible
     "Callable Bond" pp now issueDate holidayCalendarIds calendarDataProvider firstCouponDate
@@ -118,7 +118,7 @@ runCallableBondValidationFail = script do
     createParties ["Custodian", "Issuer", "Investor", "Calendar Data Provider", "PublicParty"]
 
   -- Account and holding factory
-  let pp = [("FactoryProvider", S.singleton publicParty)]
+  let pp = [("FactoryProvider", singleton publicParty)]
 
   -- Originate commercial-bank cash
   now <- getTime
@@ -156,7 +156,7 @@ runCallableBondValidationFail = script do
     createCmd HolidayCalendar with
       provider = calendarDataProvider
       calendar
-      observers = M.fromList pp
+      observers = Map.fromList pp
 
   originateCallableBondMustFail issuer issuer "BONDTEST1" TransferableFungible "Callable Bond" pp
     now issueDate holidayCalendarIds calendarDataProvider firstCouponDateIncorrect maturityDate
@@ -179,7 +179,7 @@ runFloatingCall = script do
     createParties ["Custodian", "Issuer", "Investor", "Calendar Data Provider", "PublicParty"]
 
   -- Account and holding factory
-  let pp = [("FactoryProvider", S.singleton publicParty)]
+  let pp = [("FactoryProvider", singleton publicParty)]
 
   -- Originate commercial-bank cash
   now <- getTime
@@ -215,7 +215,7 @@ runFloatingCall = script do
         businessCenters = ["EUR"]
     noticeDays = 0
     -- CREATE_12M_FLOATING_CALLABLE_BOND_VARIABLES_END
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 2019 Jan 14, 0.010)
       , (dateToDateClockTime $ date 2019 May 13, 0.010)
       ]
@@ -231,11 +231,11 @@ runFloatingCall = script do
     createCmd HolidayCalendar with
       provider = calendarDataProvider
       calendar
-      observers = M.fromList pp
+      observers = Map.fromList pp
 
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id $ referenceRateId; observations; observers = M.empty
+      provider = issuer; id = Id $ referenceRateId; observations; observers = mempty
 
   bondInstrument <- originateCallableBond issuer issuer "BONDTEST1" TransferableFungible
     "Callable Bond" pp now issueDate holidayCalendarIds calendarDataProvider firstCouponDate
@@ -280,7 +280,7 @@ runFloating = script do
     createParties ["Custodian", "Issuer", "Investor", "Calendar Data Provider", "PublicParty"]
 
   -- Account and holding factory
-  let pp = [("FactoryProvider", S.singleton publicParty)]
+  let pp = [("FactoryProvider", singleton publicParty)]
 
   -- Originate commercial-bank cash
   now <- getTime
@@ -314,7 +314,7 @@ runFloating = script do
         businessCenters = ["USD"]
     noticeDays = 0
     -- CREATE_3M_FLOATING_CALLABLE_BOND_VARIABLES_END
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 2022 Jan 13, 0.010)
       , (dateToDateClockTime $ date 2022 Apr 13, 0.010)
       , (dateToDateClockTime $ date 2022 Jul 13, 0.010)
@@ -336,11 +336,11 @@ runFloating = script do
     createCmd HolidayCalendar with
       provider = calendarDataProvider
       calendar
-      observers = M.fromList pp
+      observers = Map.fromList pp
 
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id $ referenceRateId; observations; observers = M.empty
+      provider = issuer; id = Id $ referenceRateId; observations; observers = mempty
 
   bondInstrument <- originateCallableBond issuer issuer "BONDTEST1" TransferableFungible
     "Callable Bond" pp now issueDate holidayCalendarIds calendarDataProvider firstCouponDate
@@ -433,7 +433,7 @@ runFloatingFloorCap = script do
     createParties ["Custodian", "Issuer", "Investor", "Calendar Data Provider", "PublicParty"]
 
   -- Account and holding factory
-  let pp = [("FactoryProvider", S.singleton publicParty)]
+  let pp = [("FactoryProvider", singleton publicParty)]
 
   -- Originate commercial-bank cash
   now <- getTime
@@ -467,7 +467,7 @@ runFloatingFloorCap = script do
         businessCenters = ["USD"]
     noticeDays = 0
     -- CREATE_3M_CAP_FLOOR_FLOATING_CALLABLE_BOND_VARIABLES_END
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 2022 Jan 13, 0.010)
       , (dateToDateClockTime $ date 2022 Apr 13, 0.020)
       , (dateToDateClockTime $ date 2022 Jul 13, -0.005)
@@ -489,11 +489,11 @@ runFloatingFloorCap = script do
     createCmd HolidayCalendar with
       provider = calendarDataProvider
       calendar
-      observers = M.fromList pp
+      observers = Map.fromList pp
 
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id $ referenceRateId; observations; observers = M.empty
+      provider = issuer; id = Id $ referenceRateId; observations; observers = mempty
 
   bondInstrument <- originateCallableBond issuer issuer "BONDTEST1" TransferableFungible
     "Callable Bond" pp now issueDate holidayCalendarIds calendarDataProvider firstCouponDate
@@ -582,7 +582,7 @@ runFloatingFloorCapCallable6M = script do
     createParties ["Custodian", "Issuer", "Investor", "Calendar Data Provider", "PublicParty"]
 
   -- Account and holding factory
-  let pp = [("FactoryProvider", S.singleton publicParty)]
+  let pp = [("FactoryProvider", singleton publicParty)]
 
   -- Originate commercial-bank cash
   now <- getTime
@@ -616,7 +616,7 @@ runFloatingFloorCapCallable6M = script do
         businessDayConvention = NoAdjustment
         businessCenters = ["USD"]
     -- CREATE_3M_CAP_FLOOR_FLOATING_6M_CALLABLE_BOND_VARIABLES_END
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 2022 Jan 13, 0.010)
       , (dateToDateClockTime $ date 2022 Apr 13, 0.020)
       , (dateToDateClockTime $ date 2022 Jul 13, -0.005)
@@ -638,11 +638,11 @@ runFloatingFloorCapCallable6M = script do
     createCmd HolidayCalendar with
       provider = calendarDataProvider
       calendar
-      observers = M.fromList pp
+      observers = Map.fromList pp
 
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id $ referenceRateId; observations; observers = M.empty
+      provider = issuer; id = Id $ referenceRateId; observations; observers = mempty
 
   let
   -- CREATE_3M_CAP_FLOOR_FLOATING_6M_CALLABLE_BOND_COUPON_SCHEDULE_BEGIN
@@ -766,7 +766,7 @@ runTwoCoupons = script do
     createParties ["Custodian", "Issuer", "Investor", "Calendar Data Provider", "PublicParty"]
 
   -- Account and holding factory
-  let pp = [("FactoryProvider", S.singleton publicParty)]
+  let pp = [("FactoryProvider", singleton publicParty)]
 
   -- Originate commercial-bank cash
   now <- getTime
@@ -800,7 +800,7 @@ runTwoCoupons = script do
         businessCenters = ["USD"]
     noticeDays = 0
     -- CREATE_3M_FLOATING_CALLABLE_BOND_VARIABLES_END
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 2022 Jan 13, 0.010)
       , (dateToDateClockTime $ date 2022 Apr 13, 0.010)
       ]
@@ -816,11 +816,11 @@ runTwoCoupons = script do
     createCmd HolidayCalendar with
       provider = calendarDataProvider
       calendar
-      observers = M.fromList pp
+      observers = Map.fromList pp
 
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id $ referenceRateId; observations; observers = M.empty
+      provider = issuer; id = Id $ referenceRateId; observations; observers = mempty
 
   bondInstrument <- originateCallableBond issuer issuer "BONDTEST1" TransferableFungible
     "Callable Bond" pp now issueDate holidayCalendarIds calendarDataProvider firstCouponDate
@@ -865,7 +865,7 @@ runFixCouponUnadjustedCallable6M = script do
     createParties ["Custodian", "Issuer", "Investor", "Calendar Data Provider", "PublicParty"]
 
   -- Account and holding factory
-  let pp = [("FactoryProvider", S.singleton publicParty)]
+  let pp = [("FactoryProvider", singleton publicParty)]
 
   -- Originate commercial-bank cash
   now <- getTime
@@ -900,7 +900,7 @@ runFixCouponUnadjustedCallable6M = script do
     createCmd HolidayCalendar with
       provider = calendarDataProvider
       calendar
-      observers = M.fromList pp
+      observers = Map.fromList pp
 
   let
     couponSchedule = createPaymentPeriodicSchedule firstCouponDate holidayCalendarIds
@@ -973,7 +973,7 @@ runSofrFloorCapCallable6M = script do
     createParties ["Custodian", "Issuer", "Investor", "Calendar Data Provider", "PublicParty"]
 
   -- Account and holding factory
-  let pp = [("FactoryProvider", S.singleton publicParty)]
+  let pp = [("FactoryProvider", singleton publicParty)]
 
   -- Originate commercial-bank cash
   now <- getTime
@@ -1007,7 +1007,7 @@ runSofrFloorCapCallable6M = script do
         dayType = Some Business
         businessDayConvention = NoAdjustment
         businessCenters = ["USD"]
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 2022 Jan 13, 1.04240111)
       , (dateToDateClockTime $ date 2022 Jul 13, 1.04509941)
       , (dateToDateClockTime $ date 2023 Jan 12, 1.06145226)
@@ -1025,11 +1025,11 @@ runSofrFloorCapCallable6M = script do
     createCmd HolidayCalendar with
       provider = calendarDataProvider
       calendar
-      observers = M.fromList pp
+      observers = Map.fromList pp
 
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id $ referenceRateId; observations; observers = M.empty
+      provider = issuer; id = Id $ referenceRateId; observations; observers = mempty
 
   let
     couponSchedule = createPaymentPeriodicSchedule firstCouponDate holidayCalendarIds
@@ -1094,7 +1094,7 @@ runFloatingCouponUnadjustedCallable1Y = script do
     createParties ["Custodian", "Issuer", "Investor", "Calendar Data Provider", "PublicParty"]
 
   -- Account and holding factory
-  let pp = [("FactoryProvider", S.singleton publicParty)]
+  let pp = [("FactoryProvider", singleton publicParty)]
 
   -- Originate commercial-bank cash
   now <- getTime
@@ -1127,7 +1127,7 @@ runFloatingCouponUnadjustedCallable1Y = script do
         businessDayConvention = NoAdjustment
         businessCenters = ["TARGET2"]
     noticeDays = 0
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 2022 Jan 21, 0.040)
       , (dateToDateClockTime $ date 2022 Jul 21, 0.040)
       ]
@@ -1148,16 +1148,16 @@ runFloatingCouponUnadjustedCallable1Y = script do
     createCmd HolidayCalendar with
       provider = calendarDataProvider
       calendar = calUS
-      observers = M.fromList pp
+      observers = Map.fromList pp
   submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider
       calendar = calTarget2
-      observers = M.fromList pp
+      observers = Map.fromList pp
 
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id $ referenceRateId; observations; observers = M.empty
+      provider = issuer; id = Id $ referenceRateId; observations; observers = mempty
 
   let
     couponSchedule = createPaymentPeriodicSchedule firstCouponDate holidayCalendarIds

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/FixedRate.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/FixedRate.daml
@@ -4,8 +4,8 @@
 module Daml.Finance.Instrument.Bond.Test.FixedRate where
 
 import DA.Date (DayOfWeek(..), Month(..), addDays, date, subtractDays)
-import DA.Map qualified as M (fromList)
-import DA.Set qualified as S (singleton)
+import DA.Map qualified as Map (fromList)
+import DA.Set (singleton)
 import Daml.Finance.Data.Reference.HolidayCalendar (HolidayCalendar(..))
 import Daml.Finance.Instrument.Bond.Test.Util (originateFixedRateBond)
 import Daml.Finance.Interface.Types.Common.Types (HoldingStandard(..))
@@ -26,7 +26,7 @@ run = script do
       "PublicParty"]
 
   -- Account and holding factory
-  let pp = [("FactoryProvider", S.singleton publicParty)]
+  let pp = [("FactoryProvider", singleton publicParty)]
 
   -- Originate commercial-bank cash
   now <- getTime
@@ -65,13 +65,13 @@ run = script do
     createCmd HolidayCalendar with
       provider = calendarDataProvider
       calendar
-      observers = M.fromList pp
+      observers = Map.fromList pp
 
   calendarCid2 <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider
       calendar = cal2
-      observers = M.fromList pp
+      observers = Map.fromList pp
 
   bondInstrument <- originateFixedRateBond issuer issuer "BONDTEST1" TransferableFungible
     "Fixed Rate Bond" pp now issueDate holidayCalendarIds calendarDataProvider firstCouponDate

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/FloatingRate.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/FloatingRate.daml
@@ -4,8 +4,8 @@
 module Daml.Finance.Instrument.Bond.Test.FloatingRate where
 
 import DA.Date (DayOfWeek(..), Month(..), addDays, date, subtractDays)
-import DA.Map qualified as M (empty, fromList)
-import DA.Set qualified as S (singleton)
+import DA.Map qualified as Map (fromList)
+import DA.Set (singleton)
 import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Reference.HolidayCalendar (HolidayCalendar(..))
 import Daml.Finance.Data.Time.DateClock (dateToDateClockTime)
@@ -27,11 +27,11 @@ run : Script ()
 run = script do
   [depository, custodian, issuer, calendarDataProvider, settler, publicParty] <-
     createParties ["CSD", "Custodian", "Issuer", "Calendar Data Provider", "Settler", "PublicParty"]
-  let settlers = S.singleton settler
+  let settlers = singleton settler
 
   -- Distribute commercial-bank cash
   now <- getTime
-  let pp = [("PublicParty", S.singleton publicParty)]
+  let pp = [("PublicParty", singleton publicParty)]
   cashInstrument <- originate depository issuer "EUR" TransferableFungible "Euro" pp now
 
   -- Create and distribute bond
@@ -58,7 +58,7 @@ run = script do
     dayCountConvention = Act365Fixed
     businessDayConvention = Following
   -- CREATE_FLOATING_RATE_BOND_VARIABLES_END
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 2019 Jan 16, -0.00311)
       , (dateToDateClockTime $ date 2019 Feb 15, -0.00266)
       ]
@@ -73,11 +73,11 @@ run = script do
     createCmd HolidayCalendar with
       provider = calendarDataProvider
       calendar
-      observers = M.fromList pp
+      observers = Map.fromList pp
 
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id referenceRateId; observations; observers = M.empty
+      provider = issuer; id = Id referenceRateId; observations; observers = mempty
 
   bondInstrument <- originateFloatingRateBond issuer issuer "BONDTEST1" TransferableFungible
     "Floating Rate Bond" pp now issueDate holidayCalendarIds calendarDataProvider firstCouponDate
@@ -125,7 +125,7 @@ runSofr = script do
     createParties ["Custodian", "Issuer", "Investor", "Calendar Data Provider", "PublicParty"]
 
   -- Account and holding factory
-  let pp = [("FactoryProvider", S.singleton publicParty)]
+  let pp = [("FactoryProvider", singleton publicParty)]
 
   -- Originate commercial-bank cash
   now <- getTime
@@ -157,7 +157,7 @@ runSofr = script do
         dayType = Some Business
         businessDayConvention = NoAdjustment
         businessCenters = ["USD"]
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 2022 Jan 13, 1.04240111)
       , (dateToDateClockTime $ date 2022 Jul 13, 1.04509941)
       , (dateToDateClockTime $ date 2023 Jan 12, 1.06145226)
@@ -175,11 +175,11 @@ runSofr = script do
     createCmd HolidayCalendar with
       provider = calendarDataProvider
       calendar
-      observers = M.fromList pp
+      observers = Map.fromList pp
 
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id $ referenceRateId; observations; observers = M.empty
+      provider = issuer; id = Id $ referenceRateId; observations; observers = mempty
 
   bondInstrument <- originateFloatingRateBond issuer issuer "BONDTEST1" TransferableFungible
     "Floating Rate Bond" pp now issueDate holidayCalendarIds calendarDataProvider firstCouponDate

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/InflationLinked.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/InflationLinked.daml
@@ -4,8 +4,8 @@
 module Daml.Finance.Instrument.Bond.Test.InflationLinked where
 
 import DA.Date (DayOfWeek(..), Month(..), addDays, date, subtractDays)
-import DA.Map qualified as M (empty, fromList)
-import DA.Set qualified as S (singleton)
+import DA.Map qualified as Map (fromList)
+import DA.Set (singleton)
 import Daml.Finance.Data.Numeric.Observation(Observation(..))
 import Daml.Finance.Data.Reference.HolidayCalendar (HolidayCalendar(..))
 import Daml.Finance.Data.Time.DateClock (dateToDateClockTime)
@@ -28,7 +28,7 @@ run = script do
 
   -- Distribute commercial-bank cash
   now <- getTime
-  let pp = [("PublicParty", S.singleton publicParty)]
+  let pp = [("PublicParty", singleton publicParty)]
   cashInstrument <- originate depository issuer "EUR" TransferableFungible "Euro" pp now
 
   -- Create and distribute bond
@@ -48,7 +48,7 @@ run = script do
   -- CREATE_INFLATION_LINKED_BOND_VARIABLES_END
     inflationIndexBaseValue = 200.0
     inflationIndexAtMaturity = 220.0
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 2019 Feb 15, 210.0)
       , (dateToDateClockTime $ date 2019 May 15, inflationIndexAtMaturity)
       ]
@@ -63,11 +63,11 @@ run = script do
     createCmd HolidayCalendar with
       provider = calendarDataProvider
       calendar
-      observers = M.fromList pp
+      observers = Map.fromList pp
 
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id inflationIndexId; observations; observers = M.empty
+      provider = issuer; id = Id inflationIndexId; observations; observers = mempty
 
   bondInstrument <- originateInflationLinkedBond issuer issuer "BONDTEST1" TransferableFungible
     "Inflation Linked Bond" pp now issueDate holidayCalendarIds calendarDataProvider

--- a/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Bond/Test/Util.daml
@@ -3,7 +3,7 @@
 
 module Daml.Finance.Instrument.Bond.Test.Util where
 
-import DA.Map qualified as M (empty, fromList)
+import DA.Map (fromList)
 import Daml.Finance.Instrument.Bond.Callable.Factory qualified as CallableBond (Factory(..))
 import Daml.Finance.Instrument.Bond.FixedRate.Factory qualified as FixedRateBond (Factory(..))
 import Daml.Finance.Instrument.Bond.FloatingRate.Factory qualified as FloatingRateBond (Factory(..))
@@ -46,7 +46,7 @@ originateFixedRateBond depository issuer label holdingStandard description obser
     fixedRateBondFactoryCid <- toInterfaceContractId @FixedRateBondFactory.I <$> submit issuer do
       createCmd FixedRateBond.Factory with
         provider = issuer
-        observers = M.empty
+        observers = mempty
 
     -- CREATE_FIXED_RATE_BOND_INSTRUMENT_BEGIN
     let
@@ -70,7 +70,7 @@ originateFixedRateBond depository issuer label holdingStandard description obser
           currency
           notional
           lastEventTimestamp
-        observers = M.fromList observers
+        observers = fromList observers
     -- CREATE_FIXED_RATE_BOND_INSTRUMENT_END
     pure instrument
 
@@ -94,7 +94,7 @@ originateCallableBond depository issuer label holdingStandard description observ
     callableBondFactoryCid <- toInterfaceContractId @CallableBondFactory.I <$> submit issuer do
       createCmd CallableBond.Factory with
         provider = issuer
-        observers = M.empty
+        observers = mempty
 
     -- CREATE_CALLABLE_BOND_INSTRUMENT_BEGIN
     let
@@ -125,7 +125,7 @@ originateCallableBond depository issuer label holdingStandard description observ
           notional
           lastEventTimestamp
           prevEvents = []
-        observers = M.fromList observers
+        observers = fromList observers
     -- CREATE_CALLABLE_BOND_INSTRUMENT_END
     pure instrument
 
@@ -149,7 +149,7 @@ originateCallableBondMustFail depository issuer label holdingStandard descriptio
     callableBondFactoryCid <- toInterfaceContractId @CallableBondFactory.I <$> submit issuer do
       createCmd CallableBond.Factory with
         provider = issuer
-        observers = M.empty
+        observers = mempty
 
     let
       instrument = InstrumentKey with
@@ -179,7 +179,7 @@ originateCallableBondMustFail depository issuer label holdingStandard descriptio
           notional
           lastEventTimestamp
           prevEvents = []
-        observers = M.fromList observers
+        observers = fromList observers
     pure ()
 
 originateMultiScheduleCallableBond : Party -> Party -> Text -> HoldingStandard -> Text ->
@@ -195,7 +195,7 @@ originateMultiScheduleCallableBond depository issuer label holdingStandard descr
     callableBondFactoryCid <- toInterfaceContractId @CallableBondFactory.I <$> submit issuer do
       createCmd CallableBond.Factory with
         provider = issuer
-        observers = M.empty
+        observers = mempty
 
     -- CREATE_MULTI_SCHEDULE_CALLABLE_BOND_INSTRUMENT_BEGIN
     let
@@ -226,7 +226,7 @@ originateMultiScheduleCallableBond depository issuer label holdingStandard descr
           notional
           lastEventTimestamp
           prevEvents = []
-        observers = M.fromList observers
+        observers = fromList observers
     -- CREATE_MULTI_SCHEDULE_CALLABLE_BOND_INSTRUMENT_END
     pure instrument
 
@@ -238,7 +238,7 @@ originateZeroCouponBond depository issuer label holdingStandard description obse
     zeroCouponBondFactoryCid <- toInterfaceContractId @ZeroCouponBondFactory.I <$> submit issuer do
       createCmd ZeroCouponBond.Factory with
         provider = issuer
-        observers = M.empty
+        observers = mempty
 
     -- CREATE_ZERO_COUPON_BOND_INSTRUMENT_BEGIN
     let
@@ -259,7 +259,7 @@ originateZeroCouponBond depository issuer label holdingStandard description obse
           maturityDate
           notional
           lastEventTimestamp
-        observers = M.fromList observers
+        observers = fromList observers
     -- CREATE_ZERO_COUPON_BOND_INSTRUMENT_END
     pure instrument
 
@@ -280,7 +280,7 @@ originateFloatingRateBond depository issuer label holdingStandard description
       submit issuer do
         createCmd FloatingRateBond.Factory with
           provider = issuer
-          observers = M.empty
+          observers = mempty
 
     -- CREATE_FLOATING_RATE_BOND_INSTRUMENT_BEGIN
     let
@@ -305,7 +305,7 @@ originateFloatingRateBond depository issuer label holdingStandard description
           currency
           notional
           lastEventTimestamp
-        observers = M.fromList observers
+        observers = fromList observers
     -- CREATE_FLOATING_RATE_BOND_INSTRUMENT_END
     pure instrument
 
@@ -326,7 +326,7 @@ originateInflationLinkedBond depository issuer label holdingStandard description
       submit issuer do
         createCmd InflationLinkedBond.Factory with
           provider = issuer
-          observers = M.empty
+          observers = mempty
 
     -- CREATE_INFLATION_LINKED_BOND_INSTRUMENT_BEGIN
     let
@@ -352,6 +352,6 @@ originateInflationLinkedBond depository issuer label holdingStandard description
           currency
           notional
           lastEventTimestamp
-        observers = M.fromList observers
+        observers = fromList observers
     -- CREATE_INFLATION_LINKED_BOND_INSTRUMENT_END
     pure instrument

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/DivOption.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/DivOption.daml
@@ -4,8 +4,8 @@
 module Daml.Finance.Instrument.Equity.Test.DivOption where
 
 import DA.Date (Month(..), date)
-import DA.Map qualified as M (fromList)
-import DA.Set (fromList, singleton)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (fromList, singleton)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
 import Daml.Finance.Instrument.Equity.Test.Util
 import Daml.Finance.Instrument.Option.Test.Util (electAndVerifyDivOptionPaymentEffects, originateDividendOption)
@@ -40,14 +40,15 @@ run = script do
   -- Create parties
   [cb, issuer, custodian, investor, publicParty] <-
     createParties ["CentralBank", "Issuer", "Custodian", "Investor", "PublicParty"]
-  let pp = [("PublicParty", singleton publicParty)]
+  let pp = [("PublicParty", Set.singleton publicParty)]
 
   -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory issuer pp
 
   -- Create holding factory
   holdingFactory <- createHoldingFactory
-    Holding.Factory with provider = custodian; id = Id "Holding Factory"; observers = M.fromList pp
+    Holding.Factory with
+      provider = custodian; id = Id "Holding Factory"; observers = Map.fromList pp
 
   -- Create accounts
   investorAccount <-
@@ -81,9 +82,9 @@ run = script do
   -- Create distribution rule for the dividend option
   distributionRuleCid <- toInterfaceContractId @Lifecycle.I <$> submit issuer do
     createCmd Distribution.Rule with
-      providers = singleton issuer
+      providers =Set.singleton issuer
       lifecycler = issuer
-      observers = singleton publicParty
+      observers = Set.singleton publicParty
       id = Id "LifecycleRule"
       description = "Rule to lifecycle an instrument following a distribution event"
 
@@ -107,15 +108,15 @@ run = script do
   -- Claim effect
   routeProviderCid <- toInterfaceContractId <$> submit custodian do
     createCmd SingleCustodian with
-      provider = custodian; observers = singleton publicParty; custodian
+      provider = custodian; observers = Set.singleton publicParty; custodian
   settlementFactoryCid <- toInterfaceContractId <$> submit custodian do
-    createCmd Factory with provider = custodian; observers = singleton publicParty
+    createCmd Factory with provider = custodian; observers = Set.singleton publicParty
   -- Enable netting so that there is only one holding with the new correct quantity
-  let settlers = fromList [investor, custodian]
+  let settlers = Set.fromList [investor, custodian]
   claimRuleCid <- toInterfaceContractId @Claim.I <$> submit custodian do
     createCmd Claim.Rule with
       provider = custodian
-      claimers = fromList [investor, custodian]
+      claimers = Set.fromList [investor, custodian]
       settlers
       routeProviderCid
       settlementFactoryCid
@@ -137,29 +138,30 @@ run = script do
   -- Allocate instructions
   (investorInstrumentInstructionCid, _) <- submit investor do
     exerciseCmd investorInstrumentInstructionCid Instruction.Allocate with
-      actors = singleton investor; allocation = Pledge $ fromInterfaceContractId investorEquityCid
+      actors = Set.singleton investor
+      allocation = Pledge $ fromInterfaceContractId investorEquityCid
   (custodianInstrumentInstructionCid, _) <- submit custodian do
     exerciseCmd custodianInstrumentInstructionCid Instruction.Allocate with
-      actors = singleton custodian; allocation = CreditReceiver
+      actors = Set.singleton custodian; allocation = CreditReceiver
   (custodianDivOptionInstructionCid, _) <- submit custodian do
     exerciseCmd custodianDivOptionInstructionCid Instruction.Allocate with
-      actors = singleton custodian; allocation = CreditReceiver
+      actors = Set.singleton custodian; allocation = CreditReceiver
 
   -- Approve instructions
   investorInstrumentInstructionCid <- submit custodian do
     exerciseCmd investorInstrumentInstructionCid Instruction.Approve with
-      actors = singleton custodian; approval = DebitSender
+      actors = Set.singleton custodian; approval = DebitSender
   custodianInstrumentInstructionCid <- submit investor do
     exerciseCmd custodianInstrumentInstructionCid Instruction.Approve with
-      actors = singleton investor; approval = TakeDelivery investorAccount
+      actors = Set.singleton investor; approval = TakeDelivery investorAccount
   custodianDivOptionInstructionCid <- submit investor do
     exerciseCmd custodianDivOptionInstructionCid Instruction.Approve with
-      actors = singleton investor; approval = TakeDelivery investorAccount
+      actors = Set.singleton investor; approval = TakeDelivery investorAccount
 
   -- Settle batch
   [investorEquityHoldingCid, investorDivOptionHoldingCid] <-
     submitMulti [custodian] [publicParty] do
-      exerciseCmd result.batchCid Batch.Settle with actors = singleton custodian
+      exerciseCmd result.batchCid Batch.Settle with actors = Set.singleton custodian
 
   -- Assert state
   Holding.verifyOwnerAndAmountOfHolding [(investor, 1000.00, investorEquityHoldingCid),
@@ -186,7 +188,7 @@ run = script do
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submit custodian do
     createCmd Claim.Rule with
       provider = custodian
-      claimers = fromList [investor, issuer]
+      claimers = Set.fromList [investor, issuer]
       settlers
       routeProviderCid
       settlementFactoryCid

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Dividend.daml
@@ -3,8 +3,8 @@
 
 module Daml.Finance.Instrument.Equity.Test.Dividend where
 
-import DA.Map qualified as M (fromList)
-import DA.Set qualified as S (fromList, singleton)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (fromList, singleton)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
 import Daml.Finance.Instrument.Equity.Test.Util (originateEquity)
 import Daml.Finance.Interface.Instrument.Equity.Instrument qualified as Equity (DeclareDistribution(..), I)
@@ -33,14 +33,14 @@ run = script do
   -- Create parties
   [cb, issuer, custodian, investor, publicParty] <-
     createParties ["CentralBank", "Issuer", "Custodian", "Investor", "PublicParty"]
-  let pp = [("PublicParty", S.singleton publicParty)]
+  let pp = [("PublicParty", Set.singleton publicParty)]
 
   -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory issuer pp
 
   -- Create holding factory
   holdingFactory <- createHoldingFactory
-    Holding.Factory with provider = custodian; id =Id "Holding Factory"; observers = M.fromList pp
+    Holding.Factory with provider = custodian; id =Id "Holding Factory"; observers = Map.fromList pp
 
   -- Create accounts
   investorAccount <-
@@ -66,9 +66,9 @@ run = script do
   -- Create cash dividend rule
   distributionRuleCid <- toInterfaceContractId @Lifecycle.I <$> submit issuer do
     createCmd Distribution.Rule with
-      providers = S.singleton issuer
+      providers = Set.singleton issuer
       lifecycler = issuer
-      observers = S.singleton publicParty
+      observers = Set.singleton publicParty
       id = Id "LifecycleRule"
       description = "Rule to lifecycle an instrument following a distribution event"
   -- CREATE_EQUITY_DISTRIBUTION_RULE_END
@@ -97,15 +97,15 @@ run = script do
   -- Claim effect
   routeProviderCid <- toInterfaceContractId <$> submit custodian do
     createCmd SingleCustodian with
-      provider = custodian; observers = S.singleton publicParty; custodian
+      provider = custodian; observers = Set.singleton publicParty; custodian
   settlementFactoryCid <- toInterfaceContractId <$> submit custodian do
-    createCmd Factory with provider = custodian; observers = S.singleton publicParty
+    createCmd Factory with provider = custodian; observers = Set.singleton publicParty
   -- Enable netting so that there is only one holding with the new correct quantity
   claimRuleCid <- toInterfaceContractId @Claim.I <$> submit custodian do
     createCmd Claim.Rule with
       provider = custodian
-      claimers = S.fromList [investor, custodian]
-      settlers = S.fromList [investor, custodian]
+      claimers = Set.fromList [investor, custodian]
+      settlers = Set.fromList [investor, custodian]
       routeProviderCid
       settlementFactoryCid
       netInstructions = True
@@ -126,29 +126,29 @@ run = script do
   -- Allocate instructions
   (investorInstrumentInstructionCid, _) <- submit investor do
     exerciseCmd investorInstrumentInstructionCid Instruction.Allocate with
-      actors = S.singleton investor
+      actors = Set.singleton investor
       allocation = Pledge $ fromInterfaceContractId investorEquityCid
   (custodianInstrumentInstructionCid, _) <- submit custodian do
     exerciseCmd custodianInstrumentInstructionCid Instruction.Allocate with
-      actors = S.singleton custodian; allocation = CreditReceiver
+      actors = Set.singleton custodian; allocation = CreditReceiver
   (custodianCashInstructionCid, _) <- submit custodian do
     exerciseCmd custodianCashInstructionCid Instruction.Allocate with
-      actors = S.singleton custodian; allocation = CreditReceiver
+      actors = Set.singleton custodian; allocation = CreditReceiver
 
   -- Approve instructions
   investorInstrumentInstructionCid <- submit custodian do
     exerciseCmd investorInstrumentInstructionCid Instruction.Approve with
-      actors = S.singleton custodian; approval = DebitSender
+      actors = Set.singleton custodian; approval = DebitSender
   custodianInstrumentInstructionCid <- submit investor do
     exerciseCmd custodianInstrumentInstructionCid Instruction.Approve with
-      actors = S.singleton investor; approval = TakeDelivery investorAccount
+      actors = Set.singleton investor; approval = TakeDelivery investorAccount
   custodianCashInstructionCid <- submit investor do
     exerciseCmd custodianCashInstructionCid Instruction.Approve with
-      actors = S.singleton investor; approval = TakeDelivery investorAccount
+      actors = Set.singleton investor; approval = TakeDelivery investorAccount
 
   -- Settle batch
   [investorCashHoldingCid, investorEquityHoldingCid] <- submitMulti [custodian] [publicParty] do
-    exerciseCmd result.batchCid Batch.Settle with actors = S.singleton custodian
+    exerciseCmd result.batchCid Batch.Settle with actors = Set.singleton custodian
 
   -- Assert state
   Holding.verifyOwnerAndAmountOfHolding [(investor, 1000.25, investorEquityHoldingCid),
@@ -194,23 +194,23 @@ run = script do
   -- Allocate instructions
   (investorInstrumentInstructionCid, _) <- submit investor do
     exerciseCmd investorInstrumentInstructionCid Instruction.Allocate with
-      actors = S.singleton investor
+      actors = Set.singleton investor
       allocation = Pledge $ fromInterfaceContractId investorEquityCid
   (custodianInstrumentInstructionCid, _) <- submit custodian do
     exerciseCmd custodianInstrumentInstructionCid Instruction.Allocate with
-      actors = S.singleton custodian; allocation = CreditReceiver
+      actors = Set.singleton custodian; allocation = CreditReceiver
 
   -- Approve instructions
   investorInstrumentInstructionCid <- submit custodian do
     exerciseCmd investorInstrumentInstructionCid Instruction.Approve with
-      actors = S.singleton custodian; approval = DebitSender
+      actors = Set.singleton custodian; approval = DebitSender
   custodianInstrumentInstructionCid <- submit investor do
     exerciseCmd custodianInstrumentInstructionCid Instruction.Approve with
-      actors = S.singleton investor; approval = TakeDelivery investorAccount
+      actors = Set.singleton investor; approval = TakeDelivery investorAccount
 
   -- Settle batch
   [investorEquityHoldingCid] <- submitMulti [custodian] [publicParty] do
-    exerciseCmd result.batchCid Batch.Settle with actors = S.singleton custodian
+    exerciseCmd result.batchCid Batch.Settle with actors = Set.singleton custodian
 
   -- Assert state
   Holding.verifyOwnerAndAmountOfHolding [(investor, 3000.75, investorEquityHoldingCid)]
@@ -276,23 +276,23 @@ run = script do
   -- Allocate instructions
   (investorInstrumentInstructionCid, _) <- submit investor do
     exerciseCmd investorInstrumentInstructionCid Instruction.Allocate with
-      actors = S.singleton investor
+      actors = Set.singleton investor
       allocation = Pledge $ fromInterfaceContractId investorEquityCid
   (custodianInstrumentInstructionCid, _) <- submit custodian do
     exerciseCmd custodianInstrumentInstructionCid Instruction.Allocate with
-      actors = S.singleton custodian; allocation = CreditReceiver
+      actors = Set.singleton custodian; allocation = CreditReceiver
 
   -- Approve instructions
   investorInstrumentInstructionCid <- submit custodian do
     exerciseCmd investorInstrumentInstructionCid Instruction.Approve with
-      actors = S.singleton custodian; approval = DebitSender
+      actors = Set.singleton custodian; approval = DebitSender
   custodianInstrumentInstructionCid <- submit investor do
     exerciseCmd custodianInstrumentInstructionCid Instruction.Approve with
-      actors = S.singleton investor; approval = TakeDelivery investorAccount
+      actors = Set.singleton investor; approval = TakeDelivery investorAccount
 
   -- Settle batch
   [investorEquityHoldingCid] <- submitMulti [custodian] [publicParty] do
-    exerciseCmd result.batchCid Batch.Settle with actors = S.singleton custodian
+    exerciseCmd result.batchCid Batch.Settle with actors = Set.singleton custodian
 
   -- Assert state
   Holding.verifyOwnerAndAmountOfHolding [(investor, 2500.625, investorEquityHoldingCid)]

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Merger.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Merger.daml
@@ -3,8 +3,8 @@
 
 module Daml.Finance.Instrument.Equity.Test.Merger where
 
-import DA.Map qualified as M (fromList)
-import DA.Set qualified as S (fromList, singleton)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (fromList, singleton)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
 import Daml.Finance.Instrument.Equity.Test.Util (originateEquity)
 import Daml.Finance.Interface.Instrument.Equity.Instrument qualified as Equity (DeclareReplacement(..), I)
@@ -33,14 +33,15 @@ run = script do
   -- Create parties
   [merging, merged, custodian, investor, publicParty] <-
     createParties ["MergingIssuer", "MergedIssuer", "Custodian", "Investor", "PublicParty"]
-  let pp = [("PublicParty", S.singleton publicParty)]
+  let pp = [("PublicParty", Set.singleton publicParty)]
 
   -- Account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory custodian pp
 
   -- Create holding factory
   holdingFactory <- createHoldingFactory
-    Holding.Factory with provider = custodian; id = Id "Holding Factory"; observers = M.fromList pp
+    Holding.Factory with
+      provider = custodian; id = Id "Holding Factory"; observers = Map.fromList pp
 
   -- Create accounts
   investorSecuritiesAccount <- Account.createAccount "Securities Account" [] accountFactoryCid
@@ -50,9 +51,9 @@ run = script do
   -- Create lifecycle rules
   replacementRuleCid <- toInterfaceContractId @Lifecycle.I <$> submit merging do
     createCmd Replacement.Rule with
-      providers = S.singleton merging
+      providers = Set.singleton merging
       lifecycler = merging
-      observers = S.singleton publicParty
+      observers = Set.singleton publicParty
       id = Id "LifecycleRule"
       description = "Rule to lifecycle an instrument following a replacement event"
   -- CREATE_EQUITY_REPLACEMENT_RULE_END
@@ -94,14 +95,14 @@ run = script do
   -- Claim effect
   routeProviderCid <- toInterfaceContractId <$> submit custodian do
     createCmd SingleCustodian with
-      provider = custodian; observers = S.singleton publicParty; custodian
+      provider = custodian; observers = Set.singleton publicParty; custodian
   settlementFactoryCid <- toInterfaceContractId <$> submit custodian do
-    createCmd Factory with provider = custodian; observers = S.singleton publicParty
+    createCmd Factory with provider = custodian; observers = Set.singleton publicParty
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submit custodian do
     createCmd Claim.Rule with
       provider = custodian
-      claimers = S.fromList [custodian, investor]
-      settlers = S.fromList [custodian, investor]
+      claimers = Set.fromList [custodian, investor]
+      settlers = Set.fromList [custodian, investor]
       routeProviderCid
       settlementFactoryCid
       netInstructions = False
@@ -117,23 +118,23 @@ run = script do
   let [consumeInstructionCid, produceInstructionCid] = result.instructionCids
   (consumeInstructionCid, _) <- submit investor do
     exerciseCmd consumeInstructionCid Instruction.Allocate with
-      actors = S.singleton investor
+      actors = Set.singleton investor
       allocation = Pledge $ fromInterfaceContractId investorEquityCid
   (produceInstructionCid, _) <- submit custodian do
     exerciseCmd produceInstructionCid Instruction.Allocate with
-      actors = S.singleton custodian; allocation = CreditReceiver
+      actors = Set.singleton custodian; allocation = CreditReceiver
 
   -- Approve instructions
   consumeInstructionCid <- submit custodian do
     exerciseCmd consumeInstructionCid Instruction.Approve with
-      actors = S.singleton custodian; approval = DebitSender
+      actors = Set.singleton custodian; approval = DebitSender
   produceInstructionCid <- submit investor do
     exerciseCmd produceInstructionCid Instruction.Approve with
-      actors = S.singleton investor; approval = TakeDelivery investorSecuritiesAccount
+      actors = Set.singleton investor; approval = TakeDelivery investorSecuritiesAccount
 
   -- Settle batch
   [investorEquityCid] <- submit custodian do
-    exerciseCmd result.batchCid Batch.Settle with actors = S.singleton custodian
+    exerciseCmd result.batchCid Batch.Settle with actors = Set.singleton custodian
 
   -- Assert state
   Holding.verifyOwnerOfHolding [(investor, investorEquityCid)]

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/RightsIssue.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/RightsIssue.daml
@@ -4,8 +4,8 @@
 module Daml.Finance.Instrument.Equity.Test.RightsIssue where
 
 import DA.Date (Month(..), date)
-import DA.Map qualified as M (fromList)
-import DA.Set qualified as S (fromList, singleton)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (fromList, singleton)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
 import Daml.Finance.Instrument.Equity.Test.Util (originateEquity)
 import Daml.Finance.Instrument.Option.Test.Util (originateEuropeanPhysicalOption)
@@ -41,14 +41,15 @@ run = script do
   -- Create parties
   [cb, issuer, custodian, investor, publicParty] <-
     createParties ["CentralBank", "Issuer", "Custodian", "Investor", "PublicParty"]
-  let pp = [("PublicParty", S.singleton publicParty)]
+  let pp = [("PublicParty", Set.singleton publicParty)]
 
   -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory issuer pp
 
   -- Create holding factory
   holdingFactory <- createHoldingFactory
-    Holding.Factory with provider = custodian; id = Id "Holding Factory"; observers = M.fromList pp
+    Holding.Factory with
+      provider = custodian; id = Id "Holding Factory"; observers = Map.fromList pp
 
   -- Create accounts
   investorAccount <-
@@ -79,9 +80,9 @@ run = script do
   -- Create distribution rule for the rights issue
   distributionRuleCid <- toInterfaceContractId @Lifecycle.I <$> submit issuer do
     createCmd Distribution.Rule with
-      providers = S.singleton issuer
+      providers = Set.singleton issuer
       lifecycler = issuer
-      observers = S.singleton publicParty
+      observers = Set.singleton publicParty
       id = Id "LifecycleRule"
       description = "Rule to lifecycle an instrument following a distribution event"
 
@@ -105,15 +106,15 @@ run = script do
   -- Claim effect
   routeProviderCid <- toInterfaceContractId <$> submit custodian do
     createCmd SingleCustodian with
-      provider = custodian; observers = S.singleton publicParty; custodian
+      provider = custodian; observers = Set.singleton publicParty; custodian
   settlementFactoryCid <- toInterfaceContractId <$> submit custodian do
-    createCmd Factory with provider = custodian; observers = S.singleton publicParty
+    createCmd Factory with provider = custodian; observers = Set.singleton publicParty
   -- Enable netting so that there is only one holding with the new correct quantity
-  let settlers = S.fromList [investor, custodian]
+  let settlers = Set.fromList [investor, custodian]
   claimRuleCid <- toInterfaceContractId @Claim.I <$> submit custodian do
     createCmd Claim.Rule with
       provider = custodian
-      claimers = S.fromList [investor, custodian]
+      claimers = Set.fromList [investor, custodian]
       settlers
       routeProviderCid
       settlementFactoryCid
@@ -135,29 +136,29 @@ run = script do
   -- Allocate instructions
   (investorInstrumentInstructionCid, _) <- submit investor do
     exerciseCmd investorInstrumentInstructionCid Instruction.Allocate with
-      actors = S.singleton investor
+      actors = Set.singleton investor
       allocation = Pledge $ fromInterfaceContractId investorEquityCid
   (custodianInstrumentInstructionCid, _) <- submit custodian do
     exerciseCmd custodianInstrumentInstructionCid Instruction.Allocate with
-      actors = S.singleton custodian; allocation = CreditReceiver
+      actors = Set.singleton custodian; allocation = CreditReceiver
   (custodianRightsInstructionCid, _) <- submit custodian do
     exerciseCmd custodianRightsInstructionCid Instruction.Allocate with
-      actors = S.singleton custodian; allocation = CreditReceiver
+      actors = Set.singleton custodian; allocation = CreditReceiver
 
   -- Approve instructions
   investorInstrumentInstructionCid <- submit custodian do
     exerciseCmd investorInstrumentInstructionCid Instruction.Approve with
-      actors = S.singleton custodian; approval = DebitSender
+      actors = Set.singleton custodian; approval = DebitSender
   custodianInstrumentInstructionCid <- submit investor do
     exerciseCmd custodianInstrumentInstructionCid Instruction.Approve with
-      actors = S.singleton investor; approval = TakeDelivery investorAccount
+      actors = Set.singleton investor; approval = TakeDelivery investorAccount
   custodianRightsInstructionCid <- submit investor do
     exerciseCmd custodianRightsInstructionCid Instruction.Approve with
-      actors = S.singleton investor; approval = TakeDelivery investorAccount
+      actors = Set.singleton investor; approval = TakeDelivery investorAccount
 
   -- Settle batch
   [investorEquityHoldingCid, investorRightsHoldingCid] <- submitMulti [custodian] [publicParty] do
-    exerciseCmd result.batchCid Batch.Settle with actors = S.singleton custodian
+    exerciseCmd result.batchCid Batch.Settle with actors = Set.singleton custodian
 
   -- Assert state
   Holding.verifyOwnerAndAmountOfHolding [(investor, 1000.00, investorEquityHoldingCid),
@@ -193,7 +194,7 @@ run = script do
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submit custodian do
     createCmd Claim.Rule with
       provider = custodian
-      claimers = S.fromList [custodian, investor]
+      claimers = Set.fromList [custodian, investor]
       settlers
       routeProviderCid
       settlementFactoryCid

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/StockSplit.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/StockSplit.daml
@@ -3,8 +3,8 @@
 
 module Daml.Finance.Instrument.Equity.Test.StockSplit where
 
-import DA.Map qualified as M (fromList)
-import DA.Set qualified as S (fromList, singleton)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (fromList, singleton)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
 import Daml.Finance.Instrument.Equity.Test.Util (originateEquity)
 import Daml.Finance.Interface.Instrument.Equity.Instrument qualified as Equity (DeclareStockSplit(..), I)
@@ -30,14 +30,14 @@ run : Script ()
 run = script do
   -- Create parties
   [issuer, investor, publicParty] <- createParties ["Issuer", "Investor", "PublicParty"]
-  let pp = [("PublicParty", S.singleton publicParty)]
+  let pp = [("PublicParty", Set.singleton publicParty)]
 
   -- Create factories
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory issuer pp
 
   -- Create holding factory
   holdingFactory <- createHoldingFactory
-    Holding.Factory with provider = issuer; id = Id "Holding Factory"; observers = M.fromList pp
+    Holding.Factory with provider = issuer; id = Id "Holding Factory"; observers = Map.fromList pp
 
   -- Create accounts
   investorSecuritiesAccount <- Account.createAccount "Securities Account" [] accountFactoryCid
@@ -47,9 +47,9 @@ run = script do
   -- Create lifecycle rule
   replacementRuleCid <- toInterfaceContractId @Lifecycle.I <$> submit issuer do
     createCmd Replacement.Rule with
-      providers = S.singleton issuer
+      providers = Set.singleton issuer
       lifecycler = issuer
-      observers = S.singleton publicParty
+      observers = Set.singleton publicParty
       id = Id "LifecycleRule"
       description = "Rule to lifecycle an instrument following a replacement event"
   -- CREATE_EQUITY_REPLACEMENT_RULE_END
@@ -91,14 +91,14 @@ run = script do
   -- Claim effect
   routeProviderCid <- toInterfaceContractId <$> submit issuer do
     createCmd SingleCustodian with
-      provider = issuer; observers = S.singleton publicParty; custodian = issuer
+      provider = issuer; observers = Set.singleton publicParty; custodian = issuer
   settlementFactoryCid <- toInterfaceContractId <$> submit issuer do
-    createCmd Factory with provider = issuer; observers = S.singleton publicParty
+    createCmd Factory with provider = issuer; observers = Set.singleton publicParty
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submit issuer do
     createCmd Claim.Rule with
       provider = issuer
-      claimers = S.fromList [investor, issuer]
-      settlers = S.fromList [investor, issuer]
+      claimers = Set.fromList [investor, issuer]
+      settlers = Set.fromList [investor, issuer]
       routeProviderCid
       settlementFactoryCid
       netInstructions = False
@@ -114,23 +114,23 @@ run = script do
   let [consumeInstructionCid, produceInstructionCid] = result.instructionCids
   (consumeInstructionCid, _) <- submit investor do
     exerciseCmd consumeInstructionCid Instruction.Allocate with
-      actors = S.singleton investor
+      actors = Set.singleton investor
       allocation = Pledge $ fromInterfaceContractId investorEquityCid
   (produceInstructionCid, _) <- submit issuer do
     exerciseCmd produceInstructionCid Instruction.Allocate with
-      actors = S.singleton issuer; allocation = CreditReceiver
+      actors = Set.singleton issuer; allocation = CreditReceiver
 
   -- Approve instructions
   consumeInstructionCid <- submit issuer do
     exerciseCmd consumeInstructionCid Instruction.Approve with
-      actors = S.singleton issuer; approval = DebitSender
+      actors = Set.singleton issuer; approval = DebitSender
   produceInstructionCid <- submit investor do
     exerciseCmd produceInstructionCid Instruction.Approve with
-      actors = S.singleton investor; approval = TakeDelivery investorSecuritiesAccount
+      actors = Set.singleton investor; approval = TakeDelivery investorSecuritiesAccount
 
   -- Settle batch
   [investorEquityCid] <- submitMulti [investor] [publicParty] do
-    exerciseCmd result.batchCid Batch.Settle with actors = S.singleton investor
+    exerciseCmd result.batchCid Batch.Settle with actors = Set.singleton investor
 
   -- Assert state
   Holding.verifyOwnerOfHolding [(investor, investorEquityCid)]

--- a/src/test/daml/Daml/Finance/Instrument/Equity/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Equity/Test/Util.daml
@@ -3,7 +3,7 @@
 
 module Daml.Finance.Instrument.Equity.Test.Util where
 
-import DA.Map qualified as M (empty, fromList)
+import DA.Map  (fromList)
 import Daml.Finance.Instrument.Equity.Factory (Factory(..))
 import Daml.Finance.Interface.Instrument.Equity.Factory qualified as EquityFactory (Create(..), I)
 import Daml.Finance.Interface.Types.Common.Types (HoldingStandard(..), Id(..), InstrumentKey(..), Parties)
@@ -15,13 +15,13 @@ originateEquity : Party -> Party -> Text -> Text -> HoldingStandard -> Text -> [
 originateEquity depository issuer label version holdingStandard description observers
   timestamp = do
     equityFactoryCid <- toInterfaceContractId @EquityFactory.I <$> submit issuer do
-      createCmd Factory with provider = issuer; observers = M.empty
+      createCmd Factory with provider = issuer; observers = mempty
     let
       instrument = InstrumentKey with depository; issuer; version; id = Id label; holdingStandard
     submitMulti [depository, issuer] [] do
       exerciseCmd equityFactoryCid EquityFactory.Create with
         instrument; description
-        observers = M.fromList observers
+        observers = fromList observers
         validAsOf = timestamp
     submitMulti [depository, issuer] [] do archiveCmd equityFactoryCid
     pure instrument

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/CallableBond.daml
@@ -7,8 +7,8 @@ import ContingentClaims.Core.Claim (and, at, give, one, or, scale, when)
 import ContingentClaims.Core.Observation (Observation(..))
 import DA.Assert ((===))
 import DA.Date as D (Month(..), date)
-import DA.Map qualified as M (empty, fromList)
-import DA.Set qualified as S (empty, fromList, singleton, toList)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (fromList, singleton, toList)
 import DA.Time (time)
 import Daml.Finance.Data.Time.DateClock (dateToDateClockTime)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
@@ -82,14 +82,14 @@ run = script do
 
   -- Create parties
   TestParties{..} <- setupParties
-  let pp = [("PublicParty", S.singleton publicParty)]
+  let pp = [("PublicParty", Set.singleton publicParty)]
 
   -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
 
   -- Create holding factory
   holdingFactory <- createHoldingFactory
-    Holding.Factory with provider = bank; id = Id "Holding Factory"; observers = M.fromList pp
+    Holding.Factory with provider = bank; id = Id "Holding Factory"; observers = Map.fromList pp
 
   -- Create accounts
   investorAccount <- Account.createAccount "Default Account" [] accountFactoryCid holdingFactory
@@ -118,15 +118,15 @@ run = script do
   electionFactoryCid <- submit issuer do
     toInterfaceContractId <$> createCmd Election.Factory with
       provider = issuer
-      observers = M.fromList [("Custodian", S.singleton bank)]
+      observers = Map.fromList [("Custodian", Set.singleton bank)]
 
-  currentTimeCid <- createDateClock (S.singleton issuer) coupon1Date S.empty
+  currentTimeCid <- createDateClock (Set.singleton issuer) coupon1Date mempty
 
   -- Create a lifecycle rule
   lifecycleRuleCid <- toInterfaceContractId <$> submit bank do
     createCmd Lifecycle.Rule with
-      providers = S.singleton bank
-      observers= M.empty
+      providers = Set.singleton bank
+      observers = mempty
       lifecycler = issuer
       id = Id "LifecycleRule"
       description = "Rule to lifecycle a generic instrument"
@@ -143,7 +143,7 @@ run = script do
       id = Id "bondcall1"
       description = "Bond - Call"
       claim = "CALLED"
-      observers = S.singleton publicParty
+      observers = Set.singleton publicParty
       instrument = genericInstrument
       factoryCid = electionFactoryCid
 
@@ -175,16 +175,16 @@ run = script do
 
   -- Create route provider
   routeProviderCid <- toInterfaceContractId <$> submit bank do
-    createCmd SingleCustodian with provider = bank; observers = S.empty; custodian = bank
+    createCmd SingleCustodian with provider = bank; observers = mempty; custodian = bank
 
   -- Create settlement factory
   settlementFactoryCid <- toInterfaceContractId <$> submit bank do
-    createCmd Factory with provider = bank; observers = S.empty
+    createCmd Factory with provider = bank; observers = mempty
 
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submit bank do
     createCmd Claim.Rule with
       provider = bank
-      claimers = S.fromList [bank, investor]
+      claimers = Set.fromList [bank, investor]
       settlers
       routeProviderCid
       settlementFactoryCid
@@ -205,21 +205,21 @@ run = script do
   -- Allocate instructions
   (investorInstrumentInstructionCid, _) <- submit investor do
     exerciseCmd investorInstrumentInstructionCid Instruction.Allocate with
-      actors = S.singleton investor; allocation = Pledge investorGenericHoldingCid
+      actors = Set.singleton investor; allocation = Pledge investorGenericHoldingCid
   (bankCashInstructionCouponAndPrincipalCid, _) <- submit bank do
     exerciseCmd bankCashInstructionCouponAndPrincipalCid Instruction.Allocate with
-      actors = S.singleton bank; allocation = CreditReceiver
+      actors = Set.singleton bank; allocation = CreditReceiver
 
   -- Approve instructions
   investorInstrumentInstructionCid <- submit bank do
     exerciseCmd investorInstrumentInstructionCid Instruction.Approve with
-      actors = S.singleton bank; approval = DebitSender
+      actors = Set.singleton bank; approval = DebitSender
   bankCashInstructionCouponAndPrincipalCid <- submit investor do
     exerciseCmd bankCashInstructionCouponAndPrincipalCid Instruction.Approve with
-      actors = S.singleton investor; approval = TakeDelivery investorAccount
+      actors = Set.singleton investor; approval = TakeDelivery investorAccount
 
   -- Settle batch
-  [investorCashHoldingCouponAndPrincipalCid] <- submitMulti (S.toList settlers) [publicParty] do
+  [investorCashHoldingCouponAndPrincipalCid] <- submitMulti (Set.toList settlers) [publicParty] do
     exerciseCmd result.batchCid Batch.Settle with actors = settlers
 
   -- Assert state
@@ -241,7 +241,7 @@ run = script do
       id = Id "bondDontCall1"
       description = "Bond - Do not Call"
       claim = "NOT CALLED"
-      observers = S.singleton publicParty
+      observers = Set.singleton publicParty
       instrument = genericInstrument
       factoryCid = electionFactoryCid
 
@@ -278,28 +278,28 @@ run = script do
   -- Allocate instructions
   (investorInstrumentInstructionCid, _) <- submit investor do
     exerciseCmd investorInstrumentInstructionCid Instruction.Allocate with
-      actors = S.singleton investor; allocation = Pledge investorGenericHoldingCid
+      actors = Set.singleton investor; allocation = Pledge investorGenericHoldingCid
   (bankInstrumentInstructionCid, _) <- submit bank do
     exerciseCmd bankInstrumentInstructionCid Instruction.Allocate with
-      actors = S.singleton bank; allocation = CreditReceiver
+      actors = Set.singleton bank; allocation = CreditReceiver
   (bankCashInstructionCouponAndPrincipalCid, _) <- submit bank do
     exerciseCmd bankCashInstructionCouponAndPrincipalCid Instruction.Allocate with
-      actors = S.singleton bank; allocation = CreditReceiver
+      actors = Set.singleton bank; allocation = CreditReceiver
 
   -- Approve instructions
   investorInstrumentInstructionCid <- submit bank do
     exerciseCmd investorInstrumentInstructionCid Instruction.Approve with
-      actors = S.singleton bank; approval = DebitSender
+      actors = Set.singleton bank; approval = DebitSender
   bankInstrumentInstructionCid <- submit investor do
     exerciseCmd bankInstrumentInstructionCid Instruction.Approve with
-      actors = S.singleton investor; approval = TakeDelivery investorAccount
+      actors = Set.singleton investor; approval = TakeDelivery investorAccount
   bankCashInstructionCouponAndPrincipalCid <- submit investor do
     exerciseCmd bankCashInstructionCouponAndPrincipalCid Instruction.Approve with
-      actors = S.singleton investor; approval = TakeDelivery investorAccount
+      actors = Set.singleton investor; approval = TakeDelivery investorAccount
 
   -- Settle batch
   [investorInstrumentAfterCouponHoldingCid, investorCashHoldingCouponAndPrincipalCid]
-     <- submitMulti (S.toList settlers) [publicParty] do
+     <- submitMulti (Set.toList settlers) [publicParty] do
         exerciseCmd result.batchCid Batch.Settle with actors = settlers
 
   -- Assert state
@@ -322,4 +322,4 @@ setupParties = do
   [bank, issuer, centralBank, investor, settler, publicParty] <-
     createParties ["Bank", "issuer", "Central Bank", "Investor", "Settler", "PublicParty"]
   pure TestParties with
-    bank; issuer; centralBank; investor; settlers = S.singleton settler; publicParty
+    bank; issuer; centralBank; investor; settlers = Set.singleton settler; publicParty

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/Election/Workflow.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/Election/Workflow.daml
@@ -12,8 +12,8 @@
 -- sanity-checking logic herein to be application-specific rather than generic.
 module Daml.Finance.Instrument.Generic.Test.Election.Workflow where
 
-import DA.Map qualified as M (fromList)
-import DA.Set qualified as S (fromList, singleton)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (fromList, singleton)
 import DA.Text (sha256)
 import Daml.Finance.Interface.Holding.Holding qualified as Holding (I)
 import Daml.Finance.Interface.Lifecycle.Election qualified as Election (I)
@@ -110,14 +110,14 @@ template ElectionCandidate
       do
         -- Sanity check against current time
         currentTime <- exercise currentTimeCid TimeObservable.GetTime with
-          actors = S.singleton validator
+          actors = Set.singleton validator
         assertMsg ("Election time " <> show electionTime
           <> " must be greater or equal than current time " <> show currentTime)
           $ electionTime >= currentTime
 
         -- Create election
         exercise factoryCid ElectionFactory.Create with
-          actors = S.fromList [elector, validator]
+          actors = Set.fromList [elector, validator]
           id = Id . sha256 $ show id <> show claim <> show elector <> show electionTime
           description
           claim
@@ -127,5 +127,5 @@ template ElectionCandidate
           counterparty
           instrument
           amount
-          observers = M.fromList [("Holders", S.fromList [validator, elector, counterparty])]
+          observers = Map.fromList [("Holders", Set.fromList [validator, elector, counterparty])]
           provider = validator

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/EuropeanOption.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/EuropeanOption.daml
@@ -8,8 +8,8 @@ import ContingentClaims.Core.Claim (one, scale)
 import ContingentClaims.Core.Observation (Observation(..))
 import DA.Assert ((===))
 import DA.Date (addDays, toDateUTC)
-import DA.Map qualified as M (empty, fromList)
-import DA.Set qualified as S (empty, fromList, singleton, toList)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (fromList, singleton, toList)
 import DA.Time (time)
 import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Time.DateClock (dateToDateClockTime)
@@ -82,14 +82,14 @@ run = script do
 
   -- Create parties
   TestParties{..} <- setupParties
-  let pp = [("PublicParty", S.singleton publicParty)]
+  let pp = [("PublicParty", Set.singleton publicParty)]
 
   -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
 
   -- Create holding factory
   holdingFactory <- createHoldingFactory
-    Holding.Factory with provider = bank; id = Id "Holding Factory"; observers = M.fromList pp
+    Holding.Factory with provider = bank; id = Id "Holding Factory"; observers = Map.fromList pp
 
   -- Create accounts
   [investor1Account, investor2Account] <- mapA (Account.createAccount "Default Account" []
@@ -103,10 +103,10 @@ run = script do
   -- Create observable for the underlying fixing
   let
     maturity = addDays (toDateUTC now) 1
-    observations = M.fromList [(dateToDateClockTime maturity, 200.0)]
+    observations = Map.fromList [(dateToDateClockTime maturity, 200.0)]
   observableCid <- toInterfaceContractId <$> submit broker do
     createCmd Observation with
-      provider = broker; id = Id "SPOT/AAPL"; observations; observers = M.empty
+      provider = broker; id = Id "SPOT/AAPL"; observations; observers = mempty
 
   -- Create and distribute a generic derivative
   let
@@ -125,7 +125,7 @@ run = script do
   electionFactoryCid <- submit broker do
     toInterfaceContractId <$> createCmd Election.Factory with
       provider = broker
-      observers = M.fromList pp
+      observers = Map.fromList pp
   -- CREATE_ELECTION_FACTORY_END
 
   -- CREATE_ELECTION_OFFER_EXERCISE_BEGIN
@@ -135,7 +135,7 @@ run = script do
       id = Id "EXERCISE"
       description = "OPTION-AAPL - Exercise"
       claim = "EXERCISE"
-      observers = S.singleton publicParty
+      observers = Set.singleton publicParty
       instrument = genericInstrument
       factoryCid = electionFactoryCid
   -- CREATE_ELECTION_OFFER_EXERCISE_END
@@ -147,7 +147,7 @@ run = script do
       id = Id "EXPIRE"
       description = "OPTION-AAPL - Expire"
       claim = "EXPIRE"
-      observers = S.singleton publicParty
+      observers = Set.singleton publicParty
       instrument = genericInstrument
       factoryCid = electionFactoryCid
   -- CREATE_ELECTION_OFFER_EXPIRE_END
@@ -177,7 +177,7 @@ run = script do
   -- CREATE_ELECTION_CANDIDATE_END
 
   -- CREATE_CLOCK_BEGIN
-  currentTimeCid <- createDateClock (S.singleton broker) maturity S.empty
+  currentTimeCid <- createDateClock (Set.singleton broker) maturity mempty
   -- CREATE_CLOCK_END
 
   -- CREATE_ELECTION_BEGIN
@@ -190,8 +190,8 @@ run = script do
   -- Apply election to generate new instrument version + effects
   lifecycleRuleCid <- toInterfaceContractId <$> submit bank do
     createCmd Lifecycle.Rule with
-      providers = S.singleton bank
-      observers= M.empty
+      providers = Set.singleton bank
+      observers = mempty
       lifecycler = broker
       id = Id "LifecycleRule"
       description = "Rule to lifecycle a generic instrument"
@@ -206,17 +206,17 @@ run = script do
 
   -- Create route provider
   routeProviderCid <- toInterfaceContractId <$> submit investor1 do
-    createCmd SingleCustodian with provider = investor1; observers = S.empty; custodian = bank
+    createCmd SingleCustodian with provider = investor1; observers = mempty; custodian = bank
 
   -- Create settlement factory
   settlementFactoryCid <- toInterfaceContractId <$> submit investor1 do
-    createCmd Factory with provider = investor1; observers = S.empty
+    createCmd Factory with provider = investor1; observers = mempty
 
   -- Claim effect
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submit bank do
     createCmd Claim.Rule with
       provider = bank
-      claimers = S.fromList [bank, investor1]
+      claimers = Set.fromList [bank, investor1]
       settlers
       routeProviderCid
       settlementFactoryCid
@@ -247,24 +247,24 @@ run = script do
   -- Allocate instructions
   (investorInstrumentInstructionCid, _) <- submit investor1 do
     exerciseCmd investorInstrumentInstructionCid Instruction.Allocate with
-      actors = S.singleton investor1; allocation = Pledge $ toInterfaceContractId splitCid
+      actors = Set.singleton investor1; allocation = Pledge $ toInterfaceContractId splitCid
   (bankCashInstructionCid, _) <- submit bank do
     exerciseCmd bankCashInstructionCid Instruction.Allocate with
-      actors = S.singleton bank; allocation = CreditReceiver
+      actors = Set.singleton bank; allocation = CreditReceiver
 
   -- Approve instructions
   investorInstrumentInstructionCid <- submit bank do
     exerciseCmd investorInstrumentInstructionCid Instruction.Approve with
-      actors = S.singleton bank; approval = DebitSender
+      actors = Set.singleton bank; approval = DebitSender
   bankCashInstructionCid <- submit investor1 do
     exerciseCmd bankCashInstructionCid Instruction.Approve with
-      actors = S.singleton investor1; approval = TakeDelivery investor1Account
+      actors = Set.singleton investor1; approval = TakeDelivery investor1Account
 
   -- Set time
   setTime $ time maturity 0 0 0
 
   -- Settle batch
-  [investorCashHoldingCid] <- submitMulti (S.toList settlers) [publicParty] do
+  [investorCashHoldingCid] <- submitMulti (Set.toList settlers) [publicParty] do
     exerciseCmd result.batchCid Batch.Settle with actors = settlers
 
   -- Assert state
@@ -295,16 +295,16 @@ run = script do
 
   -- Create route provider
   routeProviderCid <- toInterfaceContractId <$> submit investor2 do
-    createCmd SingleCustodian with provider = investor2; observers = S.empty; custodian = bank
+    createCmd SingleCustodian with provider = investor2; observers = mempty; custodian = bank
 
   -- Create settlement factory
   settlementFactoryCid <- toInterfaceContractId <$> submit investor2 do
-    createCmd Factory with provider = investor2; observers = S.empty
+    createCmd Factory with provider = investor2; observers = mempty
 
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submit bank do
     createCmd Claim.Rule with
       provider = bank
-      claimers = S.fromList [bank, investor2]
+      claimers = Set.fromList [bank, investor2]
       settlers
       routeProviderCid
       settlementFactoryCid
@@ -331,15 +331,15 @@ run = script do
   -- Allocate instructions
   (investorInstrumentInstructionCid, _) <- submit investor2 do
     exerciseCmd investorInstrumentInstructionCid Instruction.Allocate with
-      actors = S.singleton investor2; allocation = Pledge investor2GenericHoldingCid
+      actors = Set.singleton investor2; allocation = Pledge investor2GenericHoldingCid
 
   -- Approve instructions
   investorInstrumentInstructionCid <- submit bank do
     exerciseCmd investorInstrumentInstructionCid Instruction.Approve with
-      actors = S.singleton bank; approval = DebitSender
+      actors = Set.singleton bank; approval = DebitSender
 
   -- Settle batch
-  [] <- submitMulti (S.toList settlers) [publicParty] do
+  [] <- submitMulti (Set.toList settlers) [publicParty] do
     exerciseCmd result.batchCid Batch.Settle with actors = settlers
 
   pure ()
@@ -349,4 +349,4 @@ setupParties = do
   [bank, broker, centralBank, investor1, investor2, settler, publicParty] <- createParties
     ["Bank", "Broker", "Central Bank", "Investor 1", "Investor 2", "Settler", "PublicParty"]
   pure TestParties with
-    bank; broker; centralBank; investor1; investor2; settlers = S.singleton settler; publicParty
+    bank; broker; centralBank; investor1; investor2; settlers = Set.singleton settler; publicParty

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardCash.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardCash.daml
@@ -6,8 +6,8 @@ module Daml.Finance.Instrument.Generic.Test.ForwardCash where
 import ContingentClaims.Core.Claim (at, one, scale, when)
 import ContingentClaims.Core.Observation (Observation(..))
 import DA.Date (addDays, toDateUTC)
-import DA.Map qualified as M (empty, fromList)
-import DA.Set qualified as S (empty, fromList, singleton, toList)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (fromList, singleton, toList)
 import DA.Time (time)
 import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Time.DateClock (dateToDateClockTime)
@@ -54,14 +54,14 @@ run : Script ()
 run = script do
   -- Create parties
   TestParties{..} <- setupParties
-  let pp = [("PublicParty", S.singleton publicParty)]
+  let pp = [("PublicParty", Set.singleton publicParty)]
 
   -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
 
   -- Create holding factory
   holdingFactory <- createHoldingFactory
-    Holding.Factory with provider = bank; id = Id "Holding Factory"; observers = M.fromList pp
+    Holding.Factory with provider = bank; id = Id "Holding Factory"; observers = Map.fromList pp
 
   -- Create accounts
   investorAccount <- Account.createAccount "Default Account" [] accountFactoryCid holdingFactory
@@ -75,10 +75,10 @@ run = script do
   -- Create observable
   let
     maturity = addDays (toDateUTC now) 1
-    observations = M.fromList [(dateToDateClockTime maturity, 200.0)]
+    observations = Map.fromList [(dateToDateClockTime maturity, 200.0)]
   observableCid <- toInterfaceContractId <$> submit broker do
     createCmd Observation with
-      provider = broker; id = Id "SPOT/AAPL"; observations; observers = M.empty
+      provider = broker; id = Id "SPOT/AAPL"; observations; observers = mempty
 
   -- Create and distribute a gerneric derivative
   let
@@ -92,13 +92,13 @@ run = script do
     Account.credit [publicParty] genericInstrument 1_000.0 investorAccount
 
   -- create clock update event
-  clockEventCid <- createClockUpdateEvent (S.singleton broker) maturity S.empty
+  clockEventCid <- createClockUpdateEvent (Set.singleton broker) maturity mempty
 
   -- Lifecycle derivative
   lifecycleRuleCid <- toInterfaceContractId @Lifecycle.I <$> submit bank do
     createCmd Lifecycle.Rule with
-      providers = S.singleton bank
-      observers= M.empty
+      providers = Set.singleton bank
+      observers = mempty
       lifecycler = broker
       id = Id "LifecycleRule"
       description = "Rule to lifecycle a generic instrument"
@@ -111,17 +111,17 @@ run = script do
 
   -- Create route provider
   routeProviderCid <- toInterfaceContractId <$> submit bank do
-    createCmd SingleCustodian with provider = bank; observers = S.empty; custodian = bank
+    createCmd SingleCustodian with provider = bank; observers = mempty; custodian = bank
 
   -- Create settlement factory
   settlementFactoryCid <- toInterfaceContractId <$> submit bank do
-    createCmd Factory with provider = bank; observers = S.empty
+    createCmd Factory with provider = bank; observers = mempty
 
   -- Claim effect
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submit bank do
     createCmd Claim.Rule with
       provider = bank
-      claimers = S.fromList [bank, investor]
+      claimers = Set.fromList [bank, investor]
       settlers
       routeProviderCid
       settlementFactoryCid
@@ -140,24 +140,24 @@ run = script do
   (investorInstrumentInstructionCid, _) <- submit investor do
     exerciseCmd investorInstrumentInstructionCid
       Instruction.Allocate with
-        actors = S.singleton investor; allocation = Pledge investorGenericHoldingCid
+        actors = Set.singleton investor; allocation = Pledge investorGenericHoldingCid
   (bankCashInstructionCid, _) <- submit bank do
     exerciseCmd bankCashInstructionCid Instruction.Allocate with
-      actors = S.singleton bank; allocation = CreditReceiver
+      actors = Set.singleton bank; allocation = CreditReceiver
 
   -- Approve instructions
   investorInstrumentInstructionCid <- submit bank do
     exerciseCmd investorInstrumentInstructionCid Instruction.Approve with
-      actors = S.singleton bank; approval = DebitSender
+      actors = Set.singleton bank; approval = DebitSender
   bankCashInstructionCid <- submit investor do
     exerciseCmd bankCashInstructionCid Instruction.Approve with
-      actors = S.singleton investor; approval = TakeDelivery investorAccount
+      actors = Set.singleton investor; approval = TakeDelivery investorAccount
 
   -- Set time
   setTime $ time maturity 0 0 0
 
   -- Settle batch
-  [investorCashHoldingCid] <- submitMulti (S.toList settlers) [publicParty] do
+  [investorCashHoldingCid] <- submitMulti (Set.toList settlers) [publicParty] do
     exerciseCmd result.batchCid Batch.Settle with actors = settlers
 
   -- Assert state
@@ -170,4 +170,4 @@ setupParties = do
   [bank, broker, centralBank, investor, settler, publicParty] <-
     createParties ["Bank", "Broker", "Central Bank", "Investor", "Settler", "PublicParty"]
   pure TestParties with
-    bank; broker; centralBank; investor; settlers = S.singleton settler; publicParty
+    bank; broker; centralBank; investor; settlers = Set.singleton settler; publicParty

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardPhysical.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/ForwardPhysical.daml
@@ -6,8 +6,8 @@ module Daml.Finance.Instrument.Generic.Test.ForwardPhysical where
 import ContingentClaims.Core.Claim (and, at, give, one, scale, when)
 import ContingentClaims.Core.Observation (Observation(..))
 import DA.Date (addDays, toDateUTC)
-import DA.Map qualified as M (empty, fromList)
-import DA.Set qualified as S (empty, singleton, toList)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (singleton, toList)
 import DA.Time (time)
 import Daml.Finance.Data.Time.DateClock (dateToDateClockTime)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
@@ -57,14 +57,14 @@ run : Script ()
 run = script do
   -- Create parties
   TestParties{..} <- setupParties
-  let pp = [("PublicParty", S.singleton publicParty)]
+  let pp = [("PublicParty", Set.singleton publicParty)]
 
   -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
 
   -- Create holding factory
   holdingFactory <- createHoldingFactory
-    Holding.Factory with provider = bank; id = Id "Holding Factory"; observers = M.fromList pp
+    Holding.Factory with provider = bank; id = Id "Holding Factory"; observers = Map.fromList pp
 
   -- Create accounts
   investorAccount <- Account.createAccount "Default Account" [] accountFactoryCid holdingFactory
@@ -88,19 +88,19 @@ run = script do
              $ scale (Const 200.0)
              $ give cashInstrumentDeliverable
   genericInstrument <- originateGeneric bank broker "FWD-AAPL" TransferableFungible
-    "Forward Contract" now claims [("PublicParty", S.singleton publicParty)] now
+    "Forward Contract" now claims [("PublicParty", Set.singleton publicParty)] now
   investorGenericHoldingCid <- Account.credit [publicParty] genericInstrument 1_000.0
     investorAccount
 
   -- create clock update event
-  clockEventCid <- createClockUpdateEvent (S.singleton broker) maturity S.empty
+  clockEventCid <- createClockUpdateEvent (Set.singleton broker) maturity mempty
 
   -- Lifecycle a generic derivative
   lifecycleRuleCid <- toInterfaceContractId @Lifecycle.I <$>
     submit bank do
       createCmd Lifecycle.Rule with
-        providers = S.singleton bank
-        observers= M.empty
+        providers = Set.singleton bank
+        observers = mempty
         lifecycler = broker
         id = Id "LifecycleRule"
         description = "Rule to lifecycle a generic instrument"
@@ -115,18 +115,18 @@ run = script do
   routeProviderCid <- toInterfaceContractId <$>
     submit investor do
       createCmd SingleCustodian with
-        provider = investor; observers = S.empty; custodian = bank
+        provider = investor; observers = mempty; custodian = bank
 
   -- Create settlement factory
   settlementFactoryCid <- toInterfaceContractId <$>
-    submit investor do createCmd Factory with provider = investor; observers = S.empty
+    submit investor do createCmd Factory with provider = investor; observers = mempty
 
   -- Claim effect
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$>
     submitMulti [bank, investor] [] do
       createCmd Rule with
         provider = bank
-        claimers = S.singleton investor
+        claimers = Set.singleton investor
         settlers
         routeProviderCid
         settlementFactoryCid
@@ -146,31 +146,31 @@ run = script do
   -- Allocate instructions
   (investorInstrumentInstructionCid, _) <- submit investor do
     exerciseCmd investorInstrumentInstructionCid Instruction.Allocate with
-      actors = S.singleton investor; allocation = Pledge investorGenericHoldingCid
+      actors = Set.singleton investor; allocation = Pledge investorGenericHoldingCid
   (bankEquityInstructionCid, _) <- submit bank do
     exerciseCmd bankEquityInstructionCid Instruction.Allocate with
-      actors = S.singleton bank; allocation = CreditReceiver
+      actors = Set.singleton bank; allocation = CreditReceiver
   (investorCashInstructionCid, _) <- submit investor do
     exerciseCmd investorCashInstructionCid Instruction.Allocate with
-      actors = S.singleton investor; allocation = Pledge investorCashHoldingCid
+      actors = Set.singleton investor; allocation = Pledge investorCashHoldingCid
 
   -- Approve instructions
   investorInstrumentInstructionCid <- submit bank do
     exerciseCmd investorInstrumentInstructionCid Instruction.Approve with
-      actors = S.singleton bank; approval = DebitSender
+      actors = Set.singleton bank; approval = DebitSender
   investorCashInstructionCid <- submit bank do
     exerciseCmd investorCashInstructionCid Instruction.Approve with
-      actors = S.singleton bank; approval = DebitSender
+      actors = Set.singleton bank; approval = DebitSender
   bankEquityInstructionCid <- submit investor do
     exerciseCmd bankEquityInstructionCid Instruction.Approve with
-      actors = S.singleton investor; approval = TakeDelivery investorAccount
+      actors = Set.singleton investor; approval = TakeDelivery investorAccount
 
   -- Set time
   setTime $ time maturity 0 0 0
 
   -- Settle batch
   [investorEquityHoldingCid] <-
-    submitMulti (S.toList settlers) [publicParty] do
+    submitMulti (Set.toList settlers) [publicParty] do
       exerciseCmd result.batchCid Batch.Settle with actors = settlers
 
   -- Assert state
@@ -183,4 +183,4 @@ setupParties = do
   [bank, broker, centralBank, equityIssuer, investor, settler, publicParty] <- createParties
     ["Bank", "Broker", "Central Bank", "Equity Issuer", "Investor", "Settler", "PublicParty"]
   pure TestParties with
-    bank; broker; centralBank; equityIssuer; investor; settlers = S.singleton settler; publicParty
+    bank; broker; centralBank; equityIssuer; investor; settlers = Set.singleton settler; publicParty

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
@@ -8,8 +8,9 @@ import ContingentClaims.Core.Observation (Observation(..))
 import DA.Assert ((===))
 import DA.Date (addDays, toDateUTC)
 import DA.Foldable qualified as F (forA_)
-import DA.Map qualified as M (Map, empty, fromList)
-import DA.Set qualified as S (empty, fromList, singleton, toList)
+import DA.Map (Map)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (fromList, singleton, toList)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
 import Daml.Finance.Instrument.Generic.Lifecycle.Rule qualified as Lifecycle (Rule(..))
 import Daml.Finance.Instrument.Generic.Test.Util (mapClaimToUTCTime, originateGeneric)
@@ -93,7 +94,7 @@ originateCashAndDefineRoute : TestParties -> Time -> Script (InstrumentKey, (Tex
 originateCashAndDefineRoute TestParties{bank, centralBank, csd, investor, issuer, publicParty}
   now = do
     let
-      pp = [("PublicParty", S.singleton publicParty)]
+      pp = [("PublicParty", Set.singleton publicParty)]
       label = "USD"
       -- CREATE_CASH_ROUTE_BEGIN
       {-
@@ -132,7 +133,7 @@ originateSecurityAndDefineRoute TestParties{bank, csd, investor, issuer, publicP
         , when (at expiry) $ scale (Const 1.0) $ one cashInstrument
         ]
     -- CREATE_CC_INSTRUMENT_VARIABLES_END
-    let pp = [("PublicParty", S.singleton publicParty)]
+    let pp = [("PublicParty", Set.singleton publicParty)]
     -- CREATE_CC_INSTRUMENT_BEGIN
     instrument <-
       originateGeneric csd issuer bondLabel TransferableFungible "Bond" now claims pp now
@@ -189,15 +190,15 @@ runIntermediatedLifecyclingNonAtomic = script do
 
   -- CREATE_CLOCK_FOR_BOND_LIFECYCLING_BEGIN
   -- create clock update event
-  clockEventCid <- createClockUpdateEvent (S.singleton issuer) today S.empty
+  clockEventCid <- createClockUpdateEvent (Set.singleton issuer) today mempty
   -- CREATE_CLOCK_FOR_BOND_LIFECYCLING_END
 
   -- LIFECYCLE_BOND_CREATE_RULE_BEGIN
   -- Create a lifecycle rule
   lifecycleRuleCid <- toInterfaceContractId @Lifecycle.I <$> submit csd do
     createCmd Lifecycle.Rule with
-      providers = S.singleton csd
-      observers= M.empty
+      providers = Set.singleton csd
+      observers = mempty
       lifecycler = issuer
       id = Id "LifecycleRule"
       description = "Rule to lifecycle a generic instrument"
@@ -213,7 +214,7 @@ runIntermediatedLifecyclingNonAtomic = script do
   -- LIFECYCLE_BOND_END
 
   -- Define settlement routes across intermediaries
-  let routes = M.fromList [cashRoute, bondRoute]
+  let routes = Map.fromList [cashRoute, bondRoute]
 
   -- LIFECYCLE_BOND_ISSUER_CSD_BEGIN
   -- Setup settlement contract between issuer and CSD
@@ -221,7 +222,7 @@ runIntermediatedLifecyclingNonAtomic = script do
   -- Issuer.
   Account.submitExerciseInterfaceByKeyCmd @Disclosure.I [csd] [] csdCashAccount
     Disclosure.AddObservers with
-      disclosers = S.singleton csd; observersToAdd = ("Issuer", S.singleton issuer)
+      disclosers = Set.singleton csd; observersToAdd = ("Issuer", Set.singleton issuer)
 
   settle1Cid <- submitMulti [csd, issuer] [] do
     createCmd EffectSettlementService with
@@ -243,18 +244,18 @@ runIntermediatedLifecyclingNonAtomic = script do
   -- investor claims effect against CSD
   routeProviderCid <- toInterfaceContractId <$> submit csd do
     createCmd IntermediatedStatic with
-      provider = csd; observers = S.singleton investor; paths = routes
+      provider = csd; observers = Set.singleton investor; paths = routes
 
   settlementFactoryCid <- submit csd do
     toInterfaceContractId <$> createCmd Factory with
-      provider = csd; observers = S.singleton investor
+      provider = csd; observers = Set.singleton investor
   -- LIFECYCLE_BOND_SETTLEMENT_FACTORY_END
 
   -- LIFECYCLE_BOND_CSD_INVESTOR_BEGIN
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submit csd do
     createCmd Claim.Rule with
       provider = csd
-      claimers = S.fromList [csd, investor]
+      claimers = Set.fromList [csd, investor]
       settlers
       routeProviderCid
       settlementFactoryCid
@@ -276,34 +277,34 @@ runIntermediatedLifecyclingNonAtomic = script do
   -- Allocate instructions
   (investorBondInstructionCid, _) <- submit investor do
     exerciseCmd investorBondInstructionCid Instruction.Allocate with
-      actors = S.singleton investor; allocation = Pledge investorBondHoldingCid
+      actors = Set.singleton investor; allocation = Pledge investorBondHoldingCid
   (csdBondInstructionCid, _) <- submit csd do
     exerciseCmd csdBondInstructionCid Instruction.Allocate with
-      actors = S.singleton csd; allocation = CreditReceiver
+      actors = Set.singleton csd; allocation = CreditReceiver
   (csdCashInstructionCid, _) <- submit csd do
     exerciseCmd csdCashInstructionCid Instruction.Allocate with
-      actors = S.singleton csd; allocation = Pledge cashHolding
+      actors = Set.singleton csd; allocation = Pledge cashHolding
   (bankCashInstructionCid, _) <- submit bank do
     exerciseCmd bankCashInstructionCid Instruction.Allocate with
-      actors = S.singleton bank; allocation = CreditReceiver
+      actors = Set.singleton bank; allocation = CreditReceiver
 
   -- Approve instructions
   investorBondInstructionCid <- submit csd do
     exerciseCmd investorBondInstructionCid Instruction.Approve with
-      actors = S.singleton csd; approval = DebitSender
+      actors = Set.singleton csd; approval = DebitSender
   csdBondInstructionCid <- submit investor do
     exerciseCmd csdBondInstructionCid Instruction.Approve with
-      actors = S.singleton investor; approval = TakeDelivery investorSecuritiesAccount
+      actors = Set.singleton investor; approval = TakeDelivery investorSecuritiesAccount
   csdCashInstructionCid <- submit bank do
     exerciseCmd csdCashInstructionCid Instruction.Approve with
-      actors = S.singleton bank; approval = TakeDelivery bankCashAccount
+      actors = Set.singleton bank; approval = TakeDelivery bankCashAccount
   bankCashInstructionCid <- submit investor do
     exerciseCmd bankCashInstructionCid Instruction.Approve with
-      actors = S.singleton investor; approval = TakeDelivery investorCashAccount
+      actors = Set.singleton investor; approval = TakeDelivery investorCashAccount
 
   -- Settle batch
   [investorCashHoldingCid, bankCashHoldingCid, investorBondHoldingCid] <-
-    submitMulti (S.toList settlers) [publicParty] do
+    submitMulti (Set.toList settlers) [publicParty] do
       exerciseCmd result.batchCid Batch.Settle with actors = settlers
   -- LIFECYCLE_BOND_ALLOCATE_APPROVE_SETTLE_END
 
@@ -347,13 +348,13 @@ runIntermediatedLifecyclingAtomic = script do
     Account.credit [publicParty] bondInstrument 1_000_000.0 investorSecuritiesAccount
 
   -- create clock update event
-  clockEventCid <- createClockUpdateEvent (S.singleton issuer) today S.empty
+  clockEventCid <- createClockUpdateEvent (Set.singleton issuer) today mempty
 
   -- Create a lifecycle rule
   lifecycleRuleCid <- toInterfaceContractId @Lifecycle.I <$> submit csd do
     createCmd Lifecycle.Rule with
-      providers = S.singleton csd
-      observers= M.empty
+      providers = Set.singleton csd
+      observers = mempty
       lifecycler = issuer
       id = Id "LifecycleRule"
       description = "Rule to lifecycle a generic instrument"
@@ -366,20 +367,20 @@ runIntermediatedLifecyclingAtomic = script do
       instrument = bondInstrument
 
   -- Define settlement routes from CSD to Investor and create batch factory
-  let routes = M.fromList [cashRoute, bondRoute]
+  let routes = Map.fromList [cashRoute, bondRoute]
 
   routeProviderCid <- toInterfaceContractId <$> submit csd do
     createCmd IntermediatedStatic with
-      provider = csd; observers = S.singleton investor; paths = routes
+      provider = csd; observers = Set.singleton investor; paths = routes
 
   settlementFactoryCid <- submit csd do
     toInterfaceContractId <$> createCmd Factory with
-      provider = csd; observers = S.singleton investor
+      provider = csd; observers = Set.singleton investor
 
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$> submit csd do
     createCmd Claim.Rule with
       provider = csd
-      claimers = S.singleton csd
+      claimers = Set.singleton csd
       settlers
       routeProviderCid
       settlementFactoryCid
@@ -425,53 +426,53 @@ runIntermediatedLifecyclingAtomic = script do
   -- Allocate instructions
   (csdBondInstructionCid1, _) <- submit csd do
     exerciseCmd csdBondInstructionCid1 Instruction.Allocate with
-      actors = S.singleton csd; allocation = Pledge csdBondHoldingCid
+      actors = Set.singleton csd; allocation = Pledge csdBondHoldingCid
   (issuerBondInstructionCid, _) <- submit issuer do
     exerciseCmd issuerBondInstructionCid Instruction.Allocate with
-      actors = S.singleton issuer; allocation = CreditReceiver
+      actors = Set.singleton issuer; allocation = CreditReceiver
   (issuerCashInstructionCid, _) <- submit issuer do
     exerciseCmd issuerCashInstructionCid Instruction.Allocate with
-      actors = S.singleton issuer; allocation = Pledge issuerCashHoldingCid
+      actors = Set.singleton issuer; allocation = Pledge issuerCashHoldingCid
   (investorBondInstructionCid, _) <- submit investor do
     exerciseCmd investorBondInstructionCid Instruction.Allocate with
-      actors = S.singleton investor; allocation = Pledge investorBondHoldingCid
+      actors = Set.singleton investor; allocation = Pledge investorBondHoldingCid
   (csdBondInstructionCid2, _) <- submit csd do
     exerciseCmd csdBondInstructionCid2 Instruction.Allocate with
-      actors = S.singleton csd; allocation = CreditReceiver
+      actors = Set.singleton csd; allocation = CreditReceiver
   (csdCashInstructionCid, _) <- submit csd do
     exerciseCmd csdCashInstructionCid Instruction.Allocate with
-      actors = S.singleton csd
+      actors = Set.singleton csd
       allocation = PassThroughFrom (csdCashAccount, issuerCashInstructionKey)
   (bankCashInstructionCid, _) <- submit bank do
     exerciseCmd bankCashInstructionCid Instruction.Allocate with
-      actors = S.singleton bank; allocation = CreditReceiver
+      actors = Set.singleton bank; allocation = CreditReceiver
 
   -- Approve instructions
   csdBondInstructionCid1 <- submit issuer do
     exerciseCmd csdBondInstructionCid1 Instruction.Approve with
-      actors = S.singleton issuer; approval = DebitSender
+      actors = Set.singleton issuer; approval = DebitSender
   issuerBondInstructionCid <- submit csd do
     exerciseCmd issuerBondInstructionCid Instruction.Approve with
-      actors = S.singleton csd; approval = TakeDelivery csdAccountAtIssuer
+      actors = Set.singleton csd; approval = TakeDelivery csdAccountAtIssuer
   issuerCashInstructionCid <- submit csd do
     exerciseCmd issuerCashInstructionCid Instruction.Approve with
-      actors = S.singleton csd; approval = PassThroughTo (csdCashAccount, csdCashInstructionKey)
+      actors = Set.singleton csd; approval = PassThroughTo (csdCashAccount, csdCashInstructionKey)
   investorBondInstructionCid <- submit csd do
     exerciseCmd investorBondInstructionCid Instruction.Approve with
-      actors = S.singleton csd; approval = DebitSender
+      actors = Set.singleton csd; approval = DebitSender
   csdBondInstructionCid2 <- submit investor do
     exerciseCmd csdBondInstructionCid2 Instruction.Approve with
-      actors = S.singleton investor; approval = TakeDelivery investorSecuritiesAccount
+      actors = Set.singleton investor; approval = TakeDelivery investorSecuritiesAccount
   csdCashInstructionCid <- submit bank do
     exerciseCmd csdCashInstructionCid Instruction.Approve with
-      actors = S.singleton bank; approval = TakeDelivery bankCashAccount
+      actors = Set.singleton bank; approval = TakeDelivery bankCashAccount
   bankCashInstructionCid <- submit investor do
     exerciseCmd bankCashInstructionCid Instruction.Approve with
-      actors = S.singleton investor; approval = TakeDelivery investorCashAccount
+      actors = Set.singleton investor; approval = TakeDelivery investorCashAccount
 
   -- Settle batch
   [csdBondHoldingCid, investorBondHoldingCid, bankCashHoldingCid, investorCashHoldingCid] <-
-    submitMulti (S.toList settlers) [publicParty] do
+    submitMulti (Set.toList settlers) [publicParty] do
       exerciseCmd result.batchCid Batch.Settle with actors = settlers
 
   -- Assert state
@@ -501,7 +502,7 @@ template EffectSettlementService
     csdCashAccount : AccountKey
       -- ^ Cash account of CSD @ Central Bank. Needs to be disclosed to the Issuer (ideally as part
       --   of the creation of this contract).
-    settlementRoutes : M.Map Text Hierarchy
+    settlementRoutes : Map Text Hierarchy
   where
     signatory csd, issuer
 
@@ -544,13 +545,13 @@ template EffectSettlementService
 
         -- 1. csd claims effect against issuer
         routeProviderCid <- toInterfaceContractId <$> create IntermediatedStatic with
-          provider = csd; observers = S.empty; paths = settlementRoutes
-        settlementFactoryCid <- create Factory with provider = csd; observers = S.empty
+          provider = csd; observers = mempty; paths = settlementRoutes
+        settlementFactoryCid <- create Factory with provider = csd; observers = mempty
 
         lifecycleClaimRuleCid <- create Claim.Rule with
           provider = issuer
-          claimers = S.fromList [issuer, csd]
-          settlers = S.singleton csd
+          claimers = Set.fromList [issuer, csd]
+          settlers = Set.singleton csd
           routeProviderCid
           settlementFactoryCid = toInterfaceContractId settlementFactoryCid
           netInstructions = False
@@ -572,27 +573,30 @@ template EffectSettlementService
         -- Allocate instructions
         (csdInstrumentInstructionCid, _) <- exercise csdInstrumentInstructionCid
           Instruction.Allocate with
-            actors = S.singleton csd; allocation = Pledge instrumentHoldingCid
+            actors = Set.singleton csd; allocation = Pledge instrumentHoldingCid
         (issuerCashInstructionCouponCid, _) <- exercise issuerCashInstructionCouponCid
-          Instruction.Allocate with actors = S.singleton issuer; allocation = Pledge cashHoldingCid
+          Instruction.Allocate with
+            actors = Set.singleton issuer; allocation = Pledge cashHoldingCid
         (issuerInstrumentInstructionCid, _) <- exercise issuerInstrumentInstructionCid
-          Instruction.Allocate with actors = S.singleton issuer; allocation = CreditReceiver
+          Instruction.Allocate with actors = Set.singleton issuer; allocation = CreditReceiver
 
         -- Approve instructions
         csdInstrumentInstructionCid <- exercise csdInstrumentInstructionCid
-          Instruction.Approve with actors = S.singleton issuer; approval = DebitSender
+          Instruction.Approve with
+            actors = Set.singleton issuer; approval = DebitSender
         issuerCashInstructionCouponCid <- exercise issuerCashInstructionCouponCid
-          Instruction.Approve with actors = S.singleton csd; approval = TakeDelivery csdCashAccount
+          Instruction.Approve with
+            actors = Set.singleton csd; approval = TakeDelivery csdCashAccount
         issuerInstrumentInstructionCid <- exercise issuerInstrumentInstructionCid
           Instruction.Approve with
-            actors = S.singleton csd; approval = TakeDelivery securitiesAccount
+            actors = Set.singleton csd; approval = TakeDelivery securitiesAccount
 
         -- Settle batch
         [newInstrumentHoldingCid, investorCashHoldingCouponCid] <-
-          exercise result.batchCid Batch.Settle with actors = S.singleton csd
+          exercise result.batchCid Batch.Settle with actors = Set.singleton csd
 
         -- 2. create effect to be used by investors
-        newEffectCid <- exercise effectCid Effect.SetProviders with newProviders = S.singleton csd
+        newEffectCid <- exercise effectCid Effect.SetProviders with newProviders = Set.singleton csd
 
         pure (newEffectCid, Some newInstrumentHoldingCid, [investorCashHoldingCouponCid])
 
@@ -602,7 +606,7 @@ setupParties = do
   [bank, centralBank, csd, issuer, investor, settler, publicParty] <-
     createParties ["Bank", "CentralBank", "CSD", "Issuer", "Investor", "Settler", "PublicParty"]
   pure TestParties with
-    bank; centralBank; csd; issuer; investor; settlers = S.singleton settler; publicParty
+    bank; centralBank; csd; issuer; investor; settlers = Set.singleton settler; publicParty
 
 -- | HIDE
 -- Setup a set of accounts.
@@ -615,7 +619,7 @@ setupAccounts description custodian publicParty owners = do
     Holding.Factory with
       provider = custodian
       id = Id "Holding Factory"
-      observers = M.fromList [("PublicParty", S.singleton publicParty)]
+      observers = Map.fromList [("PublicParty", Set.singleton publicParty)]
   -- Create accounts
   forA owners $ Account.createAccount description [] accountFactoryCid holdingFactory []
     Account.Owner custodian

--- a/src/test/daml/Daml/Finance/Instrument/Generic/Test/ReverseConvertible.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Generic/Test/ReverseConvertible.daml
@@ -7,8 +7,8 @@ import ContingentClaims.Core.Claim (Inequality(..), at, cond, one, scale, when)
 import ContingentClaims.Core.Observation (Observation(..))
 import DA.Assert ((===))
 import DA.Date (Month(..), date)
-import DA.Map qualified as M (empty, fromList)
-import DA.Set qualified as S (empty, singleton, toList)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (singleton, toList)
 import DA.Time (time)
 import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Time.DateClock (dateToDateClockTime)
@@ -70,14 +70,14 @@ data TestParties = TestParties
 run : Script ()
 run = script do
   TestParties{..} <- setupParties
-  let pp = [("PublicParty", S.singleton publicParty)]
+  let pp = [("PublicParty", Set.singleton publicParty)]
 
   -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
 
   -- Create holding factory
   holdingFactory <- createHoldingFactory
-    Holding.Factory with provider = bank; id = Id "Holding Factory"; observers = M.fromList pp
+    Holding.Factory with provider = bank; id = Id "Holding Factory"; observers = Map.fromList pp
 
   -- Create accounts
   investorAccount <- Account.createAccount "Default Account" [] accountFactoryCid holdingFactory
@@ -109,25 +109,25 @@ run = script do
              $ cond autoExerciseCondition exercised notExercised
 
   genericInstrument <- originateGeneric bank broker "RC-EURGBP" TransferableFungible
-    "Reverse Convertible" now claims [("PublicParty", S.singleton publicParty)] now
+    "Reverse Convertible" now claims [("PublicParty", Set.singleton publicParty)] now
   investorGenericHoldingCid <- Account.credit [publicParty] genericInstrument 1_000.0
     investorAccount
 
   -- create clock update event
-  clockEventCid <- createClockUpdateEvent (S.singleton broker) maturity S.empty
+  clockEventCid <- createClockUpdateEvent (Set.singleton broker) maturity mempty
 
   -- Create observable
-  let observations = M.fromList [(dateToDateClockTime expiry, 0.91)]
+  let observations = Map.fromList [(dateToDateClockTime expiry, 0.91)]
   observableCid <- toInterfaceContractId <$> submit broker do
     createCmd Observation with
-      provider = broker; id = Id fxObservable; observations; observers = M.empty
+      provider = broker; id = Id fxObservable; observations; observers = mempty
 
   -- Create lifecycle rule
   lifecycleRuleCid <- toInterfaceContractId @Lifecycle.I <$>
     submit bank do
       createCmd Lifecycle.Rule with
-        providers = S.singleton bank
-        observers= M.empty
+        providers = Set.singleton bank
+        observers = mempty
         lifecycler = broker
         id = Id "LifecycleRule"
         description = "Rule to lifecycle a generic instrument"
@@ -143,18 +143,18 @@ run = script do
   routeProviderCid <- toInterfaceContractId <$>
     submit investor do
       createCmd SingleCustodian with
-        provider = investor; observers = S.empty; custodian = bank
+        provider = investor; observers = mempty; custodian = bank
 
   -- Create settlement factory
   settlementFactoryCid <- toInterfaceContractId <$>
-    submit investor do createCmd Factory with provider = investor; observers = S.empty
+    submit investor do createCmd Factory with provider = investor; observers = mempty
 
   -- Create claim rule
   lifecycleClaimRuleCid <- toInterfaceContractId @Claim.I <$>
     submitMulti [bank, investor] [] do
       createCmd Rule with
         provider = bank
-        claimers = S.singleton investor
+        claimers = Set.singleton investor
         settlers
         routeProviderCid
         settlementFactoryCid
@@ -173,24 +173,24 @@ run = script do
   -- Allocate instructions
   (investorInstrumentInstructionCid, _) <- submit investor do
     exerciseCmd investorInstrumentInstructionCid Instruction.Allocate with
-      actors = S.singleton investor; allocation = Pledge investorGenericHoldingCid
+      actors = Set.singleton investor; allocation = Pledge investorGenericHoldingCid
   (bankEquityInstructionCid, _) <- submit bank do
     exerciseCmd bankEquityInstructionCid Instruction.Allocate with
-      actors = S.singleton bank; allocation = CreditReceiver
+      actors = Set.singleton bank; allocation = CreditReceiver
 
   -- Approve instructions
   investorInstrumentInstructionCid <- submit bank do
     exerciseCmd investorInstrumentInstructionCid Instruction.Approve with
-      actors = S.singleton bank; approval = DebitSender
+      actors = Set.singleton bank; approval = DebitSender
   bankEquityInstructionCid <- submit investor do
     exerciseCmd bankEquityInstructionCid Instruction.Approve with
-      actors = S.singleton investor; approval = TakeDelivery investorAccount
+      actors = Set.singleton investor; approval = TakeDelivery investorAccount
 
   -- Set time
   setTime $ time maturity 0 0 0
 
   -- Settle batch
-  [investorCashHoldingCid] <- submitMulti (S.toList settlers) [publicParty] do
+  [investorCashHoldingCid] <- submitMulti (Set.toList settlers) [publicParty] do
     exerciseCmd result.batchCid Batch.Settle with actors = settlers
 
   -- Verify result
@@ -207,5 +207,5 @@ setupParties = do
   [bank, broker, centralBankEU, centralBankUK, investor, settler, publicParty] <- createParties
     ["Bank", "Broker", "EU Central Bank", "UK Central Bank", "Investor", "Settler", "PublicParty"]
   pure TestParties with
-    bank; broker; centralBankEU; centralBankUK; investor; settlers = S.singleton settler
+    bank; broker; centralBankEU; centralBankUK; investor; settlers = Set.singleton settler
     publicParty

--- a/src/test/daml/Daml/Finance/Instrument/Option/Test/BarrierEuropeanCash.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Option/Test/BarrierEuropeanCash.daml
@@ -4,8 +4,8 @@
 module Daml.Finance.Instrument.Option.Test.BarrierEuropeanCash where
 
 import DA.Date (Month(..), date)
-import DA.Map qualified as M (empty, fromList)
-import DA.Set (singleton)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (singleton)
 import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Time.DateClock (dateToDateClockTime)
 import Daml.Finance.Instrument.Option.Test.Util (originateBarrierEuropeanCashOption)
@@ -26,7 +26,7 @@ run = script do
 
   -- Distribute commercial-bank cash
   now <- getTime
-  let observers = [("PublicParty", singleton publicParty)]
+  let observers = [("PublicParty", Set.singleton publicParty)]
   cashInstrument <- originate custodian issuer "USD" TransferableFungible "US Dollars" observers now
 
   -- Create and distribute option
@@ -45,7 +45,7 @@ run = script do
 
   -- CREATE_BARRIER_EUROPEAN_OPTION_OBSERVATIONS_BEGIN
   let
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 2019 May 13, 28.78)
       , (dateToDateClockTime $ date 2019 May 14, 49.78)
       , (dateToDateClockTime $ date 2019 May 15, 48.78)
@@ -56,7 +56,7 @@ run = script do
       ]
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id referenceAssetId; observations; observers = M.empty
+      provider = issuer; id = Id referenceAssetId; observations; observers = mempty
   -- CREATE_BARRIER_EUROPEAN_OPTION_OBSERVATIONS_END
 
   ------------------------------------

--- a/src/test/daml/Daml/Finance/Instrument/Option/Test/EuropeanCash.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Option/Test/EuropeanCash.daml
@@ -4,8 +4,8 @@
 module Daml.Finance.Instrument.Option.Test.EuropeanCash where
 
 import DA.Date (Month(..), date, subtractDays)
-import DA.Map qualified as M (empty, fromList)
-import DA.Set (singleton)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (singleton)
 import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Time.DateClock (dateToDateClockTime)
 import Daml.Finance.Instrument.Option.Test.Util (originateEuropeanCashOption)
@@ -26,7 +26,7 @@ run = script do
 
   -- Distribute commercial-bank cash
   now <- getTime
-  let observers = [("PublicParty", singleton publicParty)]
+  let observers = [("PublicParty", Set.singleton publicParty)]
   cashInstrument <- originate custodian issuer "USD" TransferableFungible "US Dollars" observers now
 
   -- Create and distribute option
@@ -41,10 +41,10 @@ run = script do
     shortOption = False
 
   -- CREATE_EUROPEAN_OPTION_OBSERVATIONS_BEGIN
-  let observations = M.fromList [(dateToDateClockTime $ date 2019 May 15, 48.78)]
+  let observations = Map.fromList [(dateToDateClockTime $ date 2019 May 15, 48.78)]
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id referenceAssetId; observations; observers = M.empty
+      provider = issuer; id = Id referenceAssetId; observations; observers = mempty
   -- CREATE_EUROPEAN_OPTION_OBSERVATIONS_END
 
   -- Issue instruments

--- a/src/test/daml/Daml/Finance/Instrument/Option/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Option/Test/Util.daml
@@ -3,8 +3,8 @@
 
 module Daml.Finance.Instrument.Option.Test.Util where
 
-import DA.Map qualified as M (empty, fromList)
-import DA.Set qualified as S (fromList, singleton)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (fromList, singleton)
 import Daml.Finance.Claims.Lifecycle.Rule qualified as Lifecycle (Rule(..))
 import Daml.Finance.Data.Time.DateClock (dateToDateClockTime)
 import Daml.Finance.Instrument.Option.BarrierEuropeanCash.Factory qualified as BarrierEuropeanCashOption (Factory(..))
@@ -39,7 +39,7 @@ originateEuropeanCashOption depository issuer label holdingStandard description
       submit issuer do
         createCmd EuropeanCashOption.Factory with
           provider = issuer
-          observers = M.empty
+          observers = mempty
 
   -- CREATE_EUROPEAN_OPTION_INSTRUMENT_BEGIN
     let
@@ -62,7 +62,7 @@ originateEuropeanCashOption depository issuer label holdingStandard description
           ownerReceives
           currency
           lastEventTimestamp
-        observers = M.fromList observers
+        observers = Map.fromList observers
   -- CREATE_EUROPEAN_OPTION_INSTRUMENT_END
     pure instrument
 
@@ -78,7 +78,7 @@ originateBarrierEuropeanCashOption depository issuer label holdingStandard descr
       submit issuer do
         createCmd BarrierEuropeanCashOption.Factory with
           provider = issuer
-          observers = M.empty
+          observers = mempty
 
     -- CREATE_BARRIER_EUROPEAN_OPTION_INSTRUMENT_BEGIN
     let
@@ -104,7 +104,7 @@ originateBarrierEuropeanCashOption depository issuer label holdingStandard descr
           ownerReceives
           currency
           lastEventTimestamp
-        observers = M.fromList observers
+        observers = Map.fromList observers
   -- CREATE_BARRIER_EUROPEAN_OPTION_INSTRUMENT_END
     pure instrument
 
@@ -120,7 +120,7 @@ originateEuropeanPhysicalOption depository issuer label holdingStandard descript
       submit issuer do
         createCmd EuropeanPhysicalOption.Factory with
           provider = issuer
-          observers = M.empty
+          observers = mempty
 
     -- CREATE_EUROPEAN_PHYSICAL_OPTION_INSTRUMENT_BEGIN
     let
@@ -144,7 +144,7 @@ originateEuropeanPhysicalOption depository issuer label holdingStandard descript
           currency
           lastEventTimestamp
           prevEvents = []
-        observers = M.fromList observers
+        observers = Map.fromList observers
   -- CREATE_EUROPEAN_PHYSICAL_OPTION_INSTRUMENT_END
     pure instrument
 
@@ -161,7 +161,7 @@ originateDividendOption depository issuer label holdingStandard description obse
       do
         createCmd DividendOption.Factory with
           provider = issuer
-          observers = M.empty
+          observers = mempty
 
   -- CREATE_DIVIDEND_OPTION_INSTRUMENT_BEGIN
     let
@@ -183,7 +183,7 @@ originateDividendOption depository issuer label holdingStandard description obse
           fxQuantity
           lastEventTimestamp
           prevEvents = []
-        observers = M.fromList observers
+        observers = Map.fromList observers
   -- CREATE_DIVIDEND_OPTION_INSTRUMENT_END
     pure instrument
 
@@ -198,13 +198,13 @@ electAndVerifyDivOptionPaymentEffects readAs today amount instrument issuer
       toInterfaceContractId @DividendOptionElectionFactory.I <$>
         createCmd DividendOptionElection.Factory with
           provider = issuer
-          observers = M.fromList [("Observers", S.fromList [elector, issuer])]
+          observers = Map.fromList [("Observers", Set.fromList [elector, issuer])]
 
     -- Create a lifecycle rule
     lifecycleRuleCid <- toInterfaceContractId <$> submit issuer do
       createCmd Lifecycle.Rule with
-        providers = S.singleton issuer
-        observers = M.empty
+        providers = Set.singleton issuer
+        observers = mempty
         lifecycler = issuer
         id = Id "LifecycleRule"
         description = "Rule to lifecycle a generic instrument"
@@ -217,7 +217,7 @@ electAndVerifyDivOptionPaymentEffects readAs today amount instrument issuer
     electionCid <- submitMulti [elector] readAs
       do
         exerciseCmd electionFactoryCid DividendOptionElectionFactory.Create with
-          actors = S.singleton elector
+          actors = Set.singleton elector
           id = Id "election id"
           description
           claimType = electedTag
@@ -227,7 +227,7 @@ electAndVerifyDivOptionPaymentEffects readAs today amount instrument issuer
           counterparty
           instrument
           amount
-          observers = M.fromList [("Holders", S.fromList [issuer, elector, counterparty])]
+          observers = Map.fromList [("Holders", Set.fromList [issuer, elector, counterparty])]
           provider = issuer
 
     applyElectionAndVerify issuer readAs [] expectedConsumed expectedProduced electionCid

--- a/src/test/daml/Daml/Finance/Instrument/StructuredProduct/Test/BarrierReverseConvertible.daml
+++ b/src/test/daml/Daml/Finance/Instrument/StructuredProduct/Test/BarrierReverseConvertible.daml
@@ -4,8 +4,8 @@
 module Daml.Finance.Instrument.StructuredProduct.Test.BarrierReverseConvertible where
 
 import DA.Date (DayOfWeek(..), Month(..), date)
-import DA.Map qualified as M (empty, fromList)
-import DA.Set qualified as S (singleton)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (singleton)
 import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Reference.HolidayCalendar (HolidayCalendar(..))
 import Daml.Finance.Data.Time.DateClock (dateToDateClockTime)
@@ -28,11 +28,11 @@ run = script do
     createParties ["Custodian", "Issuer", "Calendar Data Provider", "PublicParty"]
 
   -- Account and holding factory
-  let pp = [("FactoryProvider", S.singleton publicParty)]
+  let pp = [("FactoryProvider", Set.singleton publicParty)]
 
   -- Distribute commercial-bank cash
   now <- getTime
-  let observers = [("PublicParty", S.singleton publicParty)]
+  let observers = [("PublicParty", Set.singleton publicParty)]
   cashInstrument <- originate custodian issuer "USD" TransferableFungible "US Dollars" observers now
 
   -- Create and distribute option
@@ -66,7 +66,7 @@ run = script do
 
   -- CREATE_BARRIER_REVERSE_CONVERTIBLE_OBSERVATIONS_BEGIN
   let
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 2019 Feb 13, 28.78)
       , (dateToDateClockTime $ date 2019 Feb 15, 39.78)
       , (dateToDateClockTime $ date 2019 May 15, 38.78)
@@ -75,7 +75,7 @@ run = script do
       ]
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id referenceAssetId; observations; observers = M.empty
+      provider = issuer; id = Id referenceAssetId; observations; observers = mempty
   -- CREATE_BARRIER_REVERSE_CONVERTIBLE_OBSERVATIONS_END
 
   -- A reference data provider publishes the holiday calendar on the ledger
@@ -83,7 +83,7 @@ run = script do
     createCmd HolidayCalendar with
       provider = calendarDataProvider
       calendar
-      observers = M.fromList pp
+      observers = Map.fromList pp
 
   --------------------------------
   -- 1. BRC with barrier event  --

--- a/src/test/daml/Daml/Finance/Instrument/StructuredProduct/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/StructuredProduct/Test/Util.daml
@@ -3,7 +3,7 @@
 
 module Daml.Finance.Instrument.StructuredProduct.Test.Util where
 
-import DA.Map qualified as M (empty, fromList)
+import DA.Map qualified as Map (fromList)
 import Daml.Finance.Instrument.StructuredProduct.BarrierReverseConvertible.Factory qualified as BarrierReverseConvertible (Factory(..))
 import Daml.Finance.Interface.Instrument.StructuredProduct.BarrierReverseConvertible.Factory qualified as BarrierReverseConvertibleFactory (Create(..), I(..))
 import Daml.Finance.Interface.Instrument.StructuredProduct.BarrierReverseConvertible.Types (BarrierReverseConvertible(..))
@@ -25,7 +25,7 @@ originateBarrierReverseConvertible depository issuer label holdingStandard descr
     brcFactoryCid <- toInterfaceContractId @BarrierReverseConvertibleFactory.I <$> submit issuer do
       createCmd BarrierReverseConvertible.Factory with
         provider = issuer
-        observers = M.empty
+        observers = mempty
 
   -- CREATE_BARRIER_REVERSE_CONVERTIBLE_INSTRUMENT_BEGIN
     let
@@ -55,6 +55,6 @@ originateBarrierReverseConvertible depository issuer label holdingStandard descr
           currency
           lastEventTimestamp
           prevEvents = []
-        observers = M.fromList observers
+        observers = Map.fromList observers
   -- CREATE_BARRIER_REVERSE_CONVERTIBLE_INSTRUMENT_END
     pure instrument

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Asset.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Asset.daml
@@ -4,8 +4,8 @@
 module Daml.Finance.Instrument.Swap.Test.Asset where
 
 import DA.Date (DayOfWeek(..), Month(..), addDays, date, subtractDays)
-import DA.Map qualified as M (empty, fromList)
-import DA.Set (singleton)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (singleton)
 import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Reference.HolidayCalendar (HolidayCalendar(..))
 import Daml.Finance.Data.Time.DateClock (dateToDateClockTime)
@@ -29,7 +29,7 @@ run = script do
 
   -- Distribute commercial-bank cash
   now <- getTime
-  let observers = [("PublicParty", singleton publicParty)]
+  let observers = [("PublicParty", Set.singleton publicParty)]
   cashInstrument <- originate custodian issuer "USD" TransferableFungible "US Dollars" observers now
 
   -- Create and distribute swap
@@ -47,7 +47,7 @@ run = script do
     dayCountConvention = Act360
     businessDayConvention = ModifiedFollowing
     -- CREATE_ASSET_SWAP_VARIABLES_END
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 2019 Jan 16, 43.54)
       , (dateToDateClockTime $ date 2019 Feb 15, 47.03)
       , (dateToDateClockTime $ date 2019 May 15, 48.78)
@@ -64,11 +64,11 @@ run = script do
     createCmd HolidayCalendar with
       provider = calendarDataProvider
       calendar
-      observers = M.fromList observers
+      observers = Map.fromList observers
 
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id referenceAssetId; observations; observers = M.empty
+      provider = issuer; id = Id referenceAssetId; observations; observers = mempty
 
   swapInstrument <- originateAssetSwap issuer issuer "SwapTest1" BaseHolding "Asset swap" observers
     now issueDate holidayCalendarIds calendarDataProvider firstPaymentDate maturityDate

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/CreditDefault.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/CreditDefault.daml
@@ -4,7 +4,7 @@
 module Daml.Finance.Instrument.Swap.Test.CreditDefault where
 
 import DA.Date (DayOfWeek(..), Month(..), addDays, date, subtractDays)
-import DA.Map qualified as M (empty, fromList)
+import DA.Map qualified as Map (fromList)
 import DA.Set (singleton)
 import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Reference.HolidayCalendar (HolidayCalendar(..))
@@ -66,13 +66,13 @@ runCreditEvent = script do
   setupCalendar parties
   let
     creditEventDate = date 2019 Mar 15
-    defaultProbabilityObservations = M.fromList
+    defaultProbabilityObservations = Map.fromList
       [ (dateToDateClockTime $ subtractDays firstPaymentDate 1, 0.2)
       , (dateToDateClockTime firstPaymentDate                 , 0.2)
       , (dateToDateClockTime $ addDays firstPaymentDate 1     , 0.2)
       , (dateToDateClockTime creditEventDate                  , 1.0) -- credit event
       ]
-    recoveryRateObservations = M.fromList
+    recoveryRateObservations = Map.fromList
       [(dateToDateClockTime creditEventDate, 0.6)]
 
   -- Create and distribute swap
@@ -81,11 +81,11 @@ runCreditEvent = script do
   observableDefaultProbabilityCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
       provider = issuer; id = Id defaultProbabilityReferenceId
-      observations = defaultProbabilityObservations; observers = M.empty
+      observations = defaultProbabilityObservations; observers = mempty
   observableRecoveryRateCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
       provider = issuer; id = Id recoveryRateReferenceId; observations = recoveryRateObservations
-      observers = M.empty
+      observers = mempty
   let observableCids = [observableDefaultProbabilityCid, observableRecoveryRateCid]
 
   -- One day before the first payment date: try to lifecycle and verify that there are no lifecycle
@@ -133,13 +133,13 @@ runCreditEventOnPaymentDate = script do
   setupCalendar parties
   let
     creditEventDate = maturityDate
-    defaultProbabilityObservations = M.fromList
+    defaultProbabilityObservations = Map.fromList
       [ (dateToDateClockTime $ subtractDays firstPaymentDate 1, 0.2)
       , (dateToDateClockTime firstPaymentDate                 , 0.2)
       , (dateToDateClockTime $ addDays firstPaymentDate 1     , 0.2)
       , (dateToDateClockTime creditEventDate                  , 1.0) -- credit event
       ]
-    recoveryRateObservations = M.fromList
+    recoveryRateObservations = Map.fromList
       [(dateToDateClockTime creditEventDate, 0.6)]
 
   -- Create and distribute swap
@@ -148,11 +148,11 @@ runCreditEventOnPaymentDate = script do
   observableDefaultProbabilityCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
       provider = issuer; id = Id defaultProbabilityReferenceId
-      observations = defaultProbabilityObservations; observers = M.empty
+      observations = defaultProbabilityObservations; observers = mempty
   observableRecoveryRateCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
       provider = issuer; id = Id recoveryRateReferenceId; observations = recoveryRateObservations
-      observers = M.empty
+      observers = mempty
   let observableCids = [observableDefaultProbabilityCid, observableRecoveryRateCid]
 
   -- First payment date: Lifecycle and verify the lifecycle effects for the fix payment.
@@ -195,7 +195,7 @@ runNoCreditEvent = script do
   -- Populate holiday calendar and observations.
   setupCalendar parties
   let
-    defaultProbabilityObservations = M.fromList
+    defaultProbabilityObservations = Map.fromList
       [ (dateToDateClockTime $ subtractDays firstPaymentDate 1, 0.2)
       , (dateToDateClockTime firstPaymentDate                 , 0.2)
       , (dateToDateClockTime $ addDays firstPaymentDate 1     , 0.2)
@@ -209,7 +209,7 @@ runNoCreditEvent = script do
   observableDefaultProbabilityCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
       provider = issuer; id = Id defaultProbabilityReferenceId
-      observations = defaultProbabilityObservations; observers = M.empty
+      observations = defaultProbabilityObservations; observers = mempty
   let observableCids = [observableDefaultProbabilityCid]
 
   -- One day before the first payment date: try to lifecycle and verify that there are no lifecycle
@@ -259,7 +259,7 @@ runCreditEventAfterMaturity = script do
   -- Populate holiday calendar and observations.
   setupCalendar parties
   let
-    defaultProbabilityObservations = M.fromList
+    defaultProbabilityObservations = Map.fromList
       [ (dateToDateClockTime firstPaymentDate, 0.2)
       , (dateToDateClockTime maturityDate, 0.2)
       , (dateToDateClockTime $ addDays maturityDate 1, 1.0) -- credit event
@@ -271,7 +271,7 @@ runCreditEventAfterMaturity = script do
   observableDefaultProbabilityCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
       provider = issuer; id = Id defaultProbabilityReferenceId
-      observations = defaultProbabilityObservations; observers = M.empty
+      observations = defaultProbabilityObservations; observers = mempty
   let observableCids = [observableDefaultProbabilityCid]
 
   -- First payment date: Lifecycle and verify the lifecycle effects for the fix payment.
@@ -321,7 +321,7 @@ setupCalendar TestParties{..} = do
     createCmd HolidayCalendar with
       provider = calendarDataProvider
       calendar = holidayCalendarData
-      observers = M.fromList pp
+      observers = Map.fromList pp
 
 -- | Setup cash instrument.
 setupCash : TestParties -> Time -> Script InstrumentKey

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Currency.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Currency.daml
@@ -4,7 +4,7 @@
 module Daml.Finance.Instrument.Swap.Test.Currency where
 
 import DA.Date (DayOfWeek(..), Month(..), addDays, date, subtractDays)
-import DA.Map qualified as M (fromList)
+import DA.Map qualified as Map (fromList)
 import DA.Set (singleton)
 import Daml.Finance.Data.Reference.HolidayCalendar (HolidayCalendar(..))
 import Daml.Finance.Instrument.Swap.Test.Util (originateCurrencySwap)
@@ -62,7 +62,7 @@ run = script do
     createCmd HolidayCalendar with
       provider = calendarDataProvider
       calendar
-      observers = M.fromList observers
+      observers = Map.fromList observers
 
   swapInstrument <- originateCurrencySwap issuer issuer "SwapTest1" BaseHolding "Currency swap"
     observers now issueDate holidayCalendarIds calendarDataProvider firstPaymentDate maturityDate

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Instrument.Swap.Test.Fpml where
 
 import DA.Assert ((===))
 import DA.Date (DayOfWeek(..), Month(..), addDays, date, subtractDays)
-import DA.Map qualified as M (empty, fromList)
+import DA.Map qualified as Map (fromList)
 import DA.Set (singleton)
 import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Reference.HolidayCalendar (HolidayCalendar(..))
@@ -48,7 +48,7 @@ run = script do
     paymentPeriodMultiplier = 3
     dayCountConvention = Act360
     businessDayConvention = ModifiedFollowing
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 2019 Jan 11, 0.0027406)
       , (dateToDateClockTime $ date 2019 Feb 13, 0.002035)
       ]
@@ -201,15 +201,15 @@ run = script do
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar
-      observers = M.fromList observers
+      observers = Map.fromList observers
   fixingCalendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar = fixingCal
-      observers = M.fromList observers
+      observers = Map.fromList observers
 
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id referenceRateId; observations; observers = M.empty
+      provider = issuer; id = Id referenceRateId; observations; observers = mempty
 
   swapInstrument <- originateFpmlSwap issuer issuer "SwapTest1" BaseHolding "Interest rate swap"
     observers now swapStreams calendarDataProvider currencies issuerPartyRef publicParty
@@ -271,11 +271,11 @@ runStubRateInterpolation = script do
     -- Use basis 1/1 in order to compare the interpolated rate calculation with the ISDA paper
     dayCountConvention = Basis1
     businessDayConvention = ModifiedFollowing
-    observationsLibor3M = M.fromList
+    observationsLibor3M = Map.fromList
       [ (dateToDateClockTime $ date 2022 Jan 06, 0.0023129)
       , (dateToDateClockTime $ date 2022 Mar 17, 0.002035)
       ]
-    observationsLibor1M = M.fromList
+    observationsLibor1M = Map.fromList
       [ (dateToDateClockTime $ date 2022 Jan 06, 0.0010414)
       , (dateToDateClockTime $ date 2022 Mar 17, 0.002035)
       ]
@@ -384,20 +384,20 @@ runStubRateInterpolation = script do
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar
-      observers = M.fromList observers
+      observers = Map.fromList observers
   fixingCalendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar = fixingCal
-      observers = M.fromList observers
+      observers = Map.fromList observers
 
   observableLibor3MCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
       provider = issuer; id = Id referenceRateId; observations=observationsLibor3M
-      observers = M.empty
+      observers = mempty
   observableLibor1MCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
       provider = issuer; id = Id referenceRateOneMonthId; observations=observationsLibor1M
-      observers = M.empty
+      observers = mempty
   let observableCids = [observableLibor3MCid, observableLibor1MCid]
 
   swapInstrument <- originateFpmlSwap issuer issuer "SwapTest1" BaseHolding "Interest rate swap"
@@ -448,13 +448,13 @@ runDualStubSampleTrade = script do
     -- CREATE_FPML_SWAP_VARIABLES_END
     secondRegularPeriodDate = date 2022 Dec 20
     thirdRegularPeriodDate = date 2023 Mar 20
-    observationsLibor3M = M.fromList
+    observationsLibor3M = Map.fromList
       [ (dateToDateClockTime $ date 2022 Sep 16, 0.013)
       , (dateToDateClockTime $ date 2022 Dec 16, 0.013)
       , (dateToDateClockTime $ date 2023 Mar 16, 0.013)
       , (dateToDateClockTime $ date 2023 Jun 16, 0.013)
       ]
-    observationsLibor1M = M.fromList [(dateToDateClockTime $ date 2023 Jun 16, 0.02)]
+    observationsLibor1M = Map.fromList [(dateToDateClockTime $ date 2023 Jun 16, 0.02)]
     calendar =
       HolidayCalendarData with
         id = "USD"
@@ -615,20 +615,20 @@ runDualStubSampleTrade = script do
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar
-      observers = M.fromList observers
+      observers = Map.fromList observers
   fixingCalendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar = fixingCal
-      observers = M.fromList observers
+      observers = Map.fromList observers
 
   observableLibor3MCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
       provider = issuer; id = Id referenceRateId; observations=observationsLibor3M
-      observers = M.empty
+      observers = mempty
   observableLibor1MCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
       provider = issuer; id = Id referenceRateOneMonthId; observations=observationsLibor1M
-      observers = M.empty
+      observers = mempty
   let observableCids = [observableLibor3MCid, observableLibor1MCid]
 
   swapInstrument <- originateFpmlSwap issuer issuer "SwapTest1" BaseHolding "Interest rate swap"
@@ -707,13 +707,13 @@ runSeparatePaymentFrequencySampleTrade = script do
     businessDayConvention = ModifiedFollowing
     issuerPartyRef = "Counterparty"
     clientPartyRef = "ExecutingParty"
-    observationsLibor6M = M.fromList
+    observationsLibor6M = Map.fromList
       [ (dateToDateClockTime $ date 2022 Oct 24, 0.01)
       , (dateToDateClockTime $ date 2023 Apr 24, 0.01)
       , (dateToDateClockTime $ date 2023 Oct 24, 0.01)
       ]
-    observationsLibor1M = M.fromList [(dateToDateClockTime $ date 2022 Oct 13, 0.02)]
-    observationsLibor1D = M.fromList [(dateToDateClockTime $ date 2022 Oct 13, 0.03)]
+    observationsLibor1M = Map.fromList [(dateToDateClockTime $ date 2022 Oct 13, 0.02)]
+    observationsLibor1D = Map.fromList [(dateToDateClockTime $ date 2022 Oct 13, 0.03)]
     holidayCalendarIds = ["USD"]
     calendar =
       HolidayCalendarData with
@@ -870,24 +870,24 @@ runSeparatePaymentFrequencySampleTrade = script do
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar
-      observers = M.fromList observers
+      observers = Map.fromList observers
   fixingCalendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar = fixingCal
-      observers = M.fromList observers
+      observers = Map.fromList observers
 
   observableLibor6MCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
       provider = issuer; id = Id referenceRateId; observations = observationsLibor6M
-      observers = M.empty
+      observers = mempty
   observableLibor1MCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
       provider = issuer; id = Id referenceRate1MId; observations=observationsLibor1M
-      observers = M.empty
+      observers = mempty
   observableLibor1DCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
       provider = issuer; id = Id referenceRate1DId; observations=observationsLibor1D
-      observers = M.empty
+      observers = mempty
   let observableCids = [observableLibor6MCid, observableLibor1MCid, observableLibor1DCid]
 
   swapInstrument <- originateFpmlSwap issuer issuer "SwapTest1" BaseHolding "Interest rate swap"
@@ -970,21 +970,21 @@ runCurrencySwapSampleTrade = script do
     businessDayConvention = ModifiedFollowing
     issuerPartyRef = "Counterparty"
     clientPartyRef = "ExecutingParty"
-    observationsLibor3M = M.fromList
+    observationsLibor3M = Map.fromList
       [ (dateToDateClockTime $ date 2022 Oct 13, 0.02)
       , (dateToDateClockTime $ date 2023 Jan 13, 0.02)
       , (dateToDateClockTime $ date 2023 Apr 13, 0.02)
       , (dateToDateClockTime $ date 2023 Jul 13, 0.02)
       , (dateToDateClockTime $ date 2023 Oct 13, 0.02)
       ]
-    observationsEuribor3M = M.fromList
+    observationsEuribor3M = Map.fromList
       [ (dateToDateClockTime $ date 2022 Oct 13, 0.01)
       , (dateToDateClockTime $ date 2023 Jan 13, 0.01)
       , (dateToDateClockTime $ date 2023 Apr 13, 0.01)
       , (dateToDateClockTime $ date 2023 Jul 13, 0.01)
       , (dateToDateClockTime $ date 2023 Oct 13, 0.01)
       ]
-    observationsFx = M.fromList
+    observationsFx = Map.fromList
       [ (dateToDateClockTime $ date 2022 Oct 13, 1.02)
       , (dateToDateClockTime $ date 2023 Jan 13, 1.03)
       , (dateToDateClockTime $ date 2023 Apr 13, 1.05)
@@ -1172,24 +1172,24 @@ runCurrencySwapSampleTrade = script do
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar
-      observers = M.fromList observers
+      observers = Map.fromList observers
   fixingCalendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar = fixingCal
-      observers = M.fromList observers
+      observers = Map.fromList observers
 
   observableLibor3MCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
       provider = issuer; id = Id referenceRateUsdId; observations=observationsLibor3M
-      observers = M.empty
+      observers = mempty
   observableEuribor3MCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
       provider = issuer; id = Id referenceRateEurId; observations=observationsEuribor3M
-      observers = M.empty
+      observers = mempty
   observableFxCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
       provider = issuer; id = Id referenceRateFxId; observations=observationsFx
-      observers = M.empty
+      observers = mempty
   let observableCids = [observableLibor3MCid, observableEuribor3MCid, observableFxCid]
 
   swapInstrument <- originateFpmlSwap issuer issuer "SwapTest1" BaseHolding "Interest rate swap"
@@ -1275,15 +1275,15 @@ runAmortizingNotionalSampleTrade = script do
     clientPartyRef = "ExecutingParty"
     secondRegularPeriodDate = date 2022 Oct 20
     thirdRegularPeriodDate = date 2027 Oct 20
-    observationsLibor3M = M.fromList $
+    observationsLibor3M = Map.fromList $
       [ (dateToDateClockTime $ date 2022 Oct 18, 0.01)
       , (dateToDateClockTime $ date 2023 Jan 18, 0.01)
       , (dateToDateClockTime $ date 2023 Apr 18, 0.01)
       , (dateToDateClockTime $ date 2023 Jul 18, 0.01)
       , (dateToDateClockTime $ date 2023 Oct 18, 0.01)
       ]
-    observationsLibor1M = M.fromList [(dateToDateClockTime $ date 2022 Oct 13, 0.02)]
-    observationsLibor1D = M.fromList [(dateToDateClockTime $ date 2022 Oct 13, 0.03)]
+    observationsLibor1M = Map.fromList [(dateToDateClockTime $ date 2022 Oct 13, 0.02)]
+    observationsLibor1D = Map.fromList [(dateToDateClockTime $ date 2022 Oct 13, 0.03)]
     calendar =
       HolidayCalendarData with
         id = "USD"
@@ -1483,24 +1483,24 @@ runAmortizingNotionalSampleTrade = script do
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar
-      observers = M.fromList observers
+      observers = Map.fromList observers
   fixingCalendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar = fixingCal
-      observers = M.fromList observers
+      observers = Map.fromList observers
 
   observableLibor3MCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
       provider = issuer; id = Id referenceRateId; observations=observationsLibor3M
-      observers = M.empty
+      observers = mempty
   observableLibor1MCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
       provider = issuer; id = Id referenceRate1MId; observations=observationsLibor1M
-      observers = M.empty
+      observers = mempty
   observableLibor1DCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
       provider = issuer; id = Id referenceRate1DId; observations=observationsLibor1D
-      observers = M.empty
+      observers = mempty
   let observableCids = [observableLibor3MCid, observableLibor1MCid, observableLibor1DCid]
 
   swapInstrument <- originateFpmlSwap issuer issuer "SwapTest1" BaseHolding "Interest rate swap"
@@ -1560,7 +1560,7 @@ runFpml1 = script do
     paymentPeriodFixed = Regular Y
     paymentPeriodMultiplierFixed = 1
     businessDayConvention = ModifiedFollowing
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 1994 Dec 12, 0.061)
       , (dateToDateClockTime $ date 1995 Jun 12, 0.063)
       , (dateToDateClockTime $ date 1995 Dec 12, 0.065)
@@ -1714,15 +1714,15 @@ runFpml1 = script do
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar
-      observers = M.fromList observers
+      observers = Map.fromList observers
   fixingCalendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar = fixingCal
-      observers = M.fromList observers
+      observers = Map.fromList observers
 
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id referenceRateId; observations; observers = M.empty
+      provider = issuer; id = Id referenceRateId; observations; observers = mempty
   let observableCids = [observableCid]
 
   swapInstrument <- originateFpmlSwap issuer issuer "SwapTest1" BaseHolding "Interest rate swap"
@@ -1778,16 +1778,16 @@ runFpml2 = script do
     paymentPeriodFixed = Regular Y
     paymentPeriodMultiplierFixed = 1
     businessDayConvention = ModifiedFollowing
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 1995 Jun 12, 0.063)
       , (dateToDateClockTime $ date 1995 Dec 12, 0.065)
       , (dateToDateClockTime $ date 1996 Jun 12, 0.065)
       , (dateToDateClockTime $ date 1996 Dec 12, 0.065)
       ]
-    observations4M = M.fromList
+    observations4M = Map.fromList
       [ (dateToDateClockTime $ date 1995 Jan 12, 0.050)
       ]
-    observations5M = M.fromList
+    observations5M = Map.fromList
       [ (dateToDateClockTime $ date 1995 Jan 12, 0.060)
       ]
     primaryBusinessCenters = ["DEFR"]
@@ -1959,21 +1959,21 @@ runFpml2 = script do
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar
-      observers = M.fromList observers
+      observers = Map.fromList observers
   fixingCalendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar = fixingCal
-      observers = M.fromList observers
+      observers = Map.fromList observers
 
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id referenceRateId; observations; observers = M.empty
+      provider = issuer; id = Id referenceRateId; observations; observers = mempty
   observable4MCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id referenceRate4MId; observations=observations4M; observers = M.empty
+      provider = issuer; id = Id referenceRate4MId; observations=observations4M; observers = mempty
   observable5MCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id referenceRate5MId; observations=observations5M; observers = M.empty
+      provider = issuer; id = Id referenceRate5MId; observations=observations5M; observers = mempty
   let observableCids = [observableCid, observable4MCid, observable5MCid]
 
   swapInstrument <- originateFpmlSwap issuer issuer "SwapTest1" BaseHolding "Interest rate swap"
@@ -2045,7 +2045,7 @@ runFpml3 = script do
     calcPeriodFloat = Regular M
     calcPeriodMultiplierFloat = 3
     businessDayConvention = ModifiedFollowing
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 2000 Apr 25, 0.063)
       , (dateToDateClockTime $ date 2000 Jul 25, 0.065)
       , (dateToDateClockTime $ date 2000 Oct 25, 0.067)
@@ -2212,15 +2212,15 @@ runFpml3 = script do
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar
-      observers = M.fromList observers
+      observers = Map.fromList observers
   fixingCalendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar = fixingCal
-      observers = M.fromList observers
+      observers = Map.fromList observers
 
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id referenceRateId; observations; observers = M.empty
+      provider = issuer; id = Id referenceRateId; observations; observers = mempty
   let observableCids = [observableCid]
 
   swapInstrument <- originateFpmlSwap issuer issuer "SwapTest1" BaseHolding "Interest rate swap"
@@ -2288,7 +2288,7 @@ runCompounding = script do
     calcPeriodFloat = Regular M
     calcPeriodMultiplierFloat = 1
     businessDayConvention = ModifiedFollowing
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 2022 Apr 25, 0.040)
       , (dateToDateClockTime $ date 2022 May 25, 0.045)
       , (dateToDateClockTime $ date 2022 Jun 23, 0.050)
@@ -2389,15 +2389,15 @@ runCompounding = script do
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar
-      observers = M.fromList observers
+      observers = Map.fromList observers
   fixingCalendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar = fixingCal
-      observers = M.fromList observers
+      observers = Map.fromList observers
 
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id referenceRateId; observations; observers = M.empty
+      provider = issuer; id = Id referenceRateId; observations; observers = mempty
   let observableCids = [observableCid]
 
   swapInstrument <- originateFpmlSwap issuer issuer "SwapTest1" BaseHolding "Interest rate swap"
@@ -2438,7 +2438,7 @@ runCompoundingFlat = script do
     calcPeriodFloat = Regular M
     calcPeriodMultiplierFloat = 1
     businessDayConvention = ModifiedFollowing
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 2022 Apr 25, 0.040)
       , (dateToDateClockTime $ date 2022 May 25, 0.045)
       , (dateToDateClockTime $ date 2022 Jun 23, 0.050)
@@ -2539,15 +2539,15 @@ runCompoundingFlat = script do
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar
-      observers = M.fromList observers
+      observers = Map.fromList observers
   fixingCalendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar = fixingCal
-      observers = M.fromList observers
+      observers = Map.fromList observers
 
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id referenceRateId; observations; observers = M.empty
+      provider = issuer; id = Id referenceRateId; observations; observers = mempty
   let observableCids = [observableCid]
 
   swapInstrument <- originateFpmlSwap issuer issuer "SwapTest1" BaseHolding "Interest rate swap"
@@ -2589,7 +2589,7 @@ runCompoundingSpreadSimple = script do
     calcPeriodFloat = Regular M
     calcPeriodMultiplierFloat = 1
     businessDayConvention = ModifiedFollowing
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 2022 Apr 25, 0.040)
       , (dateToDateClockTime $ date 2022 May 25, 0.045)
       , (dateToDateClockTime $ date 2022 Jun 23, 0.050)
@@ -2690,15 +2690,15 @@ runCompoundingSpreadSimple = script do
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar
-      observers = M.fromList observers
+      observers = Map.fromList observers
   fixingCalendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar = fixingCal
-      observers = M.fromList observers
+      observers = Map.fromList observers
 
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id referenceRateId; observations; observers = M.empty
+      provider = issuer; id = Id referenceRateId; observations; observers = mempty
   let observableCids = [observableCid]
 
   swapInstrument <- originateFpmlSwap issuer issuer "SwapTest1" BaseHolding "Interest rate swap"
@@ -2740,7 +2740,7 @@ runFpml4 = script do
     calcPeriodFloat = Regular M
     calcPeriodMultiplierFloat = 3
     businessDayConvention = ModifiedFollowing
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 2000 Jul 25, 0.063)
       , (dateToDateClockTime $ date 2000 Oct 25, 0.065)
       , (dateToDateClockTime $ date 2001 Jan 25, 0.067)
@@ -2898,15 +2898,15 @@ runFpml4 = script do
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar
-      observers = M.fromList observers
+      observers = Map.fromList observers
   fixingCalendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar = fixingCal
-      observers = M.fromList observers
+      observers = Map.fromList observers
 
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id referenceRateId; observations; observers = M.empty
+      provider = issuer; id = Id referenceRateId; observations; observers = mempty
   let observableCids = [observableCid]
 
   swapInstrument <- originateFpmlSwap issuer issuer "SwapTest1" BaseHolding "Interest rate swap"
@@ -2988,7 +2988,7 @@ runFpml4a = script do
     calcPeriodFloat = Regular M
     calcPeriodMultiplierFloat = 3
     businessDayConvention = ModifiedFollowing
-    observations = M.fromList
+    observations = Map.fromList
       -- Data for the SOFR Index (used for efficient computation of USD-SOFR-COMPOUND)
       [ (dateToDateClockTime $ date 2018 Nov 15, 1.01213)
       , (dateToDateClockTime $ date 2019 Feb 15, 1.01836)
@@ -3156,15 +3156,15 @@ runFpml4a = script do
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar
-      observers = M.fromList observers
+      observers = Map.fromList observers
   fixingCalendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar = fixingCal
-      observers = M.fromList observers
+      observers = Map.fromList observers
 
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id referenceRateId; observations; observers = M.empty
+      provider = issuer; id = Id referenceRateId; observations; observers = mempty
   let observableCids = [observableCid]
 
   swapInstrument <- originateFpmlSwap issuer issuer "SwapTest1" BaseHolding "Interest rate swap"
@@ -3236,7 +3236,7 @@ runFpml5 = script do
     calcPeriodFloat = Regular M
     calcPeriodMultiplierFloat = 6
     businessDayConvention = Following
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 2000 Oct 03, 0.063)
       , (dateToDateClockTime $ date 2001 Apr 03, 0.069)
       , (dateToDateClockTime $ date 2001 Oct 03, 0.073)
@@ -3246,7 +3246,7 @@ runFpml5 = script do
       , (dateToDateClockTime $ date 2003 Oct 02, 0.075)
       , (dateToDateClockTime $ date 2004 Apr 01, 0.075)
       ]
-    stubObservations = M.fromList
+    stubObservations = Map.fromList
       [ (dateToDateClockTime $ date 2004 Oct 01, 0.077) ]
     primaryBusinessCenters = ["EUTA"]
     calendar =
@@ -3410,15 +3410,15 @@ runFpml5 = script do
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar
-      observers = M.fromList observers
+      observers = Map.fromList observers
 
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id referenceRateId; observations; observers = M.empty
+      provider = issuer; id = Id referenceRateId; observations; observers = mempty
   stubObservableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
       provider = issuer; id = Id stubReferenceRateId; observations = stubObservations;
-        observers = M.empty
+        observers = mempty
   let observableCids = [observableCid, stubObservableCid]
 
   swapInstrument <- originateFpmlSwap issuer issuer "SwapTest1" BaseHolding "Interest rate swap"
@@ -3481,7 +3481,7 @@ runFpml6 = script do
     calcPeriodFloat = Regular M
     calcPeriodMultiplierFloat = 6
     businessDayConvention = ModifiedFollowing
-    observationsLibor3M = M.fromList
+    observationsLibor3M = Map.fromList
       [ (dateToDateClockTime $ date 1994 Dec 12, 0.047)
       , (dateToDateClockTime $ date 1995 Jun 12, 0.060)
       , (dateToDateClockTime $ date 1995 Dec 12, 0.062)
@@ -3650,20 +3650,20 @@ runFpml6 = script do
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar
-      observers = M.fromList observers
+      observers = Map.fromList observers
   jpCalendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar = jpCal
-      observers = M.fromList observers
+      observers = Map.fromList observers
   fixingCalendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar = fixingCal
-      observers = M.fromList observers
+      observers = Map.fromList observers
 
   observableLibor3MCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
       provider = issuer; id = Id referenceRateUsdId; observations=observationsLibor3M
-      observers = M.empty
+      observers = mempty
   let observableCids = [observableLibor3MCid]
 
   swapInstrument <- originateFpmlSwap issuer issuer "SwapTest1" BaseHolding "Interest rate swap"
@@ -3739,7 +3739,7 @@ runFpml7 = script do
     calcPeriod = T
     calcPeriodMultiplier = 1
     businessDayConvention = ModifiedFollowing
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 2001 Jan 25, 100.0)
       , (dateToDateClockTime $ date 2001 Apr 26, 101.25)
       ]
@@ -3887,11 +3887,11 @@ runFpml7 = script do
   calendarCid <- submit calendarDataProvider do
     createCmd HolidayCalendar with
       provider = calendarDataProvider; calendar
-      observers = M.fromList observers
+      observers = Map.fromList observers
 
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id referenceRateId; observations; observers = M.empty
+      provider = issuer; id = Id referenceRateId; observations; observers = mempty
   let observableCids = [observableCid]
 
   swapInstrument <- originateFpmlSwap issuer issuer "SwapTest1" BaseHolding "Interest rate swap"

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/InterestRate.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/InterestRate.daml
@@ -4,7 +4,7 @@
 module Daml.Finance.Instrument.Swap.Test.InterestRate where
 
 import DA.Date (DayOfWeek(..), Month(..), addDays, date, subtractDays)
-import DA.Map qualified as M (empty, fromList)
+import DA.Map qualified as Map (fromList)
 import DA.Set (singleton)
 import Daml.Finance.Data.Numeric.Observation (Observation(..))
 import Daml.Finance.Data.Reference.HolidayCalendar (HolidayCalendar(..))
@@ -58,7 +58,7 @@ run = script do
     dayCountConvention = Act360
     businessDayConvention = ModifiedFollowing
     -- CREATE_INTEREST_RATE_SWAP_VARIABLES_END
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 2019 Jan 16, 0.0027406)
       , (dateToDateClockTime $ date 2019 Feb 15, 0.002035)
       ]
@@ -74,11 +74,11 @@ run = script do
     createCmd HolidayCalendar with
       provider = calendarDataProvider
       calendar
-      observers = M.fromList observers
+      observers = Map.fromList observers
 
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id referenceRateId; observations; observers = M.empty
+      provider = issuer; id = Id referenceRateId; observations; observers = mempty
 
   swapInstrument <- originateInterestRateSwap issuer issuer "SwapTest1" Transferable
     "Interest rate swap" observers now issueDate holidayCalendarIds calendarDataProvider
@@ -153,7 +153,7 @@ runSofr = script do
     dayCountConvention = Act360
     businessDayConvention = ModifiedFollowing
     -- CREATE_SOFR-INTEREST_RATE_SWAP_VARIABLES_END
-    observations = M.fromList
+    observations = Map.fromList
       [ (dateToDateClockTime $ date 2019 Jan 14, 1.04240111)
       , (dateToDateClockTime $ date 2019 Feb 13, 1.04509941)
       , (dateToDateClockTime $ date 2019 May 13, 1.06145226)
@@ -170,11 +170,11 @@ runSofr = script do
     createCmd HolidayCalendar with
       provider = calendarDataProvider
       calendar
-      observers = M.fromList observers
+      observers = Map.fromList observers
 
   observableCid <- toInterfaceContractId <$> submit issuer do
     createCmd Observation with
-      provider = issuer; id = Id referenceRateId; observations; observers = M.empty
+      provider = issuer; id = Id referenceRateId; observations; observers = mempty
 
   swapInstrument <- originateInterestRateSwap issuer issuer "SwapTest1" Transferable
     "Interest rate swap" observers now issueDate holidayCalendarIds calendarDataProvider

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Util.daml
@@ -3,7 +3,7 @@
 
 module Daml.Finance.Instrument.Swap.Test.Util where
 
-import DA.Map qualified as M (empty, fromList)
+import DA.Map (fromList)
 import Daml.Finance.Instrument.Swap.Asset.Factory qualified as AssetSwap (Factory(..))
 import Daml.Finance.Instrument.Swap.CreditDefault.Factory qualified as CreditDefaultSwap (Factory(..))
 import Daml.Finance.Instrument.Swap.Currency.Factory qualified as CurrencySwap (Factory(..))
@@ -49,7 +49,7 @@ originateInterestRateSwap depository issuer label holdingStandard description
       submit issuer do
         createCmd InterestRateSwap.Factory with
           provider = issuer
-          observers = M.empty
+          observers = mempty
 
     -- CREATE_INTEREST_RATE_SWAP_INSTRUMENT_BEGIN
     let
@@ -74,7 +74,7 @@ originateInterestRateSwap depository issuer label holdingStandard description
           ownerReceivesFix
           currency
           lastEventTimestamp
-        observers = M.fromList observers
+        observers = fromList observers
     -- CREATE_INTEREST_RATE_SWAP_INSTRUMENT_END
     pure instrument
 
@@ -87,7 +87,7 @@ originateFpmlSwap depository issuer label holdingStandard description observers
     fpmlSwapFactoryCid <- toInterfaceContractId @FpmlSwapFactory.I <$> submit issuer do
       createCmd FpmlSwap.Factory with
         provider = issuer
-        observers = M.empty
+        observers = mempty
 
     -- CREATE_FPML_SWAP_INSTRUMENT_BEGIN
     let
@@ -108,7 +108,7 @@ originateFpmlSwap depository issuer label holdingStandard description observers
           currencies
           calendarDataProvider
           lastEventTimestamp
-        observers = M.fromList observers
+        observers = fromList observers
     -- CREATE_FPML_SWAP_INSTRUMENT_END
     pure instrument
 
@@ -129,7 +129,7 @@ originateAssetSwap depository issuer label holdingStandard description observers
     assetSwapFactoryCid <- toInterfaceContractId @AssetSwapFactory.I <$> submit issuer do
       createCmd AssetSwap.Factory with
         provider = issuer
-        observers = M.empty
+        observers = mempty
 
     -- CREATE_ASSET_SWAP_INSTRUMENT_BEGIN
     let
@@ -154,7 +154,7 @@ originateAssetSwap depository issuer label holdingStandard description observers
           referenceAssetId
           currency
           lastEventTimestamp
-        observers = M.fromList observers
+        observers = fromList observers
     -- CREATE_ASSET_SWAP_INSTRUMENT_END
     pure instrument
 
@@ -176,7 +176,7 @@ originateCreditDefaultSwap depository issuer label holdingStandard description
       submit issuer do
         createCmd CreditDefaultSwap.Factory with
           provider = issuer
-          observers = M.empty
+          observers = mempty
 
     -- CREATE_CREDIT_DEFAULT_SWAP_INSTRUMENT_BEGIN
     let
@@ -202,7 +202,7 @@ originateCreditDefaultSwap depository issuer label holdingStandard description
           recoveryRateReferenceId
           currency
           lastEventTimestamp
-        observers = M.fromList observers
+        observers = fromList observers
     -- CREATE_CREDIT_DEFAULT_SWAP_INSTRUMENT_END
     pure instrument
 
@@ -223,7 +223,7 @@ originateCurrencySwap depository issuer label holdingStandard description observ
     currencySwapFactoryCid <- toInterfaceContractId @CurrencySwapFactory.I <$> submit issuer do
       createCmd CurrencySwap.Factory with
         provider = issuer
-        observers = M.empty
+        observers = mempty
 
     -- CREATE_CURRENCY_SWAP_INSTRUMENT_BEGIN
     let
@@ -250,7 +250,7 @@ originateCurrencySwap depository issuer label holdingStandard description observ
           foreignCurrency
           fxRate
           lastEventTimestamp
-        observers = M.fromList observers
+        observers = fromList observers
     -- CREATE_CURRENCY_SWAP_INSTRUMENT_BEGIN
     pure instrument
 
@@ -266,7 +266,7 @@ originateForeignExchangeSwap depository issuer label holdingStandard description
       submit issuer do
         createCmd ForeignExchangeSwap.Factory with
           provider = issuer
-          observers = M.empty
+          observers = mempty
 
     -- CREATE_FOREIGN_EXCHANGE_SWAP_INSTRUMENT_BEGIN
     let
@@ -290,6 +290,6 @@ originateForeignExchangeSwap depository issuer label holdingStandard description
           firstPaymentDate
           maturityDate
           lastEventTimestamp
-        observers = M.fromList observers
+        observers = fromList observers
     -- CREATE_FOREIGN_EXCHANGE_SWAP_INSTRUMENT_END
     pure instrument

--- a/src/test/daml/Daml/Finance/Settlement/Test/Batch.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Batch.daml
@@ -3,8 +3,8 @@
 
 module Daml.Finance.Settlement.Test.Batch where
 
-import DA.Map qualified as M (fromList)
-import DA.Set qualified as S (fromList, singleton)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (fromList, singleton)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Cancel(..), Settle(..))
 import Daml.Finance.Interface.Settlement.Factory qualified as SettlementFactory (I, Instruct(..))
@@ -57,14 +57,14 @@ run: Bool -> Bool -> Script ()
 run settleCashOnledger bankIsInstructor = script do
   -- Create parties
   TestParties{..} <- setupParties
-  let pp = [("PublicParty", S.singleton publicParty)]
+  let pp = [("PublicParty", Set.singleton publicParty)]
 
   -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank []
 
   -- Create holding factory
   holdingFactory <- createHoldingFactory
-    Holding.Factory with provider = bank; id = Id "Holding Factory"; observers = M.fromList pp
+    Holding.Factory with provider = bank; id = Id "Holding Factory"; observers = Map.fromList pp
 
   -- Originate instruments
   now <- getTime
@@ -95,25 +95,25 @@ run settleCashOnledger bankIsInstructor = script do
   -- Discover settlement routes
   routeProviderCid <- toInterfaceContractId @RouteProvider.I <$> submit bank do
     createCmd SingleCustodian with
-      provider = bank; custodian = bank; observers = S.singleton publicParty
+      provider = bank; custodian = bank; observers = Set.singleton publicParty
   routedSteps <- submit bank do
     exerciseCmd routeProviderCid RouteProvider.Discover with
-      discoverors = S.singleton bank; contextId = None; steps
+      discoverors = Set.singleton bank; contextId = None; steps
 
   -- Setup settlement factory
   settlementFactoryCid <- toInterfaceContractId @SettlementFactory.I <$>
     submit bank do
-      createCmd Factory with provider = bank; observers = S.singleton publicParty
+      createCmd Factory with provider = bank; observers = Set.singleton publicParty
 
   -- Instruct settlement
   let
     instructor = if bankIsInstructor then bank else buyer
     consenters = if bankIsInstructor then [] else [seller]
-    settlers = S.fromList [buyer, seller]
+    settlers = Set.fromList [buyer, seller]
     instructCmd = submitMulti (instructor :: consenters) [publicParty] do
       exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
         instructor
-        consenters = S.fromList consenters
+        consenters = Set.fromList consenters
         settlers
         id = Id "APPL 1000@200.0USD"
         description = "DVP"
@@ -124,10 +124,10 @@ run settleCashOnledger bankIsInstructor = script do
   -- Create batch and instructions, and then cancel
   (batchCid, _) <- instructCmd
   -- seller can't cancel batch
-  submitMustFail seller do exerciseCmd batchCid Batch.Cancel with actors = S.singleton seller
+  submitMustFail seller do exerciseCmd batchCid Batch.Cancel with actors = Set.singleton seller
   -- instructor and consenters can cancel batch
   submitMulti (instructor :: consenters) [] do
-    exerciseCmd batchCid Batch.Cancel with actors = S.fromList $ instructor :: consenters
+    exerciseCmd batchCid Batch.Cancel with actors = Set.fromList $ instructor :: consenters
 
   -- Create batch and instructions
   (batchCid, [equityInstructionCid, cashInstructionCid]) <- instructCmd
@@ -135,10 +135,10 @@ run settleCashOnledger bankIsInstructor = script do
   -- Allocate and approve equity instruction
   (equityInstructionCid, _) <- submit seller do
     exerciseCmd equityInstructionCid Instruction.Allocate with
-      actors = S.singleton seller; allocation = Pledge equityHoldingCid
+      actors = Set.singleton seller; allocation = Pledge equityHoldingCid
   equityInstructionCid <- submit buyer do
     exerciseCmd equityInstructionCid Instruction.Approve with
-      actors = S.singleton buyer; approval = TakeDelivery buyerCustodyAccount
+      actors = Set.singleton buyer; approval = TakeDelivery buyerCustodyAccount
 
   -- Allocate and approve cash instruction
   cashInstructionCid <- if settleCashOnledger
@@ -148,37 +148,37 @@ run settleCashOnledger bankIsInstructor = script do
         cashHoldingCid <- Account.credit [publicParty] cashInstrument 200_000.0 buyerCashAccount
         (cashInstructionCid, _) <- submit buyer do
           exerciseCmd cashInstructionCid Instruction.Allocate with
-            actors = S.singleton buyer; allocation = Pledge cashHoldingCid
+            actors = Set.singleton buyer; allocation = Pledge cashHoldingCid
         submit seller do
           exerciseCmd cashInstructionCid Instruction.Approve with
-            actors = S.singleton seller; approval = TakeDelivery sellerCashAccount
+            actors = Set.singleton seller; approval = TakeDelivery sellerCashAccount
     else
       do
         -- Settle by off ledger transfer
         (cashInstructionCid, _) <- submitMulti [buyer, bank] [] do
           exerciseCmd cashInstructionCid Instruction.Allocate with
-            actors = S.fromList [buyer, bank]; allocation = SettleOffledger
+            actors = Set.fromList [buyer, bank]; allocation = SettleOffledger
         submitMulti [seller, bank] [] do
           exerciseCmd cashInstructionCid Instruction.Approve with
-            actors = S.fromList [seller, bank]; approval = SettleOffledgerAcknowledge
+            actors = Set.fromList [seller, bank]; approval = SettleOffledgerAcknowledge
 
   -- Settle batch
   -- neither the bank, nor seller, nor buyer can execute an instruction
   submitMustFail bank do
-    exerciseCmd cashInstructionCid Instruction.Execute with actors = S.singleton bank
+    exerciseCmd cashInstructionCid Instruction.Execute with actors = Set.singleton bank
   submitMustFail seller do
-    exerciseCmd cashInstructionCid Instruction.Execute with actors = S.singleton seller
+    exerciseCmd cashInstructionCid Instruction.Execute with actors = Set.singleton seller
   submitMustFail buyer do
-    exerciseCmd cashInstructionCid Instruction.Execute with actors = S.singleton buyer
+    exerciseCmd cashInstructionCid Instruction.Execute with actors = Set.singleton buyer
   -- the bank can't settle the batch
   if bankIsInstructor then
     submitMustFail bank do
-      exerciseCmd batchCid Batch.Settle with actors = S.singleton bank
+      exerciseCmd batchCid Batch.Settle with actors = Set.singleton bank
   else
     pure ()
   -- any of the settlers can settle the batch (i.e., buyer or seller)
   cids <- submitMulti [buyer] [publicParty] do
-    exerciseCmd batchCid Batch.Settle with actors = S.singleton buyer
+    exerciseCmd batchCid Batch.Settle with actors = Set.singleton buyer
 
   -- Assert state
   let ts = zip [buyer, seller] cids

--- a/src/test/daml/Daml/Finance/Settlement/Test/BatchWithIntermediaries.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/BatchWithIntermediaries.daml
@@ -4,8 +4,8 @@
 module Daml.Finance.Settlement.Test.BatchWithIntermediaries where
 
 import DA.Date (addDays, toDateUTC)
-import DA.Map qualified as M (fromList)
-import DA.Set qualified as S (empty, fromList, singleton)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (fromList, singleton)
 import DA.Time (time)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
 import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Settle(..))
@@ -15,7 +15,7 @@ import Daml.Finance.Interface.Settlement.RouteProvider qualified as RouteProvide
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), Step(..))
 import Daml.Finance.Interface.Types.Common.Types (HoldingStandard(..), Id(..))
 import Daml.Finance.Interface.Util.Common (qty)
-import Daml.Finance.Settlement.Factory (Factory(..))
+import Daml.Finance.Settlement.Factory qualified as Settlement (Factory(..))
 import Daml.Finance.Settlement.Hierarchy (Hierarchy(..))
 import Daml.Finance.Settlement.RouteProvider.IntermediatedStatic (IntermediatedStatic(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
@@ -67,14 +67,15 @@ run : Script ()
 run = script do
   -- Create parties
   TestParties{..} <- setupParties
-  let pp = [("PublicParty", S.singleton publicParty)]
+  let pp = [("PublicParty", Set.singleton publicParty)]
 
   -- Setup security accounts at CB (utilising non-fungible holdings)
   -- Create account factory
   csdAccountFactoryCid <- toInterfaceContractId <$> Account.createFactory csd []
   -- Create holding factory
   csdHoldingFactory <- createHoldingFactory
-    Holding.Factory with provider = csd; id = Id "Holding Factory @ CSD"; observers = M.fromList pp
+    Holding.Factory with
+      provider = csd; id = Id "Holding Factory @ CSD"; observers = Map.fromList pp
   -- Create accounts
   [buyerSecurityAccount, sellerSecurityAccount] <- mapA (Account.createAccount "Security Account" []
     csdAccountFactoryCid csdHoldingFactory [] Account.Owner csd) [buyer, seller]
@@ -85,7 +86,7 @@ run = script do
   -- Create holding factory
   cbHoldingFactory <- createHoldingFactory
     Holding.Factory with
-      provider = cb; id = Id "Holding Factory @ CB"; observers = M.fromList pp
+      provider = cb; id = Id "Holding Factory @ CB"; observers = Map.fromList pp
   -- Create accounts
   [buyerCashAccount, bankCashAccount] <- mapA (Account.createAccount "Cash Account" []
     cbAccountFactoryCid cbHoldingFactory [] Account.Owner cb) [buyer, bank]
@@ -97,14 +98,15 @@ run = script do
   bankHoldingFactory <-
     createHoldingFactory
       HoldingV2.Factory with
-        provider = bank; id = Id "HoldingV2 Factory @ Bank"; observers = M.fromList pp
+        provider = bank; id = Id "HoldingV2 Factory @ Bank"; observers = Map.fromList pp
   -- Create accounts
   [sellerCashAccount] <- mapA (Account.createAccount "Cash Account" [] bankAccountFactoryCid
     bankHoldingFactory [] Account.Owner bank) [seller]
 
   -- Distribute assets
   now <- getTime
-  equityInstrument <- Instrument.originate csd issuer "AAPL" TransferableFungible "Apple Inc." [] now
+  equityInstrument <-
+    Instrument.originate csd issuer "AAPL" TransferableFungible "Apple Inc." [] now
   equityHoldingCid <- Account.credit [] equityInstrument 1_000.0 sellerSecurityAccount
   cashInstrument <- Instrument.originate cb cb "USD" TransferableFungible "United States Dollar"
     [] now
@@ -121,59 +123,60 @@ run = script do
   -- Discover settlement routes (by first creating a route provider with intermediaries from Buyer
   -- to Seller)
   let
-    paths = M.fromList
+    paths = Map.fromList
       [ ("USD", Hierarchy with rootCustodian = cb; pathsToRootCustodian = [[buyer], [seller, bank]])
       , ("AAPL", Hierarchy with rootCustodian = csd; pathsToRootCustodian = [[seller], [buyer]])
       ]
   routeProviderCid <- toInterfaceContractId @RouteProvider.I <$> submit buyer do
-    createCmd IntermediatedStatic with provider = buyer; paths; observers = S.empty
+    createCmd IntermediatedStatic with provider = buyer; paths; observers = mempty
   routedSteps <- submit buyer do
     exerciseCmd routeProviderCid RouteProvider.Discover with
-      discoverors = S.singleton buyer; contextId = None; steps
+      discoverors = Set.singleton buyer; contextId = None; steps
 
   -- Instruct settlement
   settlementFactoryCid <- toInterfaceContractId @SettlementFactory.I <$> submit buyer do
-    createCmd Factory with provider = buyer; observers = S.empty
+    createCmd Settlement.Factory with provider = buyer; observers = mempty
   (batchCid, [cashInstruction1Cid, cashInstruction2Cid, equityInstructionCid]) <-
     submitMulti [buyer, seller] [] do
       exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
         instructor = buyer
-        consenters = S.singleton seller
-        settlers = S.fromList [buyer, seller]
+        consenters = Set.singleton seller
+        settlers = Set.fromList [buyer, seller]
         id = Id "APPL 1000@200.0USD"; description = "DVP"; contextId = None; routedSteps
         settlementTime = Some settlementTime
 
   -- Allocate instructions
   (equityInstructionCid, _) <- submit seller do
     exerciseCmd equityInstructionCid
-      Instruction.Allocate with actors = S.singleton seller; allocation = Pledge equityHoldingCid
+      Instruction.Allocate with actors = Set.singleton seller; allocation = Pledge equityHoldingCid
   (cashInstruction1Cid, _) <- submit buyer do
     exerciseCmd cashInstruction1Cid
-      Instruction.Allocate with actors = S.singleton buyer; allocation = Pledge buyerCashHoldingCid
+      Instruction.Allocate with
+        actors = Set.singleton buyer; allocation = Pledge buyerCashHoldingCid
   (cashInstruction2Cid, _) <-  submit bank do
     exerciseCmd cashInstruction2Cid
-      Instruction.Allocate with actors = S.singleton bank; allocation = CreditReceiver
+      Instruction.Allocate with actors = Set.singleton bank; allocation = CreditReceiver
 
   submitMustFail buyer do
     exerciseCmd cashInstruction1Cid
-      Instruction.Allocate with actors = S.singleton buyer; allocation = CreditReceiver
+      Instruction.Allocate with actors = Set.singleton buyer; allocation = CreditReceiver
 
   -- Approve instructions
   equityInstructionCid <- submit buyer do
     exerciseCmd equityInstructionCid
       Instruction.Approve with
-        actors = S.singleton buyer; approval = TakeDelivery buyerSecurityAccount
+        actors = Set.singleton buyer; approval = TakeDelivery buyerSecurityAccount
   cashInstruction1Cid <- submit bank do
     exerciseCmd cashInstruction1Cid
-      Instruction.Approve with actors = S.singleton bank; approval = TakeDelivery bankCashAccount
+      Instruction.Approve with actors = Set.singleton bank; approval = TakeDelivery bankCashAccount
   cashInstruction2Cid <- submit seller do
     exerciseCmd cashInstruction2Cid
       Instruction.Approve with
-        actors = S.singleton seller; approval = TakeDelivery sellerCashAccount
+        actors = Set.singleton seller; approval = TakeDelivery sellerCashAccount
 
   submitMustFail buyer do
     exerciseCmd equityInstructionCid
-      Instruction.Approve with actors = S.singleton buyer; approval = DebitSender
+      Instruction.Approve with actors = Set.singleton buyer; approval = DebitSender
 
   -- Set time
   setTime settlementTime
@@ -181,7 +184,7 @@ run = script do
   -- Settle batch
   [bankCashHoldingCid, sellerCashHoldingCid, equityHoldingCid] <-
     submitMulti [buyer] [publicParty] do
-      exerciseCmd batchCid Batch.Settle with actors = S.singleton buyer
+      exerciseCmd batchCid Batch.Settle with actors = Set.singleton buyer
 
   -- Assert state
   let ts = [(buyer, equityHoldingCid), (bank, bankCashHoldingCid), (seller, sellerCashHoldingCid)]

--- a/src/test/daml/Daml/Finance/Settlement/Test/Intermediated.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Intermediated.daml
@@ -4,8 +4,8 @@
 module Daml.Finance.Settlement.Test.Intermediated where
 
 import DA.Date (addDays, toDateUTC)
-import DA.Map qualified as M (fromList)
-import DA.Set qualified as S (empty, fromList, singleton)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (fromList, singleton)
 import DA.Time (time)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
 import Daml.Finance.Holding.TransferableFungible qualified as TransferableFungible (T)
@@ -19,7 +19,7 @@ import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), St
 import Daml.Finance.Interface.Types.Common.Types (HoldingStandard(..), Id(..))
 import Daml.Finance.Interface.Util.Common (qty)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (AddObservers(..), I, RemoveObservers(..))
-import Daml.Finance.Settlement.Factory (Factory(..))
+import Daml.Finance.Settlement.Factory qualified as Settlement (Factory(..))
 import Daml.Finance.Settlement.Hierarchy (Hierarchy(..))
 import Daml.Finance.Settlement.RouteProvider.IntermediatedStatic (IntermediatedStatic(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit, submitExerciseInterfaceByKeyCmd)
@@ -104,14 +104,14 @@ run : Bool -> Script ()
 run useDelegatee = script do
   -- Create parties
   TestParties{..} <- setupParties
-  let pp = [("PublicParty", S.singleton publicParty)]
+  let pp = [("PublicParty", Set.singleton publicParty)]
 
   -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory provider pp
 
   -- Create holding factory
   holdingFactory <- createHoldingFactory
-    Holding.Factory with provider; id = Id "Holding Factory"; observers = M.fromList pp
+    Holding.Factory with provider; id = Id "Holding Factory"; observers = Map.fromList pp
 
   -- Create accounts
   let
@@ -160,23 +160,23 @@ run useDelegatee = script do
     deliveryRoute = Hierarchy with
       rootCustodian = csd
       pathsToRootCustodian = [[buyer, custodian2], [seller, custodian1]]
-    paths = M.fromList [("USD", paymentRoute), ("SHARE", deliveryRoute)]
+    paths = Map.fromList [("USD", paymentRoute), ("SHARE", deliveryRoute)]
   routeProviderCid <- toInterfaceContractId @RouteProvider.I <$> submit agent do
-    createCmd IntermediatedStatic with provider = agent; paths; observers = S.empty
+    createCmd IntermediatedStatic with provider = agent; paths; observers = mempty
   routedSteps <- submit agent do
     exerciseCmd routeProviderCid RouteProvider.Discover with
-      discoverors = S.singleton agent; contextId = None; steps
+      discoverors = Set.singleton agent; contextId = None; steps
 
   -- Instruct settlement
   settlementFactoryCid <- toInterfaceContractId @SettlementFactory.I <$> submit agent do
-    createCmd Factory with provider = agent; observers = S.empty
+    createCmd Settlement.Factory with provider = agent; observers = mempty
   (batchCid, [sellerInstructionCid, custodian1InstructionCid, custodian2InstructionCid,
     buyerInstructionCid, bank1InstructionCid, bank2InstructionCid]) <-
     submit agent do
       exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
         instructor = agent
         consenters = mempty
-        settlers = S.singleton agent
+        settlers = Set.singleton agent
         id = Id "SHARE 200000.0@160.0USD DVP"; description = "Crosspayment"; contextId = None
         routedSteps; settlementTime = Some settlementTime
 
@@ -188,18 +188,18 @@ run useDelegatee = script do
         delegationCid <- submit buyer do
           createCmd AllocationDelegation with delegator = buyer; delegatee
         -- disclose
-        let observerContext = ("delegation123", S.singleton delegatee)
+        let observerContext = ("delegation123", Set.singleton delegatee)
         buyerCashCid <- fromInterfaceContractId @Holding.I <$> submit buyer do
           exerciseCmd (toInterfaceContractId @Disclosure.I buyerCashCid)
             Disclosure.AddObservers with
-              disclosers = S.singleton buyer; observersToAdd = observerContext
+              disclosers = Set.singleton buyer; observersToAdd = observerContext
         buyerInstructionCid <- fromInterfaceContractId @Instruction.I <$> submit buyer do
           exerciseCmd (toInterfaceContractId @Disclosure.I buyerInstructionCid)
             Disclosure.AddObservers with
-              disclosers = S.singleton buyer; observersToAdd = observerContext
+              disclosers = Set.singleton buyer; observersToAdd = observerContext
         Account.submitExerciseInterfaceByKeyCmd @Disclosure.I [buyer] [] buyerCashAccount
           Disclosure.AddObservers with
-            disclosers = S.singleton buyer; observersToAdd = observerContext
+            disclosers = Set.singleton buyer; observersToAdd = observerContext
         -- allocate (on behalf of buyer)
         t <- submit delegatee do
           exerciseCmd delegationCid OnBehalfAllocation with
@@ -207,61 +207,61 @@ run useDelegatee = script do
         -- undisclose
         Account.submitExerciseInterfaceByKeyCmd @Disclosure.I [buyer] [] buyerCashAccount
           Disclosure.RemoveObservers with
-            disclosers = S.singleton buyer; observersToRemove = observerContext
+            disclosers = Set.singleton buyer; observersToRemove = observerContext
         pure t
     else
       submit buyer do
         exerciseCmd buyerInstructionCid Instruction.Allocate with
-          actors = S.singleton buyer; allocation = Pledge buyerCashCid
+          actors = Set.singleton buyer; allocation = Pledge buyerCashCid
   buyerInstructionCid <- submit bank1 do
     exerciseCmd buyerInstructionCid Instruction.Approve with
-      actors = S.singleton bank1; approval = DebitSender
+      actors = Set.singleton bank1; approval = DebitSender
   bank2InstructionCid <- submit seller do
     exerciseCmd bank2InstructionCid Instruction.Approve with
-      actors = S.singleton seller; approval = TakeDelivery sellerCashAccount
+      actors = Set.singleton seller; approval = TakeDelivery sellerCashAccount
   (bank2InstructionCid, _) <- submit bank2 do
     exerciseCmd bank2InstructionCid Instruction.Allocate with
-      actors = S.singleton bank2; allocation = CreditReceiver
+      actors = Set.singleton bank2; allocation = CreditReceiver
   (bank1InstructionCid, _) <- submitMulti [bank1, cb] [] do
     exerciseCmd bank1InstructionCid Instruction.Allocate with
-      actors = S.fromList [bank1, cb]; allocation = SettleOffledger
+      actors = Set.fromList [bank1, cb]; allocation = SettleOffledger
   bank1InstructionCid <- submitMulti [bank2, cb] [] do
     exerciseCmd bank1InstructionCid Instruction.Approve with
-      actors = S.fromList [bank2, cb]; approval = SettleOffledgerAcknowledge
+      actors = Set.fromList [bank2, cb]; approval = SettleOffledgerAcknowledge
   (sellerInstructionCid, _) <- submit seller do
     exerciseCmd sellerInstructionCid Instruction.Allocate with
-      actors = S.singleton seller; allocation = Pledge sellerAssetCid
+      actors = Set.singleton seller; allocation = Pledge sellerAssetCid
   sellerInstructionCid <- submit custodian1 do
     exerciseCmd sellerInstructionCid Instruction.Approve with
-      actors = S.singleton custodian1; approval = DebitSender
+      actors = Set.singleton custodian1; approval = DebitSender
   (custodian1InstructionCid, _) <- submit custodian1 do
     exerciseCmd custodian1InstructionCid Instruction.Allocate with
-      actors = S.singleton custodian1; allocation = Pledge custodian1AssetCid
+      actors = Set.singleton custodian1; allocation = Pledge custodian1AssetCid
   custodian1InstructionCid <- submit custodian2 do
      exerciseCmd custodian1InstructionCid Instruction.Approve with
-      actors = S.singleton custodian2; approval = TakeDelivery custodian2DepoAccount
+      actors = Set.singleton custodian2; approval = TakeDelivery custodian2DepoAccount
   -- Can't settle batch before all `Instruction`s have been allocated and approved
   submitMultiMustFail [agent] [publicParty] do
     exerciseCmd batchCid Batch.Settle with
-      actors = S.singleton agent
+      actors = Set.singleton agent
   (custodian2InstructionCid, _) <- submit custodian2 do
     exerciseCmd custodian2InstructionCid Instruction.Allocate with
-      actors = S.singleton custodian2; allocation = CreditReceiver
+      actors = Set.singleton custodian2; allocation = CreditReceiver
   -- Buyer and Custodian2 approves instruction with an incompatible approval
   custodian2InstructionCid <- submitMulti [buyer, custodian2] [] do
     exerciseCmd custodian2InstructionCid Instruction.Approve with
-      actors = S.fromList [buyer, custodian2]; approval = SettleOffledgerAcknowledge
+      actors = Set.fromList [buyer, custodian2]; approval = SettleOffledgerAcknowledge
   -- Settlement of batch must fail due to the incompatible approval
   submitMultiMustFail [agent] [publicParty] do
-    exerciseCmd batchCid Batch.Settle with actors = S.singleton agent
+    exerciseCmd batchCid Batch.Settle with actors = Set.singleton agent
   -- Buyer and Custodian2 unapproves the instruction
   custodian2InstructionCid <- submitMulti [buyer, custodian2] [] do
     exerciseCmd custodian2InstructionCid Instruction.Approve with
-      actors = S.fromList [buyer, custodian2]; approval = Unapproved
+      actors = Set.fromList [buyer, custodian2]; approval = Unapproved
   -- Buyer approves her instruction with a compatible approval
   custodian2InstructionCid <- submit buyer do
     exerciseCmd custodian2InstructionCid Instruction.Approve with
-      actors = S.singleton buyer; approval = TakeDelivery buyerDepoAccount
+      actors = Set.singleton buyer; approval = TakeDelivery buyerDepoAccount
 
   -- Set time
   setTime settlementTime
@@ -269,7 +269,7 @@ run useDelegatee = script do
   -- Settle batch
   [custodian2AssetCid, buyerAssetCid, sellerCashCid] <-
     submitMulti [agent] [publicParty] do
-      exerciseCmd batchCid Batch.Settle with actors = S.singleton agent
+      exerciseCmd batchCid Batch.Settle with actors = Set.singleton agent
 
   -- Assert state
   let ts = [(seller, sellerCashCid), (custodian2, custodian2AssetCid), (buyer, buyerAssetCid)]
@@ -308,7 +308,7 @@ template AllocationDelegation
       controller delegatee
       do
         Some cid <- fmap (fromInterfaceContractId @TransferableFungible.T) <$>
-          undisclose (id, S.singleton delegatee) (S.singleton delegator) holdingCid
+          undisclose (id, Set.singleton delegatee) (Set.singleton delegator) holdingCid
         fungible <- fetch cid
         exercise instructionCid Instruction.Allocate with
-          actors = S.singleton delegator; allocation = Pledge $ toInterfaceContractId cid
+          actors = Set.singleton delegator; allocation = Pledge $ toInterfaceContractId cid

--- a/src/test/daml/Daml/Finance/Settlement/Test/Transfer.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/Transfer.daml
@@ -5,9 +5,9 @@ module Daml.Finance.Settlement.Test.Transfer where
 
 import DA.Assert ((===))
 import DA.List (head)
-import DA.Map qualified as M (fromList)
+import DA.Map qualified as Map (fromList)
 import DA.Optional (isNone, isSome)
-import DA.Set qualified as S (empty, fromList, singleton)
+import DA.Set qualified as Set (fromList, singleton)
 import Daml.Finance.Account.Account qualified as Account (T)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
 import Daml.Finance.Interface.Account.Account qualified as Account (I, getKey)
@@ -20,7 +20,7 @@ import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), In
 import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), HoldingStandard(..), Id(..))
 import Daml.Finance.Interface.Util.Common (qty)
 import Daml.Finance.Interface.Util.Lockable qualified as Lockable (I)
-import Daml.Finance.Settlement.Factory (Factory(..))
+import Daml.Finance.Settlement.Factory qualified as Settlement (Factory(..))
 import Daml.Finance.Settlement.Instruction qualified as Instruction (T)
 import Daml.Finance.Settlement.RouteProvider.SingleCustodian (SingleCustodian(..))
 import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
@@ -62,14 +62,14 @@ run : Script ()
 run = script do
   -- Create parties
   TestParties{..} <- setupParties
-  let pp = [("PublicParty", S.singleton publicParty)]
+  let pp = [("PublicParty", Set.singleton publicParty)]
 
   -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
 
   -- Create holding factory
   holdingFactory <- createHoldingFactory
-    Holding.Factory with provider = bank; id = Id "Holding Factory"; observers = M.fromList pp
+    Holding.Factory with provider = bank; id = Id "Holding Factory"; observers = Map.fromList pp
 
   -- Create accounts
   [senderAccount, receiverAccount] <- mapA (Account.createAccount "Cash Account" []
@@ -82,24 +82,24 @@ run = script do
 
   -- Create settlement factory
   settlementFactoryCid <- toInterfaceContractId @SettlementFactory.I <$>
-    submit bank do createCmd Factory with provider = bank; observers = S.empty
+    submit bank do createCmd Settlement.Factory with provider = bank; observers = mempty
 
   -- Settlement step
   let step = Step with sender; receiver; quantity = qty 200_000.0 cashInstrument
 
   -- Discover settlement route for the step
   routeProviderCid <- toInterfaceContractId @RouteProvider.I <$> submit bank do
-    createCmd SingleCustodian with provider = bank; observers = S.empty; custodian = bank
+    createCmd SingleCustodian with provider = bank; observers = mempty; custodian = bank
   routedSteps <- submit bank do
     exerciseCmd routeProviderCid RouteProvider.Discover with
-      discoverors = S.singleton bank; contextId = None; steps = [step]
+      discoverors = Set.singleton bank; contextId = None; steps = [step]
 
   -- Instruct transfer
   (batchCid, [cashInstructionCid]) <- submit bank do
     exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
       instructor = bank
       consenters = mempty
-      settlers = S.singleton bank
+      settlers = Set.singleton bank
       id = Id "transfer 1"
       description = "transfer of USD 200000.0 payment"
       contextId = None
@@ -109,7 +109,7 @@ run = script do
   -- Allocate instruction
   (cashInstructionCid, _) <- submit sender do
     exerciseCmd cashInstructionCid Instruction.Allocate with
-      actors = S.singleton sender; allocation = Pledge holdingCid
+      actors = Set.singleton sender; allocation = Pledge holdingCid
 
   -- Holding is locked
   Some cashInstruction <- queryInterfaceContractId sender cashInstructionCid
@@ -125,7 +125,7 @@ run = script do
   -- Cancel allocation
   (cashInstructionCid, Some holdingCid) <- submit sender do
     exerciseCmd cashInstructionCid Instruction.Allocate with
-      actors = S.singleton sender; allocation = Unallocated
+      actors = Set.singleton sender; allocation = Unallocated
 
   -- Holding is not locked
   Some lockable <- queryInterfaceContractId sender (toInterfaceContractId @Lockable.I holdingCid)
@@ -134,16 +134,16 @@ run = script do
   -- Allocate instruction
   (cashInstructionCid, _) <- submit sender do
     exerciseCmd cashInstructionCid Instruction.Allocate with
-      actors = S.singleton sender; allocation = Pledge holdingCid
+      actors = Set.singleton sender; allocation = Pledge holdingCid
 
   -- Approve instruction
   cashInstructionCid <- submit receiver do
     exerciseCmd cashInstructionCid Instruction.Approve with
-      actors = S.singleton receiver; approval = TakeDelivery receiverAccount
+      actors = Set.singleton receiver; approval = TakeDelivery receiverAccount
 
   -- Settle batch
   [cashHoldingCid] <- submitMulti [bank] [publicParty] do
-    exerciseCmd batchCid Batch.Settle with actors = S.singleton bank
+    exerciseCmd batchCid Batch.Settle with actors = Set.singleton bank
 
   -- Assert state
   let ts = [(receiver, cashHoldingCid)]
@@ -168,14 +168,14 @@ run = script do
 run2 : Script ()
 run2 = script do
   TestParties{..} <- setupParties
-  let pp = [("PublicParty", S.singleton publicParty)]
+  let pp = [("PublicParty", Set.singleton publicParty)]
 
   -- Create account factory
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
 
   -- Create holding factory
   holdingFactory <- createHoldingFactory $
-    Holding.Factory with provider = bank; id = Id "Holding Factory"; observers = M.fromList pp
+    Holding.Factory with provider = bank; id = Id "Holding Factory"; observers = Map.fromList pp
 
   -- Create accounts
   [senderAccount, receiverAccount] <- mapA (Account.createAccount "Cash Account" []
@@ -190,7 +190,7 @@ run2 = script do
 
   -- Create settlement factory
   settlementFactoryCid <- toInterfaceContractId @SettlementFactory.I <$>
-    submit bank do createCmd Factory with provider = bank; observers = S.empty
+    submit bank do createCmd Settlement.Factory with provider = bank; observers = mempty
 
   -- Settlement steps (to be settled independently)
   let
@@ -203,23 +203,23 @@ run2 = script do
 
   -- Discover settlement routes
   routeProviderCid <- toInterfaceContractId @RouteProvider.I <$> submit bank do
-    createCmd SingleCustodian with provider = bank; observers = S.empty; custodian = bank
+    createCmd SingleCustodian with provider = bank; observers = mempty; custodian = bank
   routedSteps1 <- submit bank do
     exerciseCmd routeProviderCid RouteProvider.Discover with
-      discoverors = S.singleton bank; contextId = None; steps = [first]
+      discoverors = Set.singleton bank; contextId = None; steps = [first]
   routedSteps2 <- submit bank do
     exerciseCmd routeProviderCid RouteProvider.Discover with
-      discoverors = S.singleton bank; contextId = None; steps = [second]
+      discoverors = Set.singleton bank; contextId = None; steps = [second]
   routedSteps3 <- submit bank do
     exerciseCmd routeProviderCid RouteProvider.Discover with
-      discoverors = S.singleton bank; contextId = None; steps = [third]
+      discoverors = Set.singleton bank; contextId = None; steps = [third]
 
   -- Instruct settlement for transfer 1
   (batchCid1, [cashInstructionCid1]) <- submit bank do
     exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
       instructor = bank
       consenters = mempty
-      settlers = S.singleton bank
+      settlers = Set.singleton bank
       id = id1
       description = "transfer of USD 100000.0 payment"
       contextId = None
@@ -230,7 +230,7 @@ run2 = script do
     exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
       instructor = bank
       consenters = mempty
-      settlers = S.singleton bank
+      settlers = Set.singleton bank
       id = id1
       description = "transfer of USD 200000.0 payment"
       contextId = None
@@ -242,7 +242,7 @@ run2 = script do
     exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
       instructor = bank
       consenters = mempty
-      settlers = S.singleton bank
+      settlers = Set.singleton bank
       id = id2
       description = "transfer of USD 200000.0 payment"
       contextId = None
@@ -254,7 +254,7 @@ run2 = script do
     exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
       instructor = bank
       consenters = mempty
-      settlers = S.singleton bank
+      settlers = Set.singleton bank
       id = id3
       description = "transfer of USD 300000.0 payment"
       contextId = None
@@ -266,11 +266,11 @@ run2 = script do
     verifyAccountDisclosureContexts account instructionCids = do
       current <- (.observers) . snd . head <$> queryFilter @Account.T account.owner
         (\a -> Account.getKey (toInterface @Account.I a) == account)
-      expected <- M.fromList <$> mapA
+      expected <- Map.fromList <$> mapA
         (\instructionCid -> do
           Some instruction <- queryContractId account.owner
             (fromInterfaceContractId @Instruction.T instructionCid)
-          pure (show $ key instruction, S.singleton bank)
+          pure (show $ key instruction, Set.singleton bank)
         )
         instructionCids
       current === expected
@@ -283,25 +283,25 @@ run2 = script do
   -- first
   (cashInstructionCid1, _) <- submit sender do
     exerciseCmd cashInstructionCid1 Instruction.Allocate with
-      actors = S.singleton sender; allocation = Pledge holdingCid1
+      actors = Set.singleton sender; allocation = Pledge holdingCid1
   verifyAccountDisclosureContexts senderAccount [cashInstructionCid1]
   (cashInstructionCid1, Some holdingCid1) <- submit sender do
     exerciseCmd cashInstructionCid1 Instruction.Allocate with
-      actors = S.singleton sender; allocation = Unallocated
+      actors = Set.singleton sender; allocation = Unallocated
   verifyAccountDisclosureContexts senderAccount []
   (cashInstructionCid1, _) <- submit sender do
     exerciseCmd cashInstructionCid1 Instruction.Allocate with
-      actors = S.singleton sender; allocation = Pledge holdingCid1
+      actors = Set.singleton sender; allocation = Pledge holdingCid1
   verifyAccountDisclosureContexts senderAccount [cashInstructionCid1]
   -- second
   (cashInstructionCid2, _) <- submit sender do
     exerciseCmd cashInstructionCid2 Instruction.Allocate with
-      actors = S.singleton sender; allocation = Pledge holdingCid2
+      actors = Set.singleton sender; allocation = Pledge holdingCid2
   verifyAccountDisclosureContexts senderAccount [cashInstructionCid1, cashInstructionCid2]
   -- third
   (cashInstructionCid3, _) <- submit sender do
     exerciseCmd cashInstructionCid3 Instruction.Allocate with
-      actors = S.singleton sender; allocation = Pledge holdingCid3
+      actors = Set.singleton sender; allocation = Pledge holdingCid3
   verifyAccountDisclosureContexts senderAccount [cashInstructionCid1, cashInstructionCid2,
     cashInstructionCid3]
 
@@ -309,34 +309,34 @@ run2 = script do
   -- third
   cashInstructionCid3 <- submit receiver do
     exerciseCmd cashInstructionCid3 Instruction.Approve with
-      actors = S.singleton receiver; approval = TakeDelivery receiverAccount
+      actors = Set.singleton receiver; approval = TakeDelivery receiverAccount
   verifyAccountDisclosureContexts receiverAccount [cashInstructionCid3]
   -- first
   cashInstructionCid1 <- submit receiver do
     exerciseCmd cashInstructionCid1 Instruction.Approve with
-      actors = S.singleton receiver; approval = TakeDelivery receiverAccount
+      actors = Set.singleton receiver; approval = TakeDelivery receiverAccount
   verifyAccountDisclosureContexts receiverAccount [cashInstructionCid1, cashInstructionCid3]
   -- second
   cashInstructionCid2 <- submit receiver do
     exerciseCmd cashInstructionCid2 Instruction.Approve with
-      actors = S.singleton receiver; approval = TakeDelivery receiverAccount
+      actors = Set.singleton receiver; approval = TakeDelivery receiverAccount
   verifyAccountDisclosureContexts receiverAccount [cashInstructionCid1, cashInstructionCid2,
     cashInstructionCid3]
 
   -- Settle transfers (in any order)
   -- second
   [cashHoldingCid2] <- submitMulti [bank] [publicParty] do
-    exerciseCmd batchCid2 Batch.Settle with actors = S.singleton bank
+    exerciseCmd batchCid2 Batch.Settle with actors = Set.singleton bank
   verifyAccountDisclosureContexts receiverAccount [cashInstructionCid1, cashInstructionCid3]
   verifyAccountDisclosureContexts receiverAccount [cashInstructionCid1, cashInstructionCid3]
   -- first
   [cashHoldingCid1] <- submitMulti [bank] [publicParty] do
-    exerciseCmd batchCid1 Batch.Settle with actors = S.singleton bank
+    exerciseCmd batchCid1 Batch.Settle with actors = Set.singleton bank
   verifyAccountDisclosureContexts senderAccount [cashInstructionCid3]
   verifyAccountDisclosureContexts receiverAccount [cashInstructionCid3]
   -- third
   [cashHoldingCid3] <- submitMulti [bank] [publicParty] do
-    exerciseCmd batchCid3 Batch.Settle with actors = S.singleton bank
+    exerciseCmd batchCid3 Batch.Settle with actors = Set.singleton bank
   verifyAccountDisclosureContexts senderAccount []
   verifyAccountDisclosureContexts receiverAccount []
 
@@ -362,12 +362,12 @@ run3 = script do
   TestParties{..} <- setupParties
 
   -- Create account factory
-  let pp = [("PublicParty", S.singleton publicParty)]
+  let pp = [("PublicParty", Set.singleton publicParty)]
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
 
   -- Create holding factory
   holdingFactory <- createHoldingFactory $
-    Holding.Factory with provider = bank; id = Id "Holding Factory"; observers = M.fromList pp
+    Holding.Factory with provider = bank; id = Id "Holding Factory"; observers = Map.fromList pp
 
   -- Create accounts
   [senderAccount, receiverAccount] <- mapA (Account.createAccount "Cash Account" []
@@ -380,22 +380,22 @@ run3 = script do
 
   -- Create settlement factory
   settlementFactoryCid <- toInterfaceContractId @SettlementFactory.I <$> submit bank do
-    createCmd Factory with provider = bank; observers = S.singleton publicParty
+    createCmd Settlement.Factory with provider = bank; observers = Set.singleton publicParty
 
   -- Discover settlement
   let step = Step with sender; receiver; quantity = qty 200_000.0 cashInstrument
   routeProviderCid <- toInterfaceContractId @RouteProvider.I <$> submit bank do
-    createCmd SingleCustodian with provider = bank; observers = S.empty; custodian = bank
+    createCmd SingleCustodian with provider = bank; observers = mempty; custodian = bank
   routedSteps <- submit bank do
     exerciseCmd routeProviderCid RouteProvider.Discover with
-      discoverors = S.singleton bank; contextId = None; steps = [step]
+      discoverors = Set.singleton bank; contextId = None; steps = [step]
 
   -- Instruct transfer
   (batchCid, [cashInstructionCid]) <- submit bank do
     exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
       instructor = bank
       consenters = mempty
-      settlers = S.fromList [sender, receiver]
+      settlers = Set.fromList [sender, receiver]
       id = Id "transfer 1"
       description = "transfer of USD 200000.0 payment"
       contextId = None
@@ -405,17 +405,17 @@ run3 = script do
   -- Allocate instruction
   (cashInstructionCid, _) <- submit sender do
     exerciseCmd cashInstructionCid Instruction.Allocate with
-      actors = S.singleton sender; allocation = Pledge holdingCid
+      actors = Set.singleton sender; allocation = Pledge holdingCid
 
   -- Approve instruction
   cashInstructionCid <- submit receiver do
     exerciseCmd cashInstructionCid Instruction.Approve with
-      actors = S.singleton receiver; approval = TakeDelivery receiverAccount
+      actors = Set.singleton receiver; approval = TakeDelivery receiverAccount
 
   -- Settle batch
   -- either sender, receiver or both can settle
   [cashHoldingCid] <- submitMulti [sender] [publicParty] do
-    exerciseCmd batchCid Batch.Settle with actors = S.singleton sender
+    exerciseCmd batchCid Batch.Settle with actors = Set.singleton sender
 
   -- Assert state
   let ts = [(receiver, cashHoldingCid)]
@@ -439,12 +439,12 @@ run4 = script do
   TestParties{..} <- setupParties
 
   -- Create account factory
-  let pp = [("PublicParty", S.singleton publicParty)]
+  let pp = [("PublicParty", Set.singleton publicParty)]
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
 
   -- Create holding factory
   holdingFactory <- createHoldingFactory $
-    Holding.Factory with provider = bank; id = Id "Holding Factory"; observers = M.fromList pp
+    Holding.Factory with provider = bank; id = Id "Holding Factory"; observers = Map.fromList pp
 
   -- Create accounts
   [senderAccount, receiverAccount] <- mapA (Account.createAccount "Cash Account" []
@@ -458,7 +458,7 @@ run4 = script do
 
   -- Create settlement factory
   settlementFactoryCid <- toInterfaceContractId @SettlementFactory.I <$> submit bank do
-    createCmd Factory with provider = bank; observers = S.singleton publicParty
+    createCmd Settlement.Factory with provider = bank; observers = Set.singleton publicParty
 
   -- Settlement steps
   let
@@ -467,17 +467,17 @@ run4 = script do
 
   -- Discover settlement routes
   routeProviderCid <- toInterfaceContractId @RouteProvider.I <$> submit bank do
-    createCmd SingleCustodian with provider = bank; observers = S.empty; custodian = bank
+    createCmd SingleCustodian with provider = bank; observers = mempty; custodian = bank
   routedSteps <- submit bank do
     exerciseCmd routeProviderCid RouteProvider.Discover with
-      discoverors = S.singleton bank; contextId = None; steps = [step1, step2]
+      discoverors = Set.singleton bank; contextId = None; steps = [step1, step2]
 
   -- Instruct transfer
   (batchCid, [cashInstructionCid1, cashInstructionCid2]) <- submit bank do
     exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
       instructor = bank
       consenters = mempty
-      settlers = S.fromList [sender, receiver]
+      settlers = Set.fromList [sender, receiver]
       id = Id "transfer 1"
       description = "transfer of USD 200000.0 and CHF 100000.0 payment"
       contextId = None
@@ -487,23 +487,23 @@ run4 = script do
   -- Allocate instruction
   (cashInstructionCid1, _) <- submit sender do
     exerciseCmd cashInstructionCid1 Instruction.Allocate with
-      actors = S.singleton sender; allocation = Pledge holdingCid1
+      actors = Set.singleton sender; allocation = Pledge holdingCid1
   (cashInstructionCid2, _) <- submit sender do
     exerciseCmd cashInstructionCid2 Instruction.Allocate with
-      actors = S.singleton sender; allocation = Pledge holdingCid2
+      actors = Set.singleton sender; allocation = Pledge holdingCid2
 
   -- Approve instruction
   cashInstructionCid1 <- submit receiver do
     exerciseCmd cashInstructionCid1 Instruction.Approve with
-      actors = S.singleton receiver; approval = TakeDelivery receiverAccount
+      actors = Set.singleton receiver; approval = TakeDelivery receiverAccount
   cashInstructionCid2 <- submit receiver do
     exerciseCmd cashInstructionCid2 Instruction.Approve with
-      actors = S.singleton receiver; approval = TakeDelivery receiverAccount
+      actors = Set.singleton receiver; approval = TakeDelivery receiverAccount
 
   -- Settle batch
   -- either sender, receiver or both can settle
   [cashHoldingCid1, cashHoldingCid2] <- submitMulti [sender] [publicParty] do
-    exerciseCmd batchCid Batch.Settle with actors = S.singleton sender
+    exerciseCmd batchCid Batch.Settle with actors = Set.singleton sender
 
   -- Assert state
   let ts = [(receiver, cashHoldingCid1), (receiver, cashHoldingCid2)]
@@ -527,12 +527,12 @@ run5 = script do
   TestParties{..} <- setupParties
 
   -- Create account factory
-  let pp = [("PublicParty", S.singleton publicParty)]
+  let pp = [("PublicParty", Set.singleton publicParty)]
   accountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank pp
 
   -- Create holding factory
   holdingFactory <- createHoldingFactory $
-    Holding.Factory with provider = bank; id = Id "Holding Factory"; observers = M.fromList pp
+    Holding.Factory with provider = bank; id = Id "Holding Factory"; observers = Map.fromList pp
 
   -- Create accounts
   [senderAccount, ccpAccount, receiverAccount] <- mapA (Account.createAccount "Cash Account" []
@@ -545,7 +545,7 @@ run5 = script do
 
   -- Create settlement factory
   settlementFactoryCid <- toInterfaceContractId @SettlementFactory.I <$>
-    submit bank do createCmd Factory with provider = bank; observers = S.empty
+    submit bank do createCmd Settlement.Factory with provider = bank; observers = mempty
 
   -- Settlement steps
   let
@@ -554,10 +554,10 @@ run5 = script do
 
   -- Discover settlement routes
   routeProviderCid <- toInterfaceContractId @RouteProvider.I <$> submit bank do
-    createCmd SingleCustodian with provider = bank; observers = S.empty; custodian = bank
+    createCmd SingleCustodian with provider = bank; observers = mempty; custodian = bank
   routedSteps <- submit bank do
     exerciseCmd routeProviderCid RouteProvider.Discover with
-      discoverors = S.singleton bank
+      discoverors = Set.singleton bank
       contextId = None
       steps = [step2, step1] -- order does not matter
 
@@ -566,7 +566,7 @@ run5 = script do
     exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
       instructor = bank
       consenters = mempty
-      settlers = S.singleton settler
+      settlers = Set.singleton settler
       id = Id "transfer 1"
       description = "transfer of USD 200000.0 payment"
       contextId = None
@@ -576,31 +576,31 @@ run5 = script do
   -- Approve instruction
   instructionCid2 <- submit receiver do
     exerciseCmd instructionCid2 Instruction.Approve with
-      actors = S.singleton receiver
+      actors = Set.singleton receiver
       approval = TakeDelivery receiverAccount
 
   -- Approve with passthrough
   instructionCid1 <- submit ccp do
     exerciseCmd instructionCid1 Instruction.Approve with
-      actors = S.singleton ccp
+      actors = Set.singleton ccp
       approval = PassThroughTo
         (ccpAccount, InstructionKey with instructor = bank; batchId = Id "transfer 1"; id = Id "0")
   -- Allocate with passthrough
   instructionCid2 <- submit ccp do
     exerciseCmd instructionCid2 Instruction.Allocate with
-      actors = S.singleton ccp
+      actors = Set.singleton ccp
       allocation = PassThroughFrom
         (ccpAccount, InstructionKey with instructor = bank; batchId = Id "transfer 1"; id = Id "1")
 
   -- Allocate instruction
   (instructionCid1, _) <- submit sender do
     exerciseCmd instructionCid1 Instruction.Allocate with
-      actors = S.singleton sender
+      actors = Set.singleton sender
       allocation = Pledge holdingCid
 
   -- Settle batch
   [cashHoldingCid] <- submitMulti [settler] [publicParty] do
-    exerciseCmd batchCid Batch.Settle with actors = S.singleton settler
+    exerciseCmd batchCid Batch.Settle with actors = Set.singleton settler
 
   -- Assert state
   let ts = [(receiver, cashHoldingCid)]

--- a/src/test/daml/Daml/Finance/Test/Util/Account.daml
+++ b/src/test/daml/Daml/Finance/Test/Util/Account.daml
@@ -7,8 +7,8 @@ module Daml.Finance.Test.Util.Account where
 
 import DA.Assert ((===))
 import DA.List (head)
-import DA.Map qualified as M (fromList)
-import DA.Set qualified as S (empty, fromList, singleton)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (fromList, singleton)
 import Daml.Finance.Account.Account qualified as Account (Factory(..))
 import Daml.Finance.Interface.Account.Account qualified as Account (Controllers(..), Credit(..), Debit(..), GetCid(..), I, R)
 import Daml.Finance.Interface.Account.Factory qualified as AccountFactory (Create(..), I)
@@ -35,18 +35,18 @@ toControllers : Party -> Party -> ControlledBy -> Account.Controllers
 toControllers custodian owner controlledBy =
   case controlledBy of
     Owner -> Account.Controllers with
-      outgoing = S.singleton owner; incoming = S.singleton owner
+      outgoing = Set.singleton owner; incoming = Set.singleton owner
     Custodian -> Account.Controllers with
-      outgoing = S.singleton custodian; incoming = S.singleton custodian
+      outgoing = Set.singleton custodian; incoming = Set.singleton custodian
     OwnerAndCustodian -> Account.Controllers with
-      outgoing = S.fromList [owner, custodian]; incoming = S.fromList [owner, custodian]
+      outgoing = Set.fromList [owner, custodian]; incoming = Set.fromList [owner, custodian]
     OwnerWithAutoApproval -> Account.Controllers with
-      outgoing = S.singleton owner; incoming = S.empty
+      outgoing = Set.singleton owner; incoming = mempty
 
 -- | Create factory for `Account`.
 createFactory : Party -> [(Text, Parties)] -> Script (ContractId Account.Factory)
 createFactory provider observers = submit provider do
-  createCmd Account.Factory with provider; observers = M.fromList observers
+  createCmd Account.Factory with provider; observers = Map.fromList observers
 
 -- | Create `Account`.
 createAccount : Text -> [Party] -> ContractId AccountFactory.I -> HoldingFactoryKey ->
@@ -59,7 +59,7 @@ createAccount description readAs accpountFactoryCid holdingFactory observers con
     submitMulti [custodian, owner] readAs do
       exerciseCmd accpountFactoryCid AccountFactory.Create with
         account; holdingFactory; controllers = toControllers custodian owner controlledBy
-        observers = M.fromList observers; description
+        observers = Map.fromList observers; description
     pure account
 
 -- | Credit an `Account`.

--- a/src/test/daml/Daml/Finance/Test/Util/Instrument.daml
+++ b/src/test/daml/Daml/Finance/Test/Util/Instrument.daml
@@ -6,7 +6,7 @@
 module Daml.Finance.Test.Util.Instrument where
 
 import DA.List (head)
-import DA.Map qualified as M (empty, fromList)
+import DA.Map (fromList)
 import Daml.Finance.Instrument.Token.Factory qualified as Token (Factory(..))
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (GetCid(..), R)
 import Daml.Finance.Interface.Instrument.Token.Factory qualified as TokenFactory (Create(..), I)
@@ -20,7 +20,7 @@ originate : Party -> Party -> Text -> HoldingStandard -> Text-> [(Text, Parties)
   -> Script InstrumentKey
 originate depository issuer label holdingStandard description observers timestamp = do
   tokenFactoryCid <- toInterfaceContractId @TokenFactory.I <$> submit issuer do
-    createCmd Token.Factory with provider = issuer; observers = M.empty
+    createCmd Token.Factory with provider = issuer; observers = mempty
   let
     instrumentKey = InstrumentKey with
       depository
@@ -35,7 +35,7 @@ originate depository issuer label holdingStandard description observers timestam
   submitMulti [depository, issuer] [] do
     exerciseCmd tokenFactoryCid TokenFactory.Create with
       token
-      observers = M.fromList observers
+      observers = fromList observers
   submitMulti [depository, issuer] [] do archiveCmd tokenFactoryCid
   pure instrumentKey
 

--- a/src/test/daml/Daml/Finance/Test/Util/Lifecycle.daml
+++ b/src/test/daml/Daml/Finance/Test/Util/Lifecycle.daml
@@ -4,8 +4,8 @@
 module Daml.Finance.Test.Util.Lifecycle where
 
 import DA.List (sort)
-import DA.Map qualified as M (empty, fromList)
-import DA.Set qualified as S (empty, fromList, singleton)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (fromList, singleton)
 import Daml.Finance.Claims.Lifecycle.Rule (Rule(..))
 import Daml.Finance.Claims.Lifecycle.Rule qualified as Lifecycle (Rule(..))
 import Daml.Finance.Data.Time.DateClock (dateToDateClockTime)
@@ -25,13 +25,13 @@ lifecycleInstrument : [Party] -> Date -> InstrumentKey -> Party ->
   [ContractId NumericObservable.I] -> Script (Optional InstrumentKey, [ContractId Effect.I])
 lifecycleInstrument readAs today instrument issuer observableCids = do
   -- Create a clock update event
-  clockEventCid <- createClockUpdateEvent (S.singleton issuer) today S.empty
+  clockEventCid <- createClockUpdateEvent (Set.singleton issuer) today mempty
 
   -- Create a lifecycle rule
   lifecycleRuleCid <- toInterfaceContractId @Lifecycle.I <$> submit issuer do
     createCmd Rule with
-      providers = S.singleton issuer
-      observers= M.empty
+      providers = Set.singleton issuer
+      observers = mempty
       lifecycler = issuer
       id = Id "LifecycleRule"
       description = "Rule to lifecycle an instrument"
@@ -99,13 +99,13 @@ createElectionAndLifecycleRule today amount instrument electorIsOwner issuer ele
   electionFactoryCid <- submit issuer do
     toInterfaceContractId @ElectionFactory.I <$> createCmd Election.Factory with
       provider = issuer
-      observers = M.fromList [("Observers", S.fromList [elector, issuer])]
+      observers = Map.fromList [("Observers", Set.fromList [elector, issuer])]
 
   -- Create a lifecycle rule
   lifecycleRuleCid <- toInterfaceContractId <$> submit issuer do
     createCmd Lifecycle.Rule with
-      providers = S.singleton issuer
-      observers = M.empty
+      providers = Set.singleton issuer
+      observers = mempty
       lifecycler = issuer
       id = Id "LifecycleRule"
       description = "Rule to lifecycle an Election based instrument"
@@ -116,7 +116,7 @@ createElectionAndLifecycleRule today amount instrument electorIsOwner issuer ele
     description = "election for a callable bond"
   electionCid <- submit elector do
     exerciseCmd electionFactoryCid ElectionFactory.Create with
-      actors = S.singleton elector
+      actors = Set.singleton elector
       id = Id "election id"
       description
       claim = electedTag
@@ -126,7 +126,7 @@ createElectionAndLifecycleRule today amount instrument electorIsOwner issuer ele
       counterparty
       instrument
       amount
-      observers = M.fromList [("Holders", S.fromList [issuer, elector, counterparty])]
+      observers = Map.fromList [("Holders", Set.fromList [issuer, elector, counterparty])]
       provider = issuer
 
   pure (electionCid, lifecycleRuleCid)

--- a/src/test/daml/Daml/Finance/Util/Test/Common.daml
+++ b/src/test/daml/Daml/Finance/Util/Test/Common.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Util.Test.Common where
 
 import DA.Assert ((===))
 import DA.List (group, groupBy, groupOn, sort)
-import DA.Map qualified as M (fromList, lookup)
+import DA.Map qualified as Map (fromList, lookup)
 import DA.Optional (fromSome)
 import Daml.Finance.Interface.Types.Common.Types (Id(..))
 import Daml.Finance.Util.Common (sortAndGroupOn)
@@ -31,8 +31,8 @@ testSortAndGroupOn = script do
 
   let
     keys = [Id "1", Id "3", Id "222", Id "0"];
-    map = M.fromList [(Id "222", "a"), (Id "0", "b"), (Id "1", "c"), (Id "3", "d")]
-    lookupAll keys map = fromSome . (`M.lookup` map) <$> keys
+    map = Map.fromList [(Id "222", "a"), (Id "0", "b"), (Id "1", "c"), (Id "3", "d")]
+    lookupAll keys map = fromSome . (`Map.lookup` map) <$> keys
   lookupAll keys map === ["c", "d", "a", "b"]
 
   pure ()

--- a/src/test/daml/Daml/Finance/Util/Test/Disclosure.daml
+++ b/src/test/daml/Daml/Finance/Util/Test/Disclosure.daml
@@ -4,9 +4,9 @@
 module Daml.Finance.Util.Test.Disclosure where
 
 import DA.Assert ((===))
-import DA.Map qualified as M (fromList, lookup, member)
+import DA.Map qualified as Map (fromList, lookup, member)
 import DA.Optional (fromSome)
-import DA.Set qualified as S (fromList, singleton)
+import DA.Set qualified as Set (fromList, singleton)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (AddObservers(..), I, RemoveObservers(..), SetObservers(..), View(..), flattenObservers)
 import Daml.Finance.Test.Util.Common (createParties)
@@ -23,7 +23,7 @@ template TestDisclosure
     observer Disclosure.flattenObservers observers
 
     interface instance Disclosure.I for TestDisclosure where
-      view = Disclosure.View with disclosureControllers = S.fromList [p1, p2]; observers
+      view = Disclosure.View with disclosureControllers = Set.fromList [p1, p2]; observers
       setObservers = setObserversImpl @TestDisclosure @Disclosure.I this None
       addObservers = addObserversImpl @TestDisclosure @Disclosure.I this None
       removeObservers = removeObserversImpl @TestDisclosure @Disclosure.I this None
@@ -42,39 +42,39 @@ run = script do
   -- only disclosure controllers, i.e., custodian or issuer, can `SetObservers`.
   cid <- submit custodian do
     exerciseCmd cid Disclosure.SetObservers with
-      disclosers = S.singleton custodian
-      newObservers = M.fromList [("context 1", S.fromList [alice, bob])]
+      disclosers = Set.singleton custodian
+      newObservers = Map.fromList [("context 1", Set.fromList [alice, bob])]
   submitMustFail alice do
     exerciseCmd cid Disclosure.SetObservers with
-      disclosers = S.singleton alice
-      newObservers = M.fromList [("context 2", S.fromList [alice, bob])]
+      disclosers = Set.singleton alice
+      newObservers = Map.fromList [("context 2", Set.fromList [alice, bob])]
   cid <- submit issuer do
     exerciseCmd cid Disclosure.SetObservers with
-      disclosers = S.singleton issuer
-      newObservers =
-        M.fromList [("context 1", S.fromList [alice, bob]), ("context 2", S.fromList [alice, bob])]
+      disclosers = Set.singleton issuer
+      newObservers = Map.fromList
+        [("context 1", Set.fromList [alice, bob]), ("context 2", Set.fromList [alice, bob])]
 
   -- Add observers
   -- any disclosure controller can `AddObservers`, but no others
   -- add observers (for context 3)
   cid <- submit custodian do
     exerciseCmd cid Disclosure.AddObservers with
-      disclosers = S.singleton custodian
-      observersToAdd = ("context 3", S.fromList [alice, bob, charlie])
+      disclosers = Set.singleton custodian
+      observersToAdd = ("context 3", Set.fromList [alice, bob, charlie])
   -- add observers (for context 4)
   cid <- submit issuer do
     exerciseCmd cid Disclosure.AddObservers with
-      disclosers = S.singleton issuer
-      observersToAdd = ("context 4", S.fromList [alice, bob])
+      disclosers = Set.singleton issuer
+      observersToAdd = ("context 4", Set.fromList [alice, bob])
   -- a non-disclosure controller can't add observers
   submitMustFail alice do
     exerciseCmd cid Disclosure.AddObservers with
-      disclosers = S.singleton alice; observersToAdd = ("context 4", S.singleton charlie)
+      disclosers = Set.singleton alice; observersToAdd = ("context 4", Set.singleton charlie)
   -- add obsevers (for context 4)
   cid <- submit issuer do
     exerciseCmd cid Disclosure.AddObservers with
-      disclosers = S.singleton issuer
-      observersToAdd = ("context 4", S.singleton charlie)
+      disclosers = Set.singleton issuer
+      observersToAdd = ("context 4", Set.singleton charlie)
 
   -- Remove observers
   -- any disclosure controller can remove observers (from any context)
@@ -82,79 +82,79 @@ run = script do
   Some cid <- submit custodian do
     exerciseCmd cid
       Disclosure.RemoveObservers with
-        disclosers = S.singleton custodian
-        observersToRemove = ("context 3", S.singleton charlie)
+        disclosers = Set.singleton custodian
+        observersToRemove = ("context 3", Set.singleton charlie)
   -- remove observer party (no update necessary)
   None <- submit issuer do
     exerciseCmd cid
       Disclosure.RemoveObservers with
-         disclosers = S.singleton issuer
-         observersToRemove = ("context 3", S.singleton charlie)
+         disclosers = Set.singleton issuer
+         observersToRemove = ("context 3", Set.singleton charlie)
   -- remove observer party (for context 3)
   Some cid <- submit issuer do
     exerciseCmd cid
       Disclosure.RemoveObservers with
-        disclosers = S.singleton issuer
-        observersToRemove = ("context 3", S.fromList [alice, bob])
+        disclosers = Set.singleton issuer
+        observersToRemove = ("context 3", Set.fromList [alice, bob])
   -- assert no context 3
   Some testDisclosure <- queryContractId issuer $ fromInterfaceContractId @TestDisclosure cid
-  M.member "context 3" testDisclosure.observers === False
+  Map.member "context 3" testDisclosure.observers === False
   -- any party of a context can remove any other party in the same context
   Some cid <- submit alice do
     exerciseCmd cid
       Disclosure.RemoveObservers with
-         disclosers = S.singleton alice
-         observersToRemove = ("context 4", S.singleton charlie)
+         disclosers = Set.singleton alice
+         observersToRemove = ("context 4", Set.singleton charlie)
   -- unauthorized party can't remove observer party
   submitMustFail charlie do
     exerciseCmd cid
       Disclosure.RemoveObservers with
-         disclosers = S.singleton charlie
-         observersToRemove = ("context 4", S.singleton alice)
+         disclosers = Set.singleton charlie
+         observersToRemove = ("context 4", Set.singleton alice)
   Some cid <- submit bob do
     exerciseCmd cid
       Disclosure.RemoveObservers with
-         disclosers = S.singleton bob
-         observersToRemove = ("context 4", S.fromList [alice, bob])
+         disclosers = Set.singleton bob
+         observersToRemove = ("context 4", Set.fromList [alice, bob])
   -- assert no context 4
   Some testDisclosure <- queryContractId issuer $ fromInterfaceContractId @TestDisclosure cid
-  M.member "context 4" testDisclosure.observers === False
+  Map.member "context 4" testDisclosure.observers === False
   -- can't remove a party for a non-existent context
   None <- submit issuer do
     exerciseCmd cid
       Disclosure.RemoveObservers with
-         disclosers = S.singleton issuer
-         observersToRemove = ("non-existing context", S.fromList [alice, bob])
+         disclosers = Set.singleton issuer
+         observersToRemove = ("non-existing context", Set.fromList [alice, bob])
   -- a disclosure controller can remove all parties
   Some cid <- submit custodian do
     exerciseCmd cid
       Disclosure.RemoveObservers with
-         disclosers = S.singleton custodian
-         observersToRemove = ("context 1", S.fromList [alice, bob, custodian])
+         disclosers = Set.singleton custodian
+         observersToRemove = ("context 1", Set.fromList [alice, bob, custodian])
   -- assert no context 1
   Some testDisclosure <- queryContractId issuer $ fromInterfaceContractId @TestDisclosure cid
-  M.member "context 1" testDisclosure.observers === False
+  Map.member "context 1" testDisclosure.observers === False
 
   -- Any authorized party can remove observers together with an unauthorized party
   Some cid <- submitMulti [alice, charlie] [] do
     exerciseCmd cid Disclosure.RemoveObservers with
-      disclosers = S.fromList [alice, charlie]
-      observersToRemove = ("context 2", S.fromList [alice, bob])
+      disclosers = Set.fromList [alice, charlie]
+      observersToRemove = ("context 2", Set.fromList [alice, bob])
   -- assert no context 2
   Some testDisclosure <- queryContractId custodian $ fromInterfaceContractId @TestDisclosure cid
-  M.member "context 2" testDisclosure.observers === False
+  Map.member "context 2" testDisclosure.observers === False
   -- Any authorized party can set observers together with an unauthorized party
   cid <- submitMulti [custodian, charlie] [] do
     exerciseCmd cid Disclosure.SetObservers with
-      disclosers = S.fromList [custodian, charlie]
-      newObservers = M.fromList [("context 2", S.singleton alice)]
+      disclosers = Set.fromList [custodian, charlie]
+      newObservers = Map.fromList [("context 2", Set.singleton alice)]
   -- Any authorized party can add observers together with an unauthorized party
   cid <- submitMulti [custodian, charlie] [] do
     exerciseCmd cid Disclosure.AddObservers with
-      disclosers = S.fromList [custodian, charlie]
-      observersToAdd = ("context 2", S.singleton bob)
+      disclosers = Set.fromList [custodian, charlie]
+      observersToAdd = ("context 2", Set.singleton bob)
   -- assert context 2 is set properly
   Some testDisclosure <- queryContractId custodian $ fromInterfaceContractId @TestDisclosure cid
-  fromSome (M.lookup "context 2" testDisclosure.observers) === S.fromList [alice, bob]
+  fromSome (Map.lookup "context 2" testDisclosure.observers) === Set.fromList [alice, bob]
 
   pure ()


### PR DESCRIPTION
* Uses Set and Map as qualified import names instead of S and M (and use the monoid `mempty` instead of the more verbose `Set.empty` and `Map.empty`)
* Refactors a few qualified import names