### PR TITLE
Bump SDK to 3.0.0

### DIFF
--- a/daml.yaml
+++ b/daml.yaml
@@ -16,6 +16,6 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-ctl/v2.3.0/daml-ctl-2.3.0.dar
+  - .lib/daml-ctl/v4.99.0.20240226.1/daml-ctl-4.99.0.20240226.1.dar
 build-options:
   - --include=src/main/daml

--- a/daml.yaml
+++ b/daml.yaml
@@ -5,9 +5,9 @@
 # to keep shell.nix in sync (CI will notice & fail)
 # You may need to comment out `daml` from the "buildInputs` list to get your
 # Nix shell to run while you update the hashes.
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 # daml-version is not used by the daml assistant, only by the finance nix config
-daml-version: 2.8.0
+daml-version: 3.0.0-snapshot.20240221.0
 name: daml-finance
 source: src/test/daml
 version: 1.3.11

--- a/docs/code-samples/getting-started/daml.yaml
+++ b/docs/code-samples/getting-started/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: quickstart-finance
 source: daml
 init-script: Scripts.Transfer:runTransfer

--- a/docs/code-samples/lifecycling/daml.yaml
+++ b/docs/code-samples/lifecycling/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: finance-lifecycling
 source: daml
 init-script: Scripts.FixedRateBond:runFixedRateBond

--- a/docs/code-samples/payoff-modeling/daml.yaml
+++ b/docs/code-samples/payoff-modeling/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: finance-payoff-modeling
 source: daml
 init-script: PayoffBuilder:runCreateAndLifecycle

--- a/docs/code-samples/settlement/daml.yaml
+++ b/docs/code-samples/settlement/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: finance-settlement
 source: daml
 init-script: Scripts.Transfer:runDualControlTransfer

--- a/docs/code-samples/upgrades/daml.yaml
+++ b/docs/code-samples/upgrades/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: finance-upgrades
 source: daml
 init-script: Scripts.UpgradeHolding:upgradeHolding

--- a/package/main/daml/ContingentClaims.Core/daml.yaml
+++ b/package/main/daml/ContingentClaims.Core/daml.yaml
@@ -4,10 +4,10 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: contingent-claims-core
 source: daml
-version: 2.0.1
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-ctl/v2.3.0/daml-ctl-2.3.0.dar
+  - .lib/daml-ctl/v4.99.0.20240226.1/daml-ctl-4.99.0.20240226.1.dar
 

--- a/package/main/daml/ContingentClaims.Core/daml.yaml
+++ b/package/main/daml/ContingentClaims.Core/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: contingent-claims-core
 source: daml
 version: 2.0.1

--- a/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
+++ b/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
@@ -4,12 +4,12 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: contingent-claims-lifecycle
 source: daml
-version: 2.0.1
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-ctl/v2.3.0/daml-ctl-2.3.0.dar
-  - .lib/daml-finance/ContingentClaims.Core/2.0.1/contingent-claims-core-2.0.1.dar
+  - .lib/daml-ctl/v4.99.0.20240226.1/daml-ctl-4.99.0.20240226.1.dar
+  - .lib/daml-finance/ContingentClaims.Core/4.99.0.20240226.1/contingent-claims-core-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
+++ b/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: contingent-claims-lifecycle
 source: daml
 version: 2.0.1

--- a/package/main/daml/ContingentClaims.Valuation/daml.yaml
+++ b/package/main/daml/ContingentClaims.Valuation/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: contingent-claims-valuation
 source: daml
 version: 0.2.2

--- a/package/main/daml/ContingentClaims.Valuation/daml.yaml
+++ b/package/main/daml/ContingentClaims.Valuation/daml.yaml
@@ -4,12 +4,12 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: contingent-claims-valuation
 source: daml
-version: 0.2.2
+version: 0.4.99.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-ctl/v2.3.0/daml-ctl-2.3.0.dar
-  - .lib/daml-finance/ContingentClaims.Core/2.0.1/contingent-claims-core-2.0.1.dar
+  - .lib/daml-ctl/v4.99.0.20240226.1/daml-ctl-4.99.0.20240226.1.dar
+  - .lib/daml-finance/ContingentClaims.Core/4.99.0.20240226.1/contingent-claims-core-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Account/daml.yaml
@@ -4,15 +4,15 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-account
 source: daml
-version: 3.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.0/daml-finance-interface-account-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/3.1.0/daml-finance-util-3.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240226.1/daml-finance-interface-account-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Account/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-account
 source: daml
 version: 3.0.0

--- a/package/main/daml/Daml.Finance.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Claims/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-claims
 source: daml
 version: 2.1.0

--- a/package/main/daml/Daml.Finance.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Claims/daml.yaml
@@ -4,21 +4,21 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-claims
 source: daml
-version: 2.1.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/ContingentClaims.Core/2.0.1/contingent-claims-core-2.0.1.dar
-  - .lib/daml-finance/ContingentClaims.Lifecycle/2.0.1/contingent-claims-lifecycle-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.0/daml-finance-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/3.1.0/daml-finance-util-3.1.0.dar
+  - .lib/daml-finance/ContingentClaims.Core/4.99.0.20240226.1/contingent-claims-core-4.99.0.20240226.1.dar
+  - .lib/daml-finance/ContingentClaims.Lifecycle/4.99.0.20240226.1/contingent-claims-lifecycle-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240226.1/daml-finance-interface-claims-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/4.99.0.20240226.1/daml-finance-interface-instrument-types-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/4.99.0.20240226.1/daml-finance-lifecycle-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Data/daml.yaml
@@ -4,16 +4,16 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-data
 source: daml
-version: 3.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Data/3.1.0/daml-finance-interface-data-3.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/3.1.0/daml-finance-util-3.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/4.99.0.20240226.1/daml-finance-interface-data-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Data/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-data
 source: daml
 version: 3.0.0

--- a/package/main/daml/Daml.Finance.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Holding/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-holding
 source: daml
 version: 3.0.0

--- a/package/main/daml/Daml.Finance.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Holding/daml.yaml
@@ -4,15 +4,15 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-holding
 source: daml
-version: 3.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.0/daml-finance-interface-account-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/3.1.0/daml-finance-util-3.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240226.1/daml-finance-interface-account-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-bond
 source: daml
 version: 2.0.0

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -4,21 +4,21 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-bond
 source: daml
-version: 2.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/ContingentClaims.Core/2.0.1/contingent-claims-core-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Claims/2.1.0/daml-finance-claims-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Data/3.0.0/daml-finance-data-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/2.0.0/daml-finance-interface-instrument-bond-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/3.1.0/daml-finance-util-3.1.0.dar
+  - .lib/daml-finance/ContingentClaims.Core/4.99.0.20240226.1/contingent-claims-core-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Claims/4.99.0.20240226.1/daml-finance-claims-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240226.1/daml-finance-data-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240226.1/daml-finance-interface-claims-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/4.99.0.20240226.1/daml-finance-interface-instrument-bond-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/4.99.0.20240226.1/daml-finance-interface-instrument-types-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
@@ -4,16 +4,16 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-equity
 source: daml
-version: 0.4.0
+version: 0.4.99.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.4.0/daml-finance-interface-instrument-equity-0.4.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.0/daml-finance-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/3.1.0/daml-finance-util-3.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.4.99.20240226.1/daml-finance-interface-instrument-equity-0.4.99.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/4.99.0.20240226.1/daml-finance-lifecycle-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-equity
 source: daml
 version: 0.4.0

--- a/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
@@ -4,19 +4,19 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-generic
 source: daml
-version: 3.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Claims/2.1.0/daml-finance-claims-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/3.0.0/daml-finance-interface-instrument-generic-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.0/daml-finance-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/3.1.0/daml-finance-util-3.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Claims/4.99.0.20240226.1/daml-finance-claims-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240226.1/daml-finance-interface-claims-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/4.99.0.20240226.1/daml-finance-interface-instrument-generic-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/4.99.0.20240226.1/daml-finance-lifecycle-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-generic
 source: daml
 version: 3.0.0

--- a/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-option
 source: daml
 version: 0.3.0

--- a/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
@@ -4,19 +4,19 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-option
 source: daml
-version: 0.3.0
+version: 0.4.99.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Claims/2.1.0/daml-finance-claims-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Data/3.0.0/daml-finance-data-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.3.0/daml-finance-interface-instrument-option-0.3.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.0/daml-finance-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/3.1.0/daml-finance-util-3.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Claims/4.99.0.20240226.1/daml-finance-claims-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240226.1/daml-finance-data-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240226.1/daml-finance-interface-claims-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.4.99.20240226.1/daml-finance-interface-instrument-option-0.4.99.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/4.99.0.20240226.1/daml-finance-lifecycle-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
@@ -4,20 +4,20 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-structuredproduct
 source: daml
-version: 0.1.0
+version: 0.4.99.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Claims/2.1.0/daml-finance-claims-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Data/3.0.0/daml-finance-data-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.3.0/daml-finance-interface-instrument-option-0.3.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.StructuredProduct/0.1.0/daml-finance-interface-instrument-structuredproduct-0.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/3.1.0/daml-finance-util-3.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Claims/4.99.0.20240226.1/daml-finance-claims-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240226.1/daml-finance-data-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240226.1/daml-finance-interface-claims-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.4.99.20240226.1/daml-finance-interface-instrument-option-0.4.99.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.StructuredProduct/0.4.99.20240226.1/daml-finance-interface-instrument-structuredproduct-0.4.99.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-structuredproduct
 source: daml
 version: 0.1.0

--- a/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-swap
 source: daml
 version: 0.4.0

--- a/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
@@ -4,23 +4,23 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-swap
 source: daml
-version: 0.4.0
+version: 0.4.99.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/ContingentClaims.Core/2.0.1/contingent-claims-core-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Claims/2.1.0/daml-finance-claims-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Data/3.0.0/daml-finance-data-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.4.0/daml-finance-interface-instrument-swap-0.4.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.0/daml-finance-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/3.1.0/daml-finance-util-3.1.0.dar
+  - .lib/daml-finance/ContingentClaims.Core/4.99.0.20240226.1/contingent-claims-core-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Claims/4.99.0.20240226.1/daml-finance-claims-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240226.1/daml-finance-data-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240226.1/daml-finance-interface-claims-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.4.99.20240226.1/daml-finance-interface-instrument-swap-0.4.99.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/4.99.0.20240226.1/daml-finance-interface-instrument-types-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/4.99.0.20240226.1/daml-finance-lifecycle-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
@@ -4,15 +4,15 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-token
 source: daml
-version: 3.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/3.0.0/daml-finance-interface-instrument-token-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/3.1.0/daml-finance-util-3.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/4.99.0.20240226.1/daml-finance-interface-instrument-token-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-token
 source: daml
 version: 3.0.0

--- a/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-account
 source: daml
 version: 3.0.0

--- a/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
@@ -4,13 +4,13 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-account
 source: daml
-version: 3.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
@@ -4,14 +4,14 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-claims
 source: daml
-version: 3.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/ContingentClaims.Core/2.0.1/contingent-claims-core-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/ContingentClaims.Core/4.99.0.20240226.1/contingent-claims-core-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-claims
 source: daml
 version: 3.0.0

--- a/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-data
 source: daml
 version: 3.1.0

--- a/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
@@ -4,14 +4,14 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-data
 source: daml
-version: 3.1.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-holding
 source: daml
 version: 3.0.0

--- a/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
@@ -4,12 +4,12 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-holding
 source: daml
-version: 3.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-instrument-base
 source: daml
 version: 3.0.0

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
@@ -4,13 +4,13 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-instrument-base
 source: daml
-version: 3.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
@@ -4,16 +4,16 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-instrument-bond
 source: daml
-version: 2.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240226.1/daml-finance-interface-claims-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/4.99.0.20240226.1/daml-finance-interface-instrument-types-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-instrument-bond
 source: daml
 version: 2.0.0

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
@@ -4,14 +4,14 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-instrument-equity
 source: daml
-version: 0.4.0
+version: 0.4.99.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-instrument-equity
 source: daml
 version: 0.4.0

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
@@ -4,14 +4,14 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-instrument-generic
 source: daml
-version: 3.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240226.1/daml-finance-interface-claims-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-instrument-generic
 source: daml
 version: 3.0.0

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-instrument-option
 source: daml
 version: 0.3.0

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
@@ -4,15 +4,15 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-instrument-option
 source: daml
-version: 0.3.0
+version: 0.4.99.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240226.1/daml-finance-interface-claims-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
@@ -4,15 +4,15 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-instrument-structuredproduct
 source: daml
-version: 0.1.0
+version: 0.4.99.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240226.1/daml-finance-interface-claims-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-instrument-structuredproduct
 source: daml
 version: 0.1.0

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-instrument-swap
 source: daml
 version: 0.4.0

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
@@ -4,15 +4,15 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-instrument-swap
 source: daml
-version: 0.4.0
+version: 0.4.99.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/4.99.0.20240226.1/daml-finance-interface-instrument-types-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-instrument-token
 source: daml
 version: 3.0.0

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
@@ -4,13 +4,13 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-instrument-token
 source: daml
-version: 3.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
@@ -4,11 +4,11 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-instrument-types
 source: daml
-version: 1.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-instrument-types
 source: daml
 version: 1.0.0

--- a/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
@@ -4,14 +4,14 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-lifecycle
 source: daml
-version: 3.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/3.0.0/daml-finance-interface-settlement-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/4.99.0.20240226.1/daml-finance-interface-settlement-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-lifecycle
 source: daml
 version: 3.0.0

--- a/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
@@ -4,13 +4,13 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-settlement
 source: daml
-version: 3.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-settlement
 source: daml
 version: 3.0.0

--- a/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-types-common
 source: daml
-version: 2.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-types-common
 source: daml
 version: 2.0.0

--- a/package/main/daml/Daml.Finance.Interface.Types.Date/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Date/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-types-date
 source: daml
-version: 2.1.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/main/daml/Daml.Finance.Interface.Types.Date/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Date/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-types-date
 source: daml
 version: 2.1.0

--- a/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
@@ -4,11 +4,11 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-util
 source: daml
-version: 2.1.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-interface-util
 source: daml
 version: 2.1.0

--- a/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-lifecycle
 source: daml
 version: 3.0.0

--- a/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
@@ -4,18 +4,18 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-lifecycle
 source: daml
-version: 3.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.0/daml-finance-interface-account-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/3.0.0/daml-finance-interface-settlement-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/3.1.0/daml-finance-util-3.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240226.1/daml-finance-interface-account-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/4.99.0.20240226.1/daml-finance-interface-settlement-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Settlement/daml.yaml
@@ -4,16 +4,16 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-settlement
 source: daml
-version: 3.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.0/daml-finance-interface-account-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/3.0.0/daml-finance-interface-settlement-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/3.1.0/daml-finance-util-3.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240226.1/daml-finance-interface-account-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/4.99.0.20240226.1/daml-finance-interface-settlement-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Settlement/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-settlement
 source: daml
 version: 3.0.0

--- a/package/main/daml/Daml.Finance.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Util/daml.yaml
@@ -4,13 +4,13 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-util
 source: daml
-version: 3.1.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-util
 source: daml
 version: 3.1.0

--- a/package/packages.yaml
+++ b/package/packages.yaml
@@ -11,8 +11,8 @@ remote:
           organisation: digital-asset
           name: daml-ctl
         base-module: Daml.Control
-        tag: v2.3.0
-        dar-name: daml-ctl-2.3.0.dar
+        tag: v4.99.0.20240226.1
+        dar-name: daml-ctl-4.99.0.20240226.1.dar
 local:
   repo:
     host: github.com

--- a/package/test/daml/ContingentClaims.Test/daml.yaml
+++ b/package/test/daml/ContingentClaims.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: contingent-claims-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/ContingentClaims.Test/daml.yaml
+++ b/package/test/daml/ContingentClaims.Test/daml.yaml
@@ -4,15 +4,15 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: contingent-claims-test
 source: daml
-version: 1.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-ctl/v2.3.0/daml-ctl-2.3.0.dar
-  - .lib/daml-finance/ContingentClaims.Core/2.0.1/contingent-claims-core-2.0.1.dar
-  - .lib/daml-finance/ContingentClaims.Lifecycle/2.0.1/contingent-claims-lifecycle-2.0.1.dar
-  - .lib/daml-finance/ContingentClaims.Valuation/0.2.2/contingent-claims-valuation-0.2.2.dar
+  - .lib/daml-ctl/v4.99.0.20240226.1/daml-ctl-4.99.0.20240226.1.dar
+  - .lib/daml-finance/ContingentClaims.Core/4.99.0.20240226.1/contingent-claims-core-4.99.0.20240226.1.dar
+  - .lib/daml-finance/ContingentClaims.Lifecycle/4.99.0.20240226.1/contingent-claims-lifecycle-4.99.0.20240226.1.dar
+  - .lib/daml-finance/ContingentClaims.Valuation/0.4.99.20240226.1/contingent-claims-valuation-0.4.99.20240226.1.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Account.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Account.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-account-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Account.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Account.Test/daml.yaml
@@ -4,18 +4,18 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-account-test
 source: daml
-version: 1.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Holding.Test/1.0.0/daml-finance-holding-test-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Holding/3.0.0/daml-finance-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.0/daml-finance-interface-account-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Holding.Test/4.99.0.20240226.1/daml-finance-holding-test-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Holding/4.99.0.20240226.1/daml-finance-holding-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240226.1/daml-finance-interface-account-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240226.1/daml-finance-test-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Data.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Data.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-data-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Data.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Data.Test/daml.yaml
@@ -4,17 +4,17 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-data-test
 source: daml
-version: 1.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Data/3.0.0/daml-finance-data-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Data/3.1.0/daml-finance-interface-data-3.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240226.1/daml-finance-data-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/4.99.0.20240226.1/daml-finance-interface-data-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240226.1/daml-finance-test-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
@@ -4,18 +4,18 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-holding-test
 source: daml
-version: 1.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Account/3.0.0/daml-finance-account-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Holding/3.0.0/daml-finance-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.0/daml-finance-interface-account-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Account/4.99.0.20240226.1/daml-finance-account-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Holding/4.99.0.20240226.1/daml-finance-holding-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240226.1/daml-finance-interface-account-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240226.1/daml-finance-test-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-holding-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-bond-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
@@ -4,20 +4,20 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-bond-test
 source: daml
-version: 1.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Data/3.0.0/daml-finance-data-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Bond/2.0.0/daml-finance-instrument-bond-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/2.0.0/daml-finance-interface-instrument-bond-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240226.1/daml-finance-data-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Bond/4.99.0.20240226.1/daml-finance-instrument-bond-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240226.1/daml-finance-interface-claims-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/4.99.0.20240226.1/daml-finance-interface-instrument-bond-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/4.99.0.20240226.1/daml-finance-interface-instrument-types-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240226.1/daml-finance-test-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
@@ -4,24 +4,24 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-equity-test
 source: daml
-version: 1.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Holding/3.0.0/daml-finance-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Equity/0.4.0/daml-finance-instrument-equity-0.4.0.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Option.Test/1.0.0/daml-finance-instrument-option-test-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Option/0.3.0/daml-finance-instrument-option-0.3.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.4.0/daml-finance-interface-instrument-equity-0.4.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.3.0/daml-finance-interface-instrument-option-0.3.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/3.0.0/daml-finance-interface-settlement-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.0/daml-finance-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/3.0.0/daml-finance-settlement-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Holding/4.99.0.20240226.1/daml-finance-holding-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Equity/0.4.99.20240226.1/daml-finance-instrument-equity-0.4.99.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Option.Test/4.99.0.20240226.1/daml-finance-instrument-option-test-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Option/0.4.99.20240226.1/daml-finance-instrument-option-0.4.99.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.4.99.20240226.1/daml-finance-interface-instrument-equity-0.4.99.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.4.99.20240226.1/daml-finance-interface-instrument-option-0.4.99.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/4.99.0.20240226.1/daml-finance-interface-settlement-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/4.99.0.20240226.1/daml-finance-lifecycle-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/4.99.0.20240226.1/daml-finance-settlement-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240226.1/daml-finance-test-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-equity-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
@@ -4,29 +4,29 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-generic-test
 source: daml
-version: 1.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/ContingentClaims.Core/2.0.1/contingent-claims-core-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Claims/2.1.0/daml-finance-claims-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Data/3.0.0/daml-finance-data-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Holding/3.0.0/daml-finance-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Generic/3.0.0/daml-finance-instrument-generic-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.0/daml-finance-interface-account-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.0/daml-finance-interface-claims-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/3.0.0/daml-finance-interface-instrument-generic-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/3.0.0/daml-finance-interface-settlement-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.0/daml-finance-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/3.0.0/daml-finance-settlement-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/3.1.0/daml-finance-util-3.1.0.dar
+  - .lib/daml-finance/ContingentClaims.Core/4.99.0.20240226.1/contingent-claims-core-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Claims/4.99.0.20240226.1/daml-finance-claims-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240226.1/daml-finance-data-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Holding/4.99.0.20240226.1/daml-finance-holding-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Generic/4.99.0.20240226.1/daml-finance-instrument-generic-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240226.1/daml-finance-interface-account-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240226.1/daml-finance-interface-claims-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/4.99.0.20240226.1/daml-finance-interface-instrument-generic-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/4.99.0.20240226.1/daml-finance-interface-settlement-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/4.99.0.20240226.1/daml-finance-lifecycle-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/4.99.0.20240226.1/daml-finance-settlement-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240226.1/daml-finance-test-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-generic-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-option-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
@@ -4,19 +4,19 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-option-test
 source: daml
-version: 1.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Claims/2.1.0/daml-finance-claims-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Data/3.0.0/daml-finance-data-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Option/0.3.0/daml-finance-instrument-option-0.3.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.3.0/daml-finance-interface-instrument-option-0.3.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Claims/4.99.0.20240226.1/daml-finance-claims-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240226.1/daml-finance-data-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Option/0.4.99.20240226.1/daml-finance-instrument-option-0.4.99.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.4.99.20240226.1/daml-finance-interface-instrument-option-0.4.99.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240226.1/daml-finance-test-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
@@ -4,18 +4,18 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-structuredproduct-test
 source: daml
-version: 1.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Data/3.0.0/daml-finance-data-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.StructuredProduct/0.1.0/daml-finance-instrument-structuredproduct-0.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.StructuredProduct/0.1.0/daml-finance-interface-instrument-structuredproduct-0.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240226.1/daml-finance-data-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.StructuredProduct/0.4.99.20240226.1/daml-finance-instrument-structuredproduct-0.4.99.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.StructuredProduct/0.4.99.20240226.1/daml-finance-interface-instrument-structuredproduct-0.4.99.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240226.1/daml-finance-test-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-structuredproduct-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
@@ -4,23 +4,23 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-swap-test
 source: daml
-version: 1.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Data/3.0.0/daml-finance-data-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Equity.Test/1.0.0/daml-finance-instrument-equity-test-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Equity/0.4.0/daml-finance-instrument-equity-0.4.0.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Swap/0.4.0/daml-finance-instrument-swap-0.4.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.4.0/daml-finance-interface-instrument-equity-0.4.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.4.0/daml-finance-interface-instrument-swap-0.4.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240226.1/daml-finance-data-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Equity.Test/4.99.0.20240226.1/daml-finance-instrument-equity-test-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Equity/0.4.99.20240226.1/daml-finance-instrument-equity-0.4.99.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Swap/0.4.99.20240226.1/daml-finance-instrument-swap-0.4.99.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.4.99.20240226.1/daml-finance-interface-instrument-equity-0.4.99.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.4.99.20240226.1/daml-finance-interface-instrument-swap-0.4.99.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/4.99.0.20240226.1/daml-finance-interface-instrument-types-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240226.1/daml-finance-test-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-instrument-swap-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
@@ -4,20 +4,20 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-settlement-test
 source: daml
-version: 1.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Account/3.0.0/daml-finance-account-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Holding/3.0.0/daml-finance-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.0/daml-finance-interface-account-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/3.0.0/daml-finance-interface-settlement-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/3.0.0/daml-finance-settlement-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Account/4.99.0.20240226.1/daml-finance-account-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Holding/4.99.0.20240226.1/daml-finance-holding-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240226.1/daml-finance-interface-account-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/4.99.0.20240226.1/daml-finance-interface-settlement-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/4.99.0.20240226.1/daml-finance-settlement-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240226.1/daml-finance-test-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-settlement-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Test.Util/daml.yaml
+++ b/package/test/daml/Daml.Finance.Test.Util/daml.yaml
@@ -4,26 +4,26 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-test-util
 source: daml
-version: 1.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Account/3.0.0/daml-finance-account-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Claims/2.1.0/daml-finance-claims-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Data/3.0.0/daml-finance-data-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Holding/3.0.0/daml-finance-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Token/3.0.0/daml-finance-instrument-token-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.0/daml-finance-interface-account-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/3.0.0/daml-finance-interface-instrument-token-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.0/daml-finance-interface-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.0/daml-finance-lifecycle-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/3.1.0/daml-finance-util-3.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Account/4.99.0.20240226.1/daml-finance-account-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Claims/4.99.0.20240226.1/daml-finance-claims-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240226.1/daml-finance-data-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Holding/4.99.0.20240226.1/daml-finance-holding-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Token/4.99.0.20240226.1/daml-finance-instrument-token-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240226.1/daml-finance-interface-account-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/4.99.0.20240226.1/daml-finance-interface-instrument-token-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/4.99.0.20240226.1/daml-finance-lifecycle-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Test.Util/daml.yaml
+++ b/package/test/daml/Daml.Finance.Test.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-test-util
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Util.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Util.Test/daml.yaml
@@ -4,16 +4,16 @@
 sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-util-test
 source: daml
-version: 1.0.0
+version: 4.99.0.20240226.1
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Util/3.1.0/daml-finance-util-3.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240226.1/daml-finance-test-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Util.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Util.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
 name: daml-finance-util-test
 source: daml
 version: 1.0.0

--- a/shell.nix
+++ b/shell.nix
@@ -19,8 +19,8 @@ let
                        curl = pkgs.curl;
                        curl_cert = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
                        os = if pkgs.stdenv.isDarwin then "macos" else "linux";
-                       hashes = { linux = "+lxcjoWVdS19wTIh5+eqM0KMpE3WkMbKYWrvTAThSwA=";
-                                  macos = "IjJDQu+csqrNnRzvAUWqz8uFgPo4Xsx7vQXTdrMunzA="; };});
+                       hashes = { linux = "nBXxtmXhFpDNMef5gskJkhPsm6d1I4QlcA7Xf3p04mY=";
+                                  macos = "789BB0WIFU/WFnOAl6q7jJLxlLnDfX0qQeiGLA5Y3rY="; };});
 in
 pkgs.mkShell {
   SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -5,10 +5,11 @@ module Daml.Finance.Instrument.Swap.Fpml.Util where
 
 import ContingentClaims.Core.Claim (Claim, Inequality(..), andList, give, one, scale, when)
 import ContingentClaims.Core.Observation (Observation(..))
-import DA.BigNumeric qualified as BN
 import DA.Date (addDays, subDate)
 import DA.Foldable (foldMap)
 import DA.List (dedup, head, init, last, sortOn, tail)
+import DA.Math (logBase, (**))
+import DA.Numeric (div)
 import DA.Optional (fromOptional, fromSome, fromSomeNote, isNone, isSome, whenSome)
 import Daml.Finance.Claims.Util.Builders (prepareAndTagClaims)
 import Daml.Finance.Claims.Util.Date (convertImplicitDcfToActualDcf)
@@ -407,12 +408,17 @@ calculatePrincipalExchangePaymentClaims paymentScheduleAligned issuerPaysLeg cur
 -- https://www.fpml.org/spec/fpml-5-11-3-lcwd-1/html/confirmation/schemaDocumentation/schemas/fpml-shared-5-11_xsd/complexTypes/FloatingRateCalculation/finalRateRounding.html
 roundRate : Decimal -> Rounding -> Decimal
 roundRate rate rounding =
-  fromBigNumeric $ BN.round rounding.precision roundingMode (fromNumeric rate)
-    where
-      roundingMode = case rounding.roundingDirection of
-        Up -> RoundingCeiling
-        Down -> RoundingFloor
-        Nearest -> RoundingHalfUp
+  let exponent : Int = truncate $ logBase 10.0 rate
+      characteristic : Decimal = 10.0 ** intToDecimal exponent
+      mantissa = rate `div` characteristic
+      _ =  if mantissa * characteristic == rate then () else error "fatal: rounding error"
+      roundMantissa : (Decimal -> Int) -> Decimal
+      roundMantissa r = intToDecimal $ r (mantissa * 10.0 ** (intToDecimal (exponent + rounding.precision)))
+  in case rounding.roundingDirection of
+            Up ->  roundMantissa ceiling * (10.0 ** (- (intToDecimal rounding.precision)))
+            Down -> roundMantissa floor * (10.0 ** (- (intToDecimal rounding.precision)))
+            Nearest -> roundMantissa round * (10.0 ** (- (intToDecimal rounding.precision)))
+
 
 -- | HIDE
 -- Get the floating rate to be used for a period, taking stub periods into account.

--- a/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Swap/Fpml/Util.daml
@@ -8,8 +8,7 @@ import ContingentClaims.Core.Observation (Observation(..))
 import DA.Date (addDays, subDate)
 import DA.Foldable (foldMap)
 import DA.List (dedup, head, init, last, sortOn, tail)
-import DA.Math (logBase, (**))
-import DA.Numeric (div)
+import DA.Math ((**))
 import DA.Optional (fromOptional, fromSome, fromSomeNote, isNone, isSome, whenSome)
 import Daml.Finance.Claims.Util.Builders (prepareAndTagClaims)
 import Daml.Finance.Claims.Util.Date (convertImplicitDcfToActualDcf)
@@ -408,17 +407,14 @@ calculatePrincipalExchangePaymentClaims paymentScheduleAligned issuerPaysLeg cur
 -- https://www.fpml.org/spec/fpml-5-11-3-lcwd-1/html/confirmation/schemaDocumentation/schemas/fpml-shared-5-11_xsd/complexTypes/FloatingRateCalculation/finalRateRounding.html
 roundRate : Decimal -> Rounding -> Decimal
 roundRate rate rounding =
-  let exponent : Int = truncate $ logBase 10.0 rate
-      characteristic : Decimal = 10.0 ** intToDecimal exponent
-      mantissa = rate `div` characteristic
-      _ =  if mantissa * characteristic == rate then () else error "fatal: rounding error"
-      roundMantissa : (Decimal -> Int) -> Decimal
-      roundMantissa r = intToDecimal $ r (mantissa * 10.0 ** (intToDecimal (exponent + rounding.precision)))
+  let
+    scaleFactor = 10.0 ** (- (intToDecimal rounding.precision))
+    roundNumber : (Decimal -> Int) -> Decimal
+    roundNumber r = intToDecimal $ r (rate * 10.0 ** (intToDecimal (rounding.precision)))
   in case rounding.roundingDirection of
-            Up ->  roundMantissa ceiling * (10.0 ** (- (intToDecimal rounding.precision)))
-            Down -> roundMantissa floor * (10.0 ** (- (intToDecimal rounding.precision)))
-            Nearest -> roundMantissa round * (10.0 ** (- (intToDecimal rounding.precision)))
-
+        Up ->  roundNumber ceiling * scaleFactor
+        Down -> roundNumber floor * scaleFactor
+        Nearest -> roundNumber round * scaleFactor
 
 -- | HIDE
 -- Get the floating rate to be used for a period, taking stub periods into account.

--- a/src/test/daml/Daml/Finance/Holding/Test/Common.daml
+++ b/src/test/daml/Daml/Finance/Holding/Test/Common.daml
@@ -61,7 +61,6 @@ setupInitialState :
   , HasSignatory a
   , HasObserver a
   , HasEnsure a
-  , HasAgreement a
   , HasCreate a
   , HasFetch a
   , HasArchive a

--- a/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
+++ b/src/test/daml/Daml/Finance/Instrument/Swap/Test/Fpml.daml
@@ -2253,6 +2253,14 @@ runFpmlRateRounding = script do
   -- https://www.fpml.org/spec/fpml-5-11-3-lcwd-1/html/confirmation/schemaDocumentation/schemas/fpml-shared-5-11_xsd/complexTypes/Rounding/precision.html
   0.0987654 === roundRate 0.09876543 Rounding with roundingDirection = Nearest; precision = 7
 
+  -- Test rounding direction of negative numbers
+  (-0.052) === roundRate (-0.0521) Rounding with roundingDirection = Up; precision = 3
+  (-0.052) === roundRate (-0.0525) Rounding with roundingDirection = Up; precision = 3
+  (-0.053) === roundRate (-0.0529) Rounding with roundingDirection = Down; precision = 3
+  (-0.053) === roundRate (-0.0525) Rounding with roundingDirection = Down; precision = 3
+  (-0.052) === roundRate (-0.0524) Rounding with roundingDirection = Nearest; precision = 3
+  (-0.053) === roundRate (-0.0525) Rounding with roundingDirection = Nearest; precision = 3
+
   pure ()
 
 -- ISDA calculation example for straight compounding, example 4.1:

--- a/src/test/daml/Daml/Finance/Test/Util/HoldingFactory.daml
+++ b/src/test/daml/Daml/Finance/Test/Util/HoldingFactory.daml
@@ -15,10 +15,8 @@ import Daml.Script
 -- | Create a holding factory with reference.
 createHoldingFactory :
   forall t.
-  ( HasAgreement t
-  , HasTemplateTypeRep t
-  , HasToAnyTemplate t
-  , HasFromAnyTemplate t
+  ( Template t
+  , HasEnsure t -- Used to enforce that this is a template, not an interface
   , HasToInterface t HoldingFactory.I
   )
   => t -> Script HoldingFactoryKey


### PR DESCRIPTION
Re-compile Daml finance with 3.x snapshot SDK (LF-2).
Work around any missing features in the new SDK.
The target branch will be used for releasing unsupported versions used internally for CN apps. Eventually we hope it will become the 3.0.0 release branch.
We're targeting `daml-finance` version `5.0.0` (or `0.5.0` for experimental modules) to make it easy to identify the switch to LF-2, which is not backward compatible with LF-1.