### PR TITLE
Remove type synonym F (for packages with major version changes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,7 @@ This document tracks pending changes to packages. It is facilitating the write-u
   state, requiring them to be unlocked first. Notably, the type signatures for `splitImpl` and
   `mergeImpl` have been modified, and the re-entrant lock logic of `transferImpl` removed.
 
-- Added `T` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+- Renamed the `F` type synonym to `T`.
 
 ### Daml.Finance.Instrument.Bond
 
@@ -125,7 +125,7 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - The `Remove` implementation was removed from the `Factory` (it is newly part of the `Base`
   instrument interface).
 
-- Added `T` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+- Renamed the `F` type synonym to `T`.
 
 - Added support for SOFR style rates (via a compounded index) to the floating rate bond.
 
@@ -138,7 +138,7 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - The `Remove` implementation was removed from the `Factory` (it is newly part of the `Base`
   instrument interface).
 
-- Added `T` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+- Renamed the `F` type synonym to `T`.
 
 ### Daml.Finance.Instrument.Generic
 
@@ -149,7 +149,7 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - The `Remove` implementation was removed from the `Factory` (it is newly part of the `Base`
   instrument interface).
 
-- Added `T` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+- Renamed the `F` type synonym to `T`.
 
 ### Daml.Finance.Instrument.Option
 
@@ -160,7 +160,7 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - The `Remove` implementation was removed from the `Factory` (it is newly part of the `Base`
   instrument interface).
 
-- Added `T` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+- Renamed the `F` type synonym to `T`.
 
 - Removed the `Remove` choice from the election factory.
 
@@ -177,7 +177,7 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - The `Remove` implementation was removed from the `Factory` (it is newly part of the `Base`
   instrument interface).
 
-- Added `T` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+- Renamed the `F` type synonym to `T`.
 
 - Added support for SOFR style rates (via a compounded index) to the interest rate swap.
 
@@ -190,7 +190,7 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - The `Remove` implementation was removed from the `Factory` (it is newly part of the `Base`
   instrument interface).
 
-- Added `T` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+- Renamed the `F` type synonym to `T`.
 
 ### Daml.Finance.Interface.Account
 
@@ -204,7 +204,7 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - The `Create` choice of the account's `Factory` has been adapted, it now takes a
   `HoldingFactoryKey` instead of the `ContractId Daml.Finance.Interface.Holding.Factory` as input
 
-- Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+- Renamed the `F` type synonym to `I` .
 
 ### Daml.Finance.Interface.Claims
 
@@ -234,7 +234,7 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 - Renamed `Base` to `Holding`.
 
-- Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+- Renamed the `F` type synonym to `I`.
 
 ### Daml.Finance.Interface.Instrument.Base
 
@@ -247,6 +247,11 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
 
 - Made the `issuer` a single-maintainer of the `Instrument` key.
+
+- Added an enumeration data type `HoldingStandard` to the `InstrumentKey` for referring to various
+  holding standards.
+
+- Renamed the `F` type synonym to `I`.
 
 ### Daml.Finance.Interface.Instrument.Bond
 
@@ -261,6 +266,11 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 - Added support for SOFR style rates (via a compounded index) to the floating rate bond.
 
+- Added an enumeration data type `HoldingStandard` to the `InstrumentKey` for referring to various
+  holding standards.
+
+- Renamed the `F` type synonym to `I`.
+
 ### Daml.Finance.Interface.Instrument.Equity
 
 - Update of SDK version and dependencies.
@@ -270,7 +280,7 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - The `Remove` choice was removed from the `Factory` (it is newly part of the `Base` instrument
   interface).
 
-- Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+- Renamed the `F` type synonym to `I`.
 
 ### Daml.Finance.Interface.Instrument.Generic
 
@@ -281,7 +291,7 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - The `Remove` choice was removed from the `Factory` (it is newly part of the `Base` instrument
   interface).
 
-- Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+- Renamed the `F` type synonym to `I`.
 
 ### Daml.Finance.Interface.Instrument.Option
 
@@ -294,7 +304,7 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - The `Remove` choice was removed from the `Factory` (it is newly part of the `Base` instrument
   interface).
 
-- Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+- Renamed the `F` type synonym to `I`.
 
 ### Daml.Finance.Interface.Instrument.StructuredProduct
 
@@ -309,7 +319,7 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - The `Remove` choice was removed from the `Factory` (it is newly part of the `Base` instrument
   interface).
 
-- Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+- Renamed the `F` type synonym to `I`.
 
 - Added support for SOFR style rates (via a compounded index) to the interest rate swap.
 
@@ -322,7 +332,7 @@ This document tracks pending changes to packages. It is facilitating the write-u
 - The `Remove` choice was removed from the `Factory` (it is newly part of the `Base` instrument
   interface).
 
-- Added `I` as type synonym for `Factory` (the `F` type synonym is to be deprecated).
+- Renamed the `F` type synonym to `I`.
 
 ### Daml.Finance.Interface.Instrument.Types
 
@@ -332,8 +342,7 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 - Update of SDK version and dependencies.
 
-- Added `I` as type synonym for each `Factory` in the package (the `F` type synonyms are to be
-  deprecated).
+- Renamed the `F` type synonym to `I`.
 
 - Changed the `Calculate` choice of the `Effect.I` to take a quantity as argument instead of a
   `ContractId Holding` (in order to not leak information about the holding to the effect provider).

--- a/src/main/daml/Daml/Finance/Holding/Factory.daml
+++ b/src/main/daml/Daml/Finance/Holding/Factory.daml
@@ -14,9 +14,8 @@ import Daml.Finance.Interface.Types.Common.Types qualified as HoldingStandard (H
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type T = Factory
-type F = Factory -- to be deprecated
 
 -- | Implementation of a factory template for holdings.
 template Factory

--- a/src/main/daml/Daml/Finance/Instrument/Bond/Callable/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/Callable/Factory.daml
@@ -13,9 +13,8 @@ import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type T = Factory
-type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory

--- a/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/FixedRate/Factory.daml
@@ -13,9 +13,8 @@ import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type T = Factory
-type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory

--- a/src/main/daml/Daml/Finance/Instrument/Bond/InflationLinked/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/InflationLinked/Factory.daml
@@ -13,9 +13,8 @@ import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type T = Factory
-type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory

--- a/src/main/daml/Daml/Finance/Instrument/Bond/ZeroCoupon/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Bond/ZeroCoupon/Factory.daml
@@ -13,9 +13,8 @@ import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type T = Factory
-type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory

--- a/src/main/daml/Daml/Finance/Instrument/Equity/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Equity/Factory.daml
@@ -11,9 +11,8 @@ import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type T = Factory
-type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory

--- a/src/main/daml/Daml/Finance/Instrument/Generic/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Generic/Factory.daml
@@ -11,9 +11,8 @@ import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type T = Factory
-type F = Factory -- to be deprecated
 
 -- | Factory template for generic instrument creation.
 template Factory

--- a/src/main/daml/Daml/Finance/Instrument/Option/BarrierEuropeanCash/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Option/BarrierEuropeanCash/Factory.daml
@@ -13,9 +13,8 @@ import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type T = Factory
-type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory

--- a/src/main/daml/Daml/Finance/Instrument/Option/Dividend/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Option/Dividend/Factory.daml
@@ -13,9 +13,8 @@ import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type T = Factory
-type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory

--- a/src/main/daml/Daml/Finance/Instrument/Option/EuropeanCash/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Option/EuropeanCash/Factory.daml
@@ -13,9 +13,8 @@ import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type T = Factory
-type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory

--- a/src/main/daml/Daml/Finance/Instrument/Option/EuropeanPhysical/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Option/EuropeanPhysical/Factory.daml
@@ -13,9 +13,8 @@ import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type T = Factory
-type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory

--- a/src/main/daml/Daml/Finance/Instrument/StructuredProduct/BarrierReverseConvertible/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/StructuredProduct/BarrierReverseConvertible/Factory.daml
@@ -13,9 +13,8 @@ import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type T = Factory
-type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Asset/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Asset/Factory.daml
@@ -13,9 +13,8 @@ import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type T = Factory
-type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Currency/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Currency/Factory.daml
@@ -13,9 +13,8 @@ import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type T = Factory
-type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory

--- a/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/ForeignExchange/Factory.daml
@@ -13,9 +13,8 @@ import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type T = Factory
-type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Factory.daml
@@ -13,9 +13,8 @@ import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type T = Factory
-type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory

--- a/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/InterestRate/Factory.daml
@@ -13,9 +13,8 @@ import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type T = Factory
-type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory

--- a/src/main/daml/Daml/Finance/Instrument/Token/Factory.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Token/Factory.daml
@@ -12,9 +12,8 @@ import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type T = Factory
-type F = Factory -- to be deprecated
 
 -- | Factory template for instrument creation.
 template Factory

--- a/src/main/daml/Daml/Finance/Interface/Account/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Account/Factory.daml
@@ -7,9 +7,8 @@ import Daml.Finance.Interface.Account.Account qualified as Account (Controllers(
 import Daml.Finance.Interface.Types.Common.Types (AccountKey(..), HoldingFactoryKey, PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type I = Factory
-type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Holding/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Holding/Factory.daml
@@ -11,9 +11,8 @@ import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (AddObserv
 import Daml.Finance.Interface.Util.InterfaceKey (createReferenceHelper, disclosureUpdateReferenceHelper, exerciseInterfaceByKeyHelper)
 import Daml.Finance.Interface.Util.InterfaceKey qualified as InterfaceKey (HasInterfaceKey(..))
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type I = Factory
-type F = Factory -- to be deprecated
 
 -- | Type synonym for `Reference`. This type is currently used as a work-around given the lack of
 -- interface keys.

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Bond/Callable/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Bond/Callable/Factory.daml
@@ -8,9 +8,8 @@ import Daml.Finance.Interface.Instrument.Bond.Callable.Types (Callable)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type I = Factory
-type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Bond/FixedRate/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Bond/FixedRate/Factory.daml
@@ -8,9 +8,8 @@ import Daml.Finance.Interface.Instrument.Bond.FixedRate.Types (FixedRate)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type I = Factory
-type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Bond/FloatingRate/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Bond/FloatingRate/Factory.daml
@@ -8,9 +8,8 @@ import Daml.Finance.Interface.Instrument.Bond.FloatingRate.Types (FloatingRate)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type I = Factory
-type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Bond/InflationLinked/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Bond/InflationLinked/Factory.daml
@@ -8,9 +8,8 @@ import Daml.Finance.Interface.Instrument.Bond.InflationLinked.Types (InflationLi
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type I = Factory
-type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Bond/ZeroCoupon/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Bond/ZeroCoupon/Factory.daml
@@ -8,9 +8,8 @@ import Daml.Finance.Interface.Instrument.Bond.ZeroCoupon.Types (ZeroCoupon)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type I = Factory
-type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Equity/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Equity/Factory.daml
@@ -7,9 +7,8 @@ import Daml.Finance.Interface.Instrument.Equity.Instrument qualified as Instrume
 import Daml.Finance.Interface.Types.Common.Types (InstrumentKey(..), PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type I = Factory
-type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Generic/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Generic/Factory.daml
@@ -8,9 +8,8 @@ import Daml.Finance.Interface.Instrument.Generic.Instrument qualified as Instrum
 import Daml.Finance.Interface.Types.Common.Types (InstrumentKey(..), PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type I = Factory
-type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Option/BarrierEuropeanCash/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Option/BarrierEuropeanCash/Factory.daml
@@ -8,9 +8,8 @@ import Daml.Finance.Interface.Instrument.Option.BarrierEuropeanCash.Types (Barri
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type I = Factory
-type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Option/Dividend/Election/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Option/Dividend/Election/Factory.daml
@@ -8,9 +8,8 @@ import Daml.Finance.Interface.Lifecycle.Election qualified as Election (I)
 import Daml.Finance.Interface.Types.Common.Types (Id, InstrumentKey(..), Parties, PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type I = Factory
-type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Option/Dividend/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Option/Dividend/Factory.daml
@@ -8,9 +8,8 @@ import Daml.Finance.Interface.Instrument.Option.Dividend.Types (Dividend)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type I = Factory
-type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Option/EuropeanCash/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Option/EuropeanCash/Factory.daml
@@ -8,9 +8,8 @@ import Daml.Finance.Interface.Instrument.Option.EuropeanCash.Types (European)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type I = Factory
-type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Option/EuropeanPhysical/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Option/EuropeanPhysical/Factory.daml
@@ -8,9 +8,8 @@ import Daml.Finance.Interface.Instrument.Option.EuropeanPhysical.Types (European
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type I = Factory
-type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/StructuredProduct/BarrierReverseConvertible/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/StructuredProduct/BarrierReverseConvertible/Factory.daml
@@ -8,9 +8,8 @@ import Daml.Finance.Interface.Instrument.StructuredProduct.BarrierReverseConvert
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type I = Factory
-type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Asset/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Asset/Factory.daml
@@ -8,9 +8,8 @@ import Daml.Finance.Interface.Instrument.Swap.Asset.Types (Asset)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type I = Factory
-type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/CreditDefault/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/CreditDefault/Factory.daml
@@ -8,9 +8,8 @@ import Daml.Finance.Interface.Instrument.Swap.CreditDefault.Types (CreditDefault
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type I = Factory
-type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Currency/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Currency/Factory.daml
@@ -8,9 +8,8 @@ import Daml.Finance.Interface.Instrument.Swap.Currency.Types (CurrencySwap)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type I = Factory
-type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/ForeignExchange/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/ForeignExchange/Factory.daml
@@ -8,9 +8,8 @@ import Daml.Finance.Interface.Instrument.Swap.ForeignExchange.Types (ForeignExch
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type I = Factory
-type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Fpml/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/Fpml/Factory.daml
@@ -8,9 +8,8 @@ import Daml.Finance.Interface.Instrument.Swap.Fpml.Types (Fpml)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type I = Factory
-type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Swap/InterestRate/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Swap/InterestRate/Factory.daml
@@ -8,9 +8,8 @@ import Daml.Finance.Interface.Instrument.Swap.InterestRate.Types (InterestRate)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type I = Factory
-type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Instrument/Token/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Instrument/Token/Factory.daml
@@ -8,9 +8,8 @@ import Daml.Finance.Interface.Instrument.Token.Types (Token)
 import Daml.Finance.Interface.Types.Common.Types (PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type I = Factory
-type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Lifecycle/Election/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Lifecycle/Election/Factory.daml
@@ -7,9 +7,8 @@ import Daml.Finance.Interface.Lifecycle.Election qualified as Election (I)
 import Daml.Finance.Interface.Types.Common.Types (Id, InstrumentKey(..), Parties, PartiesMap)
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type I = Factory
-type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/main/daml/Daml/Finance/Interface/Settlement/Factory.daml
+++ b/src/main/daml/Daml/Finance/Interface/Settlement/Factory.daml
@@ -8,9 +8,8 @@ import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (I
 import Daml.Finance.Interface.Settlement.Types (RoutedStep)
 import Daml.Finance.Interface.Types.Common.Types (Id, Parties)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type I = Factory
-type F = Factory -- to be deprecated
 
 -- | Type synonym for `View`.
 type V = View

--- a/src/test/daml/Daml/Finance/Test/Util/HoldingDuplicates/Factory.daml
+++ b/src/test/daml/Daml/Finance/Test/Util/HoldingDuplicates/Factory.daml
@@ -19,9 +19,8 @@ import Daml.Finance.Test.Util.HoldingDuplicates.Transferable (Transferable(..))
 import Daml.Finance.Test.Util.HoldingDuplicates.TransferableFungible (TransferableFungible(..))
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
--- | Type synonyms for `Factory`.
+-- | Type synonym for `Factory`.
 type T = Factory
-type F = Factory -- to be deprecated
 
 -- | Implementation of a factory template for holdings.
 template Factory


### PR DESCRIPTION
Only package left with the `F` type synonym is
```
| Daml.Finance.Interface.Data                | 3.0.0              | 3.1.0          |
```