### PR TITLE
daml from artifactory

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,3 @@
-use nix
-
 source_env_if_exists .envrc.private
-
+use nix
 watch_file daml.yaml

--- a/nix/daml.nix
+++ b/nix/daml.nix
@@ -1,16 +1,41 @@
-{ stdenv, jdk, version }:
+{ stdenv, jdk, curl, curl_cert, version, os, hashes }:
 let
-  os = if stdenv.isDarwin then "macos" else "linux";
-  tarball = fetchTarball {
-    url = "https://github.com/digital-asset/daml/releases/download/v${version}/daml-sdk-${version}-${os}.tar.gz";
+  tarball = stdenv.mkDerivation {
+    pname = "daml-tarball";
+    version = version;
+    src = ./..;
+    buildInputs = [ curl ];
+    SSL_CERT_FILE = curl_cert;
+    impureEnvVars = [ "ARTIFACTORY_USERNAME" "ARTIFACTORY_PASSWORD" ];
+    buildPhase = ''
+      set -euo pipefail
+
+      if [ -n "''${ARTIFACTORY_PASSWORD:-}" ]; then
+        curl -u $ARTIFACTORY_USERNAME:$ARTIFACTORY_PASSWORD \
+             https://digitalasset.jfrog.io/artifactory/assembly/daml/${version}/daml-sdk-${version}-${os}.tar.gz \
+          > $out
+      else
+        echo "ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD must be set." >&2
+        exit 1
+      fi
+    '';
+    dontInstall = true;
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = hashes.${os};
   };
 in
   stdenv.mkDerivation {
-    name = "daml-sdk";
-    version = "$version";
+    pname = "daml-sdk";
+    version = version;
     src = tarball;
-    buildPhase = "patchShebangs .";
-    installPhase = "DAML_HOME=$out ./install.sh";
+    dontUnpack = true;
+    buildPhase = ''
+      mkdir daml
+      tar xzf $src -C daml --strip-components 1
+      patchShebangs .
+    '';
+    installPhase = "cd daml; DAML_HOME=$out ./install.sh";
     propagatedBuildInputs = [ jdk ];
     preFixup = ''
       # Set DAML_HOME automatically.

--- a/shell.nix
+++ b/shell.nix
@@ -18,7 +18,12 @@ pkgs.mkShell {
   buildInputs = [
     (daml { stdenv = pkgs.stdenv;
             jdk = pkgs.openjdk11_headless;
-            version = damlYaml.sdk-version; })
+            curl = pkgs.curl;
+            curl_cert = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+            version = damlYaml.sdk-version;
+            os = if pkgs.stdenv.isDarwin then "macos" else "linux";
+            hashes = { linux = "sha256-aiYGXjOtVMtAthaTMz4EIkQC0M4H68y1FH3eHZC3Hhw=";
+                       macos = "sha256-DuMQRBTd+S4T0m1Uuf+O4i5gCQz5QpJun/bkf6eqCNI="; };})
     (packell { pkgs = pkgsGhc; stdenv = pkgsGhc.stdenv; version = "0.0.2"; })
     pkgs.bash
     pkgs.binutils # cp, grep, etc.


### PR DESCRIPTION
Context: If we want to be able to publish all of Daml Enterprise in one step, individual components need to depend directly on other individual components, rather than on the published package.