### PR TITLE
Bump SDK to pre-mainnet version

### DIFF
--- a/bin/update-daml-hashes
+++ b/bin/update-daml-hashes
@@ -17,6 +17,7 @@ release_exists() (
 get_hash() (
   os=$1
   out=$(mktemp)
+  arch="-intel" #TODO(#1213) handle arch suffix correctly
   case $2 in
     public)
       curl --location \
@@ -29,7 +30,7 @@ get_hash() (
       if [ -n "''${ARTIFACTORY_PASSWORD:-}" ]; then
         curl -u $ARTIFACTORY_USERNAME:$ARTIFACTORY_PASSWORD \
              --silent \
-             https://digitalasset.jfrog.io/artifactory/assembly/daml/${sdkVersion}/daml-sdk-${sdkVersion}-${os}.tar.gz \
+             https://digitalasset.jfrog.io/artifactory/assembly/daml/${sdkVersion}/daml-sdk-${sdkVersion}-${os}${arch}.tar.gz \
           > $out
       else
         echo "ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD must be set." >&2

--- a/daml.yaml
+++ b/daml.yaml
@@ -5,9 +5,9 @@
 # to keep shell.nix in sync (CI will notice & fail)
 # You may need to comment out `daml` from the "buildInputs` list to get your
 # Nix shell to run while you update the hashes.
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 # daml-version is not used by the daml assistant, only by the finance nix config
-daml-version: 3.0.0-snapshot.20240221.0
+daml-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance
 source: src/test/daml
 version: 1.3.11
@@ -16,6 +16,6 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-ctl/v4.99.0.20240226.1/daml-ctl-4.99.0.20240226.1.dar
+  - .lib/daml-ctl/v4.99.0.20240328.0/daml-ctl-4.99.0.20240328.0.dar
 build-options:
   - --include=src/main/daml

--- a/docs/code-samples/getting-started/daml.yaml
+++ b/docs/code-samples/getting-started/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: quickstart-finance
 source: daml
 init-script: Scripts.Transfer:runTransfer

--- a/docs/code-samples/lifecycling/daml.yaml
+++ b/docs/code-samples/lifecycling/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: finance-lifecycling
 source: daml
 init-script: Scripts.FixedRateBond:runFixedRateBond

--- a/docs/code-samples/payoff-modeling/daml.yaml
+++ b/docs/code-samples/payoff-modeling/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: finance-payoff-modeling
 source: daml
 init-script: PayoffBuilder:runCreateAndLifecycle

--- a/docs/code-samples/settlement/daml.yaml
+++ b/docs/code-samples/settlement/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: finance-settlement
 source: daml
 init-script: Scripts.Transfer:runDualControlTransfer

--- a/docs/code-samples/upgrades/daml.yaml
+++ b/docs/code-samples/upgrades/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: finance-upgrades
 source: daml
 init-script: Scripts.UpgradeHolding:upgradeHolding

--- a/nix/daml.nix
+++ b/nix/daml.nix
@@ -23,7 +23,7 @@ let
       get_ee() (
         if [ -n "''${ARTIFACTORY_PASSWORD:-}" ]; then
           curl -u $ARTIFACTORY_USERNAME:$ARTIFACTORY_PASSWORD \
-               https://digitalasset.jfrog.io/artifactory/assembly/daml/${sdkVersion}/daml-sdk-${sdkVersion}-${os}.tar.gz \
+               https://digitalasset.jfrog.io/artifactory/assembly/daml/${sdkVersion}/daml-sdk-${sdkVersion}-${os}-intel.tar.gz \
             > $out
         else
           echo "ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD must be set." >&2

--- a/package/main/daml/ContingentClaims.Core/daml.yaml
+++ b/package/main/daml/ContingentClaims.Core/daml.yaml
@@ -1,13 +1,13 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: contingent-claims-core
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-ctl/v4.99.0.20240226.1/daml-ctl-4.99.0.20240226.1.dar
+  - .lib/daml-ctl/v4.99.0.20240328.0/daml-ctl-4.99.0.20240328.0.dar
 

--- a/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
+++ b/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
@@ -1,15 +1,15 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: contingent-claims-lifecycle
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-ctl/v4.99.0.20240226.1/daml-ctl-4.99.0.20240226.1.dar
-  - .lib/daml-finance/ContingentClaims.Core/4.99.0.20240226.1/contingent-claims-core-4.99.0.20240226.1.dar
+  - .lib/daml-ctl/v4.99.0.20240328.0/daml-ctl-4.99.0.20240328.0.dar
+  - .lib/daml-finance/ContingentClaims.Core/4.99.0.20240328.0/contingent-claims-core-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/ContingentClaims.Valuation/daml.yaml
+++ b/package/main/daml/ContingentClaims.Valuation/daml.yaml
@@ -1,15 +1,15 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: contingent-claims-valuation
 source: daml
-version: 0.4.99.20240226.1
+version: 0.4.99.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-ctl/v4.99.0.20240226.1/daml-ctl-4.99.0.20240226.1.dar
-  - .lib/daml-finance/ContingentClaims.Core/4.99.0.20240226.1/contingent-claims-core-4.99.0.20240226.1.dar
+  - .lib/daml-ctl/v4.99.0.20240328.0/daml-ctl-4.99.0.20240328.0.dar
+  - .lib/daml-finance/ContingentClaims.Core/4.99.0.20240328.0/contingent-claims-core-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Account/daml.yaml
@@ -1,18 +1,18 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-account
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240226.1/daml-finance-interface-account-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240328.0/daml-finance-interface-account-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240328.0/daml-finance-interface-holding-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240328.0/daml-finance-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Claims/daml.yaml
@@ -1,24 +1,24 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-claims
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/ContingentClaims.Core/4.99.0.20240226.1/contingent-claims-core-4.99.0.20240226.1.dar
-  - .lib/daml-finance/ContingentClaims.Lifecycle/4.99.0.20240226.1/contingent-claims-lifecycle-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240226.1/daml-finance-interface-claims-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/4.99.0.20240226.1/daml-finance-interface-instrument-types-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/4.99.0.20240226.1/daml-finance-lifecycle-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/ContingentClaims.Core/4.99.0.20240328.0/contingent-claims-core-4.99.0.20240328.0.dar
+  - .lib/daml-finance/ContingentClaims.Lifecycle/4.99.0.20240328.0/contingent-claims-lifecycle-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240328.0/daml-finance-interface-claims-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240328.0/daml-finance-interface-instrument-base-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/4.99.0.20240328.0/daml-finance-interface-instrument-types-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240328.0/daml-finance-interface-lifecycle-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240328.0/daml-finance-interface-types-date-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/4.99.0.20240328.0/daml-finance-lifecycle-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240328.0/daml-finance-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Data/daml.yaml
@@ -1,19 +1,19 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-data
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Data/4.99.0.20240226.1/daml-finance-interface-data-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/4.99.0.20240328.0/daml-finance-interface-data-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240328.0/daml-finance-interface-lifecycle-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240328.0/daml-finance-interface-types-date-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240328.0/daml-finance-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Holding/daml.yaml
@@ -1,18 +1,18 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-holding
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240226.1/daml-finance-interface-account-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240328.0/daml-finance-interface-account-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240328.0/daml-finance-interface-holding-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240328.0/daml-finance-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -1,24 +1,24 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-instrument-bond
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/ContingentClaims.Core/4.99.0.20240226.1/contingent-claims-core-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Claims/4.99.0.20240226.1/daml-finance-claims-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240226.1/daml-finance-data-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240226.1/daml-finance-interface-claims-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/4.99.0.20240226.1/daml-finance-interface-instrument-bond-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/4.99.0.20240226.1/daml-finance-interface-instrument-types-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/ContingentClaims.Core/4.99.0.20240328.0/contingent-claims-core-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Claims/4.99.0.20240328.0/daml-finance-claims-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240328.0/daml-finance-data-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240328.0/daml-finance-interface-claims-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240328.0/daml-finance-interface-instrument-base-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/4.99.0.20240328.0/daml-finance-interface-instrument-bond-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/4.99.0.20240328.0/daml-finance-interface-instrument-types-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240328.0/daml-finance-interface-types-date-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240328.0/daml-finance-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
@@ -1,19 +1,19 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-instrument-equity
 source: daml
-version: 0.4.99.20240226.1
+version: 0.4.99.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.4.99.20240226.1/daml-finance-interface-instrument-equity-0.4.99.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/4.99.0.20240226.1/daml-finance-lifecycle-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240328.0/daml-finance-interface-instrument-base-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.4.99.20240328.0/daml-finance-interface-instrument-equity-0.4.99.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/4.99.0.20240328.0/daml-finance-lifecycle-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240328.0/daml-finance-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
@@ -1,22 +1,22 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-instrument-generic
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Claims/4.99.0.20240226.1/daml-finance-claims-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240226.1/daml-finance-interface-claims-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/4.99.0.20240226.1/daml-finance-interface-instrument-generic-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/4.99.0.20240226.1/daml-finance-lifecycle-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Claims/4.99.0.20240328.0/daml-finance-claims-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240328.0/daml-finance-interface-claims-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240328.0/daml-finance-interface-instrument-base-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/4.99.0.20240328.0/daml-finance-interface-instrument-generic-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240328.0/daml-finance-interface-lifecycle-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/4.99.0.20240328.0/daml-finance-lifecycle-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240328.0/daml-finance-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
@@ -1,22 +1,22 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-instrument-option
 source: daml
-version: 0.4.99.20240226.1
+version: 0.4.99.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Claims/4.99.0.20240226.1/daml-finance-claims-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240226.1/daml-finance-data-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240226.1/daml-finance-interface-claims-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.4.99.20240226.1/daml-finance-interface-instrument-option-0.4.99.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/4.99.0.20240226.1/daml-finance-lifecycle-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Claims/4.99.0.20240328.0/daml-finance-claims-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240328.0/daml-finance-data-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240328.0/daml-finance-interface-claims-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240328.0/daml-finance-interface-instrument-base-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.4.99.20240328.0/daml-finance-interface-instrument-option-0.4.99.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/4.99.0.20240328.0/daml-finance-lifecycle-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240328.0/daml-finance-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
@@ -1,23 +1,23 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-instrument-structuredproduct
 source: daml
-version: 0.4.99.20240226.1
+version: 0.4.99.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Claims/4.99.0.20240226.1/daml-finance-claims-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240226.1/daml-finance-data-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240226.1/daml-finance-interface-claims-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.4.99.20240226.1/daml-finance-interface-instrument-option-0.4.99.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.StructuredProduct/0.4.99.20240226.1/daml-finance-interface-instrument-structuredproduct-0.4.99.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Claims/4.99.0.20240328.0/daml-finance-claims-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240328.0/daml-finance-data-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240328.0/daml-finance-interface-claims-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240328.0/daml-finance-interface-instrument-base-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.4.99.20240328.0/daml-finance-interface-instrument-option-0.4.99.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.StructuredProduct/0.4.99.20240328.0/daml-finance-interface-instrument-structuredproduct-0.4.99.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240328.0/daml-finance-interface-types-date-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240328.0/daml-finance-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
@@ -1,26 +1,26 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-instrument-swap
 source: daml
-version: 0.4.99.20240226.1
+version: 0.4.99.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/ContingentClaims.Core/4.99.0.20240226.1/contingent-claims-core-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Claims/4.99.0.20240226.1/daml-finance-claims-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240226.1/daml-finance-data-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240226.1/daml-finance-interface-claims-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.4.99.20240226.1/daml-finance-interface-instrument-swap-0.4.99.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/4.99.0.20240226.1/daml-finance-interface-instrument-types-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/4.99.0.20240226.1/daml-finance-lifecycle-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/ContingentClaims.Core/4.99.0.20240328.0/contingent-claims-core-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Claims/4.99.0.20240328.0/daml-finance-claims-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240328.0/daml-finance-data-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240328.0/daml-finance-interface-claims-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240328.0/daml-finance-interface-instrument-base-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.4.99.20240328.0/daml-finance-interface-instrument-swap-0.4.99.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/4.99.0.20240328.0/daml-finance-interface-instrument-types-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240328.0/daml-finance-interface-lifecycle-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240328.0/daml-finance-interface-types-date-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/4.99.0.20240328.0/daml-finance-lifecycle-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240328.0/daml-finance-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
@@ -1,18 +1,18 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-instrument-token
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/4.99.0.20240226.1/daml-finance-interface-instrument-token-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240328.0/daml-finance-interface-instrument-base-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/4.99.0.20240328.0/daml-finance-interface-instrument-token-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240328.0/daml-finance-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
@@ -1,16 +1,16 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-interface-account
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240328.0/daml-finance-interface-holding-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
@@ -1,17 +1,17 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-interface-claims
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/ContingentClaims.Core/4.99.0.20240226.1/contingent-claims-core-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/ContingentClaims.Core/4.99.0.20240328.0/contingent-claims-core-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240328.0/daml-finance-interface-instrument-base-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
@@ -1,17 +1,17 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-interface-data
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240328.0/daml-finance-interface-lifecycle-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240328.0/daml-finance-interface-types-date-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
@@ -1,15 +1,15 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-interface-holding
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
@@ -1,16 +1,16 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-interface-instrument-base
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240328.0/daml-finance-interface-holding-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
@@ -1,19 +1,19 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-interface-instrument-bond
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240226.1/daml-finance-interface-claims-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/4.99.0.20240226.1/daml-finance-interface-instrument-types-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240328.0/daml-finance-interface-claims-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240328.0/daml-finance-interface-instrument-base-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/4.99.0.20240328.0/daml-finance-interface-instrument-types-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240328.0/daml-finance-interface-types-date-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
@@ -1,17 +1,17 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-interface-instrument-equity
 source: daml
-version: 0.4.99.20240226.1
+version: 0.4.99.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240328.0/daml-finance-interface-instrument-base-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240328.0/daml-finance-interface-lifecycle-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
@@ -1,17 +1,17 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-interface-instrument-generic
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240226.1/daml-finance-interface-claims-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240328.0/daml-finance-interface-claims-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240328.0/daml-finance-interface-instrument-base-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
@@ -1,18 +1,18 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-interface-instrument-option
 source: daml
-version: 0.4.99.20240226.1
+version: 0.4.99.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240226.1/daml-finance-interface-claims-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240328.0/daml-finance-interface-claims-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240328.0/daml-finance-interface-instrument-base-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240328.0/daml-finance-interface-lifecycle-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
@@ -1,18 +1,18 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-interface-instrument-structuredproduct
 source: daml
-version: 0.4.99.20240226.1
+version: 0.4.99.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240226.1/daml-finance-interface-claims-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240328.0/daml-finance-interface-claims-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240328.0/daml-finance-interface-instrument-base-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240328.0/daml-finance-interface-types-date-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
@@ -1,18 +1,18 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-interface-instrument-swap
 source: daml
-version: 0.4.99.20240226.1
+version: 0.4.99.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/4.99.0.20240226.1/daml-finance-interface-instrument-types-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240328.0/daml-finance-interface-instrument-base-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/4.99.0.20240328.0/daml-finance-interface-instrument-types-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240328.0/daml-finance-interface-types-date-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
@@ -1,16 +1,16 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-interface-instrument-token
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240328.0/daml-finance-interface-instrument-base-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
@@ -1,14 +1,14 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-interface-instrument-types
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240328.0/daml-finance-interface-types-date-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
@@ -1,17 +1,17 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-interface-lifecycle
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/4.99.0.20240226.1/daml-finance-interface-settlement-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240328.0/daml-finance-interface-holding-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/4.99.0.20240328.0/daml-finance-interface-settlement-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
@@ -1,16 +1,16 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-interface-settlement
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240328.0/daml-finance-interface-holding-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
@@ -1,10 +1,10 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-interface-types-common
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/main/daml/Daml.Finance.Interface.Types.Date/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Date/daml.yaml
@@ -1,10 +1,10 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-interface-types-date
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
@@ -1,14 +1,14 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-interface-util
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
@@ -1,21 +1,21 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-lifecycle
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240226.1/daml-finance-interface-account-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/4.99.0.20240226.1/daml-finance-interface-settlement-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240328.0/daml-finance-interface-account-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240328.0/daml-finance-interface-holding-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240328.0/daml-finance-interface-instrument-base-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240328.0/daml-finance-interface-lifecycle-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/4.99.0.20240328.0/daml-finance-interface-settlement-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240328.0/daml-finance-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Settlement/daml.yaml
@@ -1,19 +1,19 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-settlement
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240226.1/daml-finance-interface-account-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/4.99.0.20240226.1/daml-finance-interface-settlement-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240328.0/daml-finance-interface-account-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240328.0/daml-finance-interface-holding-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/4.99.0.20240328.0/daml-finance-interface-settlement-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240328.0/daml-finance-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Util/daml.yaml
@@ -1,16 +1,16 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-util
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240328.0/daml-finance-interface-types-date-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/packages.yaml
+++ b/package/packages.yaml
@@ -11,8 +11,8 @@ remote:
           organisation: digital-asset
           name: daml-ctl
         base-module: Daml.Control
-        tag: v4.99.0.20240226.1
-        dar-name: daml-ctl-4.99.0.20240226.1.dar
+        tag: v4.99.0.20240328.0
+        dar-name: daml-ctl-4.99.0.20240328.0.dar
 local:
   repo:
     host: github.com

--- a/package/test/daml/ContingentClaims.Test/daml.yaml
+++ b/package/test/daml/ContingentClaims.Test/daml.yaml
@@ -1,18 +1,18 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: contingent-claims-test
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-ctl/v4.99.0.20240226.1/daml-ctl-4.99.0.20240226.1.dar
-  - .lib/daml-finance/ContingentClaims.Core/4.99.0.20240226.1/contingent-claims-core-4.99.0.20240226.1.dar
-  - .lib/daml-finance/ContingentClaims.Lifecycle/4.99.0.20240226.1/contingent-claims-lifecycle-4.99.0.20240226.1.dar
-  - .lib/daml-finance/ContingentClaims.Valuation/0.4.99.20240226.1/contingent-claims-valuation-0.4.99.20240226.1.dar
+  - .lib/daml-ctl/v4.99.0.20240328.0/daml-ctl-4.99.0.20240328.0.dar
+  - .lib/daml-finance/ContingentClaims.Core/4.99.0.20240328.0/contingent-claims-core-4.99.0.20240328.0.dar
+  - .lib/daml-finance/ContingentClaims.Lifecycle/4.99.0.20240328.0/contingent-claims-lifecycle-4.99.0.20240328.0.dar
+  - .lib/daml-finance/ContingentClaims.Valuation/0.4.99.20240328.0/contingent-claims-valuation-0.4.99.20240328.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Account.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Account.Test/daml.yaml
@@ -1,21 +1,21 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-account-test
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Holding.Test/4.99.0.20240226.1/daml-finance-holding-test-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Holding/4.99.0.20240226.1/daml-finance-holding-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240226.1/daml-finance-interface-account-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240226.1/daml-finance-test-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Holding.Test/4.99.0.20240328.0/daml-finance-holding-test-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Holding/4.99.0.20240328.0/daml-finance-holding-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240328.0/daml-finance-interface-account-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240328.0/daml-finance-interface-holding-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240328.0/daml-finance-test-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Data.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Data.Test/daml.yaml
@@ -1,20 +1,20 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-data-test
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240226.1/daml-finance-data-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Data/4.99.0.20240226.1/daml-finance-interface-data-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240226.1/daml-finance-test-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240328.0/daml-finance-data-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Data/4.99.0.20240328.0/daml-finance-interface-data-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240328.0/daml-finance-interface-lifecycle-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240328.0/daml-finance-interface-types-date-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240328.0/daml-finance-test-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
@@ -1,21 +1,21 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-holding-test
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Account/4.99.0.20240226.1/daml-finance-account-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Holding/4.99.0.20240226.1/daml-finance-holding-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240226.1/daml-finance-interface-account-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240226.1/daml-finance-test-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Account/4.99.0.20240328.0/daml-finance-account-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Holding/4.99.0.20240328.0/daml-finance-holding-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240328.0/daml-finance-interface-account-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240328.0/daml-finance-interface-holding-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240328.0/daml-finance-test-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
@@ -1,23 +1,23 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-instrument-bond-test
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240226.1/daml-finance-data-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Bond/4.99.0.20240226.1/daml-finance-instrument-bond-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240226.1/daml-finance-interface-claims-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/4.99.0.20240226.1/daml-finance-interface-instrument-bond-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/4.99.0.20240226.1/daml-finance-interface-instrument-types-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240226.1/daml-finance-test-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240328.0/daml-finance-data-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Bond/4.99.0.20240328.0/daml-finance-instrument-bond-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240328.0/daml-finance-interface-claims-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/4.99.0.20240328.0/daml-finance-interface-instrument-bond-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/4.99.0.20240328.0/daml-finance-interface-instrument-types-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240328.0/daml-finance-interface-types-date-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240328.0/daml-finance-test-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
@@ -1,27 +1,27 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-instrument-equity-test
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Holding/4.99.0.20240226.1/daml-finance-holding-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Equity/0.4.99.20240226.1/daml-finance-instrument-equity-0.4.99.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Option.Test/4.99.0.20240226.1/daml-finance-instrument-option-test-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Option/0.4.99.20240226.1/daml-finance-instrument-option-0.4.99.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.4.99.20240226.1/daml-finance-interface-instrument-equity-0.4.99.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.4.99.20240226.1/daml-finance-interface-instrument-option-0.4.99.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/4.99.0.20240226.1/daml-finance-interface-settlement-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/4.99.0.20240226.1/daml-finance-lifecycle-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/4.99.0.20240226.1/daml-finance-settlement-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240226.1/daml-finance-test-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Holding/4.99.0.20240328.0/daml-finance-holding-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Equity/0.4.99.20240328.0/daml-finance-instrument-equity-0.4.99.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Option.Test/4.99.0.20240328.0/daml-finance-instrument-option-test-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Option/0.4.99.20240328.0/daml-finance-instrument-option-0.4.99.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.4.99.20240328.0/daml-finance-interface-instrument-equity-0.4.99.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.4.99.20240328.0/daml-finance-interface-instrument-option-0.4.99.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240328.0/daml-finance-interface-lifecycle-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/4.99.0.20240328.0/daml-finance-interface-settlement-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/4.99.0.20240328.0/daml-finance-lifecycle-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/4.99.0.20240328.0/daml-finance-settlement-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240328.0/daml-finance-test-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
@@ -1,32 +1,32 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-instrument-generic-test
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/ContingentClaims.Core/4.99.0.20240226.1/contingent-claims-core-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Claims/4.99.0.20240226.1/daml-finance-claims-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240226.1/daml-finance-data-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Holding/4.99.0.20240226.1/daml-finance-holding-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Generic/4.99.0.20240226.1/daml-finance-instrument-generic-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240226.1/daml-finance-interface-account-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240226.1/daml-finance-interface-claims-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/4.99.0.20240226.1/daml-finance-interface-instrument-generic-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/4.99.0.20240226.1/daml-finance-interface-settlement-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/4.99.0.20240226.1/daml-finance-lifecycle-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/4.99.0.20240226.1/daml-finance-settlement-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240226.1/daml-finance-test-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/ContingentClaims.Core/4.99.0.20240328.0/contingent-claims-core-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Claims/4.99.0.20240328.0/daml-finance-claims-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240328.0/daml-finance-data-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Holding/4.99.0.20240328.0/daml-finance-holding-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Generic/4.99.0.20240328.0/daml-finance-instrument-generic-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240328.0/daml-finance-interface-account-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Claims/4.99.0.20240328.0/daml-finance-interface-claims-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240328.0/daml-finance-interface-holding-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/4.99.0.20240328.0/daml-finance-interface-instrument-generic-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240328.0/daml-finance-interface-lifecycle-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/4.99.0.20240328.0/daml-finance-interface-settlement-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240328.0/daml-finance-interface-types-date-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/4.99.0.20240328.0/daml-finance-lifecycle-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/4.99.0.20240328.0/daml-finance-settlement-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240328.0/daml-finance-test-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240328.0/daml-finance-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
@@ -1,22 +1,22 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-instrument-option-test
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Claims/4.99.0.20240226.1/daml-finance-claims-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240226.1/daml-finance-data-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Option/0.4.99.20240226.1/daml-finance-instrument-option-0.4.99.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.4.99.20240226.1/daml-finance-interface-instrument-option-0.4.99.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240226.1/daml-finance-test-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Claims/4.99.0.20240328.0/daml-finance-claims-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240328.0/daml-finance-data-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Option/0.4.99.20240328.0/daml-finance-instrument-option-0.4.99.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.4.99.20240328.0/daml-finance-interface-instrument-option-0.4.99.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240328.0/daml-finance-interface-lifecycle-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240328.0/daml-finance-test-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
@@ -1,21 +1,21 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-instrument-structuredproduct-test
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240226.1/daml-finance-data-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.StructuredProduct/0.4.99.20240226.1/daml-finance-instrument-structuredproduct-0.4.99.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.StructuredProduct/0.4.99.20240226.1/daml-finance-interface-instrument-structuredproduct-0.4.99.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240226.1/daml-finance-test-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240328.0/daml-finance-data-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.StructuredProduct/0.4.99.20240328.0/daml-finance-instrument-structuredproduct-0.4.99.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.StructuredProduct/0.4.99.20240328.0/daml-finance-interface-instrument-structuredproduct-0.4.99.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240328.0/daml-finance-interface-types-date-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240328.0/daml-finance-test-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
@@ -1,26 +1,26 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-instrument-swap-test
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240226.1/daml-finance-data-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Equity.Test/4.99.0.20240226.1/daml-finance-instrument-equity-test-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Equity/0.4.99.20240226.1/daml-finance-instrument-equity-0.4.99.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Swap/0.4.99.20240226.1/daml-finance-instrument-swap-0.4.99.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.4.99.20240226.1/daml-finance-interface-instrument-equity-0.4.99.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.4.99.20240226.1/daml-finance-interface-instrument-swap-0.4.99.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/4.99.0.20240226.1/daml-finance-interface-instrument-types-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240226.1/daml-finance-test-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240328.0/daml-finance-data-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Equity.Test/4.99.0.20240328.0/daml-finance-instrument-equity-test-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Equity/0.4.99.20240328.0/daml-finance-instrument-equity-0.4.99.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Swap/0.4.99.20240328.0/daml-finance-instrument-swap-0.4.99.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.4.99.20240328.0/daml-finance-interface-instrument-equity-0.4.99.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.4.99.20240328.0/daml-finance-interface-instrument-swap-0.4.99.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/4.99.0.20240328.0/daml-finance-interface-instrument-types-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240328.0/daml-finance-interface-lifecycle-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240328.0/daml-finance-interface-types-date-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240328.0/daml-finance-test-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
@@ -1,23 +1,23 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-settlement-test
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Account/4.99.0.20240226.1/daml-finance-account-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Holding/4.99.0.20240226.1/daml-finance-holding-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240226.1/daml-finance-interface-account-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/4.99.0.20240226.1/daml-finance-interface-settlement-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Settlement/4.99.0.20240226.1/daml-finance-settlement-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240226.1/daml-finance-test-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Account/4.99.0.20240328.0/daml-finance-account-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Holding/4.99.0.20240328.0/daml-finance-holding-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240328.0/daml-finance-interface-account-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240328.0/daml-finance-interface-holding-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/4.99.0.20240328.0/daml-finance-interface-settlement-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Settlement/4.99.0.20240328.0/daml-finance-settlement-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240328.0/daml-finance-test-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Test.Util/daml.yaml
+++ b/package/test/daml/Daml.Finance.Test.Util/daml.yaml
@@ -1,29 +1,29 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-test-util
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Account/4.99.0.20240226.1/daml-finance-account-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Claims/4.99.0.20240226.1/daml-finance-claims-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240226.1/daml-finance-data-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Holding/4.99.0.20240226.1/daml-finance-holding-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Instrument.Token/4.99.0.20240226.1/daml-finance-instrument-token-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240226.1/daml-finance-interface-account-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240226.1/daml-finance-interface-holding-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240226.1/daml-finance-interface-instrument-base-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/4.99.0.20240226.1/daml-finance-interface-instrument-token-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240226.1/daml-finance-interface-lifecycle-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Lifecycle/4.99.0.20240226.1/daml-finance-lifecycle-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Account/4.99.0.20240328.0/daml-finance-account-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Claims/4.99.0.20240328.0/daml-finance-claims-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Data/4.99.0.20240328.0/daml-finance-data-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Holding/4.99.0.20240328.0/daml-finance-holding-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Instrument.Token/4.99.0.20240328.0/daml-finance-instrument-token-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/4.99.0.20240328.0/daml-finance-interface-account-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/4.99.0.20240328.0/daml-finance-interface-holding-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/4.99.0.20240328.0/daml-finance-interface-instrument-base-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/4.99.0.20240328.0/daml-finance-interface-instrument-token-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/4.99.0.20240328.0/daml-finance-interface-lifecycle-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240328.0/daml-finance-interface-types-date-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Lifecycle/4.99.0.20240328.0/daml-finance-lifecycle-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240328.0/daml-finance-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Util.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Util.Test/daml.yaml
@@ -1,19 +1,19 @@
 # Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 3.0.0-snapshot.20240214.12763.0.v307b621e
+sdk-version: 3.0.0-snapshot.20240318.12913.0.v1c415c97
 name: daml-finance-util-test
 source: daml
-version: 4.99.0.20240226.1
+version: 4.99.0.20240328.0
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240226.1/daml-finance-interface-types-common-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240226.1/daml-finance-interface-types-date-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240226.1/daml-finance-interface-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240226.1/daml-finance-test-util-4.99.0.20240226.1.dar
-  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240226.1/daml-finance-util-4.99.0.20240226.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/4.99.0.20240328.0/daml-finance-interface-types-common-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/4.99.0.20240328.0/daml-finance-interface-types-date-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/4.99.0.20240328.0/daml-finance-interface-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Test.Util/4.99.0.20240328.0/daml-finance-test-util-4.99.0.20240328.0.dar
+  - .lib/daml-finance/Daml.Finance.Util/4.99.0.20240328.0/daml-finance-util-4.99.0.20240328.0.dar
 build-options: null
 

--- a/shell.nix
+++ b/shell.nix
@@ -19,8 +19,8 @@ let
                        curl = pkgs.curl;
                        curl_cert = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
                        os = if pkgs.stdenv.isDarwin then "macos" else "linux";
-                       hashes = { linux = "nBXxtmXhFpDNMef5gskJkhPsm6d1I4QlcA7Xf3p04mY=";
-                                  macos = "789BB0WIFU/WFnOAl6q7jJLxlLnDfX0qQeiGLA5Y3rY="; };});
+                       hashes = { linux = "Z3UFETFXhX9Mlk8hAVNNA2rpPBH7itWY4TN93TIWUkQ=";
+                                  macos = "ZJe3XoxRnXLhWafI+VwuDCJ1iAUAzJ3WQiT94+AqSQ8="; };});
 in
 pkgs.mkShell {
   SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";


### PR DESCRIPTION
- The APIs in this SDK should be stabler than previous 3.x versions.
- The tarball names have changed; Have patched scripts to make this work on CI, but this will only work for unofficial linux-intel snapshots. Raised #1213 to cater for this in future.
- CI will probably fail as there's no release for `daml-ctl` yet.