### PR TITLE
`Batch` with HTLC / Relax the `Cancel` choice

### DIFF
--- a/src/main/daml/Daml/Finance/Settlement/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Batch.daml
@@ -14,7 +14,7 @@ import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Cancel(..), I
 import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Cancel(..), Execute(..), I)
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), InstructionKey(..), RoutedStep(..))
 import Daml.Finance.Interface.Types.Common.Types (Id(..), Parties)
-import Daml.Finance.Settlement.HTLC qualified as HTLC (verifyExpirationStatus, verifyRevealedState)
+import Daml.Finance.Settlement.HTLC qualified as HTLC (verifyCanCancel, verifyRevealedState)
 import Daml.Finance.Settlement.Instruction (Instruction(..), mustAuthorizeHelper)
 
 -- | Type synonym for `Batch`.
@@ -78,7 +78,7 @@ template Batch
             instructionIds this.routedStepsWithInstructionId
         pure $ catOptionals settledCids
       cancel Batch.Cancel{actors} = do
-        when useHTLC do HTLC.verifyExpirationStatus True $ Left (instructor, id)
+        when useHTLC do HTLC.verifyCanCancel $ Left (instructor, id)
         let
           allMustAuthorize = mustAuthorizeHelper True actors
           cancelInstruction instruction = do

--- a/src/main/daml/Daml/Finance/Settlement/HTLC.daml
+++ b/src/main/daml/Daml/Finance/Settlement/HTLC.daml
@@ -6,7 +6,7 @@ module Daml.Finance.Settlement.HTLC where
 import DA.Text (sha256)
 import Daml.Finance.Interface.Types.Common.Types (Id(..), Parties)
 
--- | Represents the state of a Hash Time Lock Contract (HTLC) in a financial settlement system.
+-- | Represents the state of a Hash Time Lock Contract (HTLC).
 data HTLCState
   = Open
     -- ^ The 'Open' state indicates that the HTLC is available for allocating and approving
@@ -95,6 +95,16 @@ verifyExpirationStatus shouldBeExpired input = do
   now <- getTime
   let hasExpired = now > htlc.expiry
   assertMsg ("Expiration status must be " <> show shouldBeExpired) $ hasExpired == shouldBeExpired
+
+-- | Verify that a HTLC can be cancelled. HTLC can be cancelled if it is Open or expired.
+verifyCanCancel : Either HTLCKey HTLC -> Update ()
+verifyCanCancel input = do
+  htlc <- getHTLC input
+  now <- getTime
+  let
+    hasExpired = now > htlc.expiry
+    isOpen = htlc.state == Open
+  assertMsg ("In order to cancel, the HTLC must be Open or expired") $ isOpen || hasExpired
 
 -- | Get HTLC.
 getHTLC : Either HTLCKey HTLC -> Update HTLC

--- a/src/main/daml/Daml/Finance/Settlement/Instruction.daml
+++ b/src/main/daml/Daml/Finance/Settlement/Instruction.daml
@@ -18,7 +18,7 @@ import Daml.Finance.Interface.Types.Common.Types (AccountKey, Id(..), Parties, P
 import Daml.Finance.Interface.Util.Disclosure qualified as Disclosure (I, View(..), flattenObservers)
 import Daml.Finance.Interface.Util.InterfaceKey (fetchInterfaceByKey)
 import Daml.Finance.Interface.Util.Lockable qualified as Lockable (Acquire(..), I, LockType(..), Release(..))
-import Daml.Finance.Settlement.HTLC qualified as HTLC (HTLCState(..), verifyAnyState, verifyExpirationStatus, verifyRevealedState)
+import Daml.Finance.Settlement.HTLC qualified as HTLC (HTLCState(..), verifyAnyState, verifyCanCancel, verifyRevealedState)
 import Daml.Finance.Util.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 
 -- | Type synonym for `Instruction`.
@@ -80,7 +80,7 @@ template Instruction
           atLeastOneMustAuthorize = mustAuthorizeHelper False actors
         atLeastOneMustAuthorize $ Set.fromList [routedStep.custodian, routedStep.sender]
         assertMsg ("Allocation must be new. " <> context this) $ allocation /= this.allocation
-        releasedCid <- releasePreviousAllocation this actors
+        releasedCid <- releasePreviousAllocation this actors True
         -- allocate
         newAllocation <- case allocation of
           Pledge holdingCid -> do
@@ -137,7 +137,7 @@ template Instruction
           atLeastOneMustAuthorize = mustAuthorizeHelper False actors
         atLeastOneMustAuthorize $ Set.fromList [routedStep.custodian, routedStep.receiver]
         assertMsg ("Approval must be new. " <> context this) $ approval /= this.approval
-        releasePreviousApproval this actors
+        releasePreviousApproval this actors True
         -- approve
         case approval of
           TakeDelivery receiverAccountKey -> do
@@ -256,11 +256,11 @@ template Instruction
               SettleOffledgerAcknowledge -> pure None
               _ -> abortOnOffledgerMix
       cancel Instruction.Cancel{actors} = do
-        when useHTLC do HTLC.verifyExpirationStatus True $ Left (instructor, batchId)
+        when useHTLC do HTLC.verifyCanCancel $ Left (instructor, batchId)
         let allMustAuthorize = mustAuthorizeHelper True actors
         allMustAuthorize $ Set.insert instructor consenters
-        releasePreviousApproval this actors
-        releasePreviousAllocation this actors
+        releasePreviousApproval this actors False
+        releasePreviousAllocation this actors False
 
 -- | HIDE
 context : Instruction -> Text
@@ -306,11 +306,10 @@ undisclosePledge this@Instruction {settlers} holdingCid actors = Holding.undiscl
   (context this, settlers) (addSignatories this actors) holdingCid
 
 -- | HIDE
-releasePreviousAllocation : Instruction -> Parties -> Update (Optional (ContractId Holding.I))
-releasePreviousAllocation this@Instruction {allocation; signedSenders} actors = do
+releasePreviousAllocation : Instruction -> Parties -> Bool -> Update (Optional (ContractId Holding.I))
+releasePreviousAllocation this@Instruction{allocation; signedSenders} actors signedSendersMustAuthorize = do
   let allMustAuthorize = mustAuthorizeHelper True actors
-  -- signed senders must agree to release previous allocation
-  allMustAuthorize signedSenders
+  when signedSendersMustAuthorize $ allMustAuthorize signedSenders
   case allocation of
     Pledge holdingCid -> do
       holdingCid <- fromInterfaceContractId @Holding.I <$>
@@ -326,11 +325,10 @@ releasePreviousAllocation this@Instruction {allocation; signedSenders} actors = 
     _ -> pure None
 
 -- | HIDE
-releasePreviousApproval : Instruction -> Parties -> Update (Optional (ContractId Account.I))
-releasePreviousApproval this@Instruction {approval; signedReceivers} actors = do
+releasePreviousApproval : Instruction -> Parties -> Bool -> Update (Optional (ContractId Account.I))
+releasePreviousApproval this@Instruction{approval; signedReceivers} actors signedReceiversMustAuthorize = do
   let allMustAuthorize = mustAuthorizeHelper True actors
-  -- signed receivers must authorize to release previous approval
-  allMustAuthorize signedReceivers
+  when signedReceiversMustAuthorize $ allMustAuthorize signedReceivers
   case approval of
     TakeDelivery receiverAccountKey -> undiscloseAccount this receiverAccountKey actors
     PassThroughTo (passThroughAccountKey, _) -> undiscloseAccount this passThroughAccountKey actors

--- a/src/test/daml/Daml/Finance/Settlement/Test/TransferWithHTLC.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/TransferWithHTLC.daml
@@ -3,15 +3,16 @@
 
 module Daml.Finance.Settlement.Test.TransferWithHTLC where
 
+import DA.Assert ((===))
 import DA.Map qualified as Map (fromList)
 import DA.Optional (isSome)
 import DA.Set qualified as Set (fromList, singleton)
 import DA.Text (sha256)
-import DA.Time (addRelTime, hours)
+import DA.Time (addRelTime, hours, subTime)
 import Daml.Finance.Holding.Factory qualified as Holding (Factory(..))
-import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Cancel(..), Settle(..))
+import Daml.Finance.Interface.Settlement.Batch qualified as Batch (Cancel(..), I, Settle(..))
 import Daml.Finance.Interface.Settlement.Factory qualified as SettlementFactory (I, Instruct(..))
-import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..))
+import Daml.Finance.Interface.Settlement.Instruction qualified as Instruction (Allocate(..), Approve(..), I)
 import Daml.Finance.Interface.Settlement.Types (Allocation(..), Approval(..), RoutedStep(..))
 import Daml.Finance.Interface.Types.Common.Types (HoldingStandard(..), Id(..))
 import Daml.Finance.Interface.Util.Common (qty)
@@ -30,23 +31,16 @@ import Daml.Script
 data TestParties = TestParties
   with
     bank : Party
-      -- ^ Acts as custodian in the respective holdings and provider of the holding factories.
-      --   Acts as issuer and repository of the security instrument. 
-    cb : Party
-      -- ^ Depository and issuer of the cash instrument.
+      -- ^ Acts as custodian of the holdings, provider of the holding factories, instructor of the
+      -- batch, and settler of the batch.
     sender : Party
       -- ^ Sends units of security to receiver.
     receiver : Party
       -- ^ Receives units of security from sender.
-    cashSender : Party
-      -- ^ Sends units of cash to receiver.
-    cashReceiver : Party
-      -- ^ Receives units of cash from sender.
-    settler : Party
-      -- ^ Executes the settlement of the batch.
 
--- Transfer of cash between two parties (sender -> receiver) facilitated by an intermediary (bank)
--- using HTLC module.
+-- Scenario test for transferring a security between two parties (sender -> receiver), facilitated
+-- by an intermediary (bank), using the HTLC module. Cash could be transferred in the opposite
+-- direction on a separate ledger.
 -- +------------------------------------------+
 -- | Accounts                                 |
 -- +------------------+-----------------------+
@@ -56,8 +50,11 @@ data TestParties = TestParties
 -- |      /  \        | securities            |
 -- | Sender  Receiver |                       |
 -- +------------------+-----------------------+
-run : Bool -> Script ()
-run isHappyPath = script do
+
+-- | Allocate and approve the instruction.
+runAllocateAndApprove : Script (TestParties, (Text, Time, ContractId HTLC),
+  (ContractId Batch.I, ContractId Instruction.I))
+runAllocateAndApprove = do
   -- Create parties
   TestParties{..} <- setupParties
   let
@@ -80,24 +77,15 @@ run isHappyPath = script do
 
   -- Distribute asset
   now <- getTime
-  cashInstrument <- Instrument.originate cb cb "USD" Transferable "United States Dollar" [] now
   securityInstrument <- Instrument.originate bank bank "SECURITY" Transferable "A Security" [] now
-
   securityCid <- Account.credit [] securityInstrument 1000.0 senderAccount
 
   -- Create settlement factory
   settlementFactoryCid <- toInterfaceContractId @SettlementFactory.I <$>
     submit bank do createCmd Settlement.FactoryWithHTLC with provider = bank; observers
 
-
-  -- Settlement step
-  let
-    routedSteps =
-      [ RoutedStep with sender; receiver; custodian = bank; quantity = qty 1_000.0 securityInstrument
-      ]
-
+  -- Create batch
   let batchId = Id "transfer abc"
-
   (batchCid, [securityInstructionCid]) <- submit bank do
     exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
       instructor = bank
@@ -106,42 +94,99 @@ run isHappyPath = script do
       id = batchId
       description = "transfer of 1000 units of security conditional on 200000 units of cash"
       contextId = None
-      routedSteps
+      routedSteps =
+        [ RoutedStep with
+            sender; receiver; custodian = bank; quantity = qty 1_000.0 securityInstrument
+        ]
       settlementTime = None
 
+  -- Create HTLC
   let
     secret = "dfgrhtdnni46rhf"
     expiry = addRelTime now $ hours 12
     hash = sha256 secret
-
   htlcCid <- submit bank do
     createCmd HTLC with
       batchId
       instructor = bank
       consenters = mempty
-      settlers = Set.singleton bank -- do we validate this against the batch?
-      observers = Set.fromList [sender, receiver, cashSender, cashReceiver, settler]
+      settlers = Set.singleton bank
+      observers = Set.fromList [sender, receiver]
       expiry
       hash
       state = HTLC.Open
 
-
-  -- Allocate instruction and lock the holding
+  -- Allocate instruction
   (securityInstructionCid, _) <- submit sender do
     exerciseCmd securityInstructionCid Instruction.Allocate with
       actors = Set.singleton sender; allocation = Pledge securityCid
 
+  -- Sanity check
   Some securityInstruction <- queryInterfaceContractId sender securityInstructionCid
-
   let Pledge holdingCid = securityInstruction.allocation
   Some lockable <- queryInterfaceContractId sender (toInterfaceContractId @Lockable.I holdingCid)
   assertMsg "holding is locked" $ isSome lockable.lock
-
 
   -- Approve instruction
   securityInstructionCid <- submit receiver do
     exerciseCmd securityInstructionCid Instruction.Approve with
       actors = Set.singleton receiver; approval = TakeDelivery receiverAccount
+
+  pure (TestParties{..}, (secret, expiry, htlcCid), (batchCid, securityInstructionCid))
+
+-- | Cancel a batch when Open.
+cancelOpenBatch : Script ()
+cancelOpenBatch = do
+  -- Allocate and approve
+  (TestParties{..}, (secret, expiry, htlcCid), (batchCid, securityInstructionCid))
+    <- runAllocateAndApprove
+
+  -- Cancel the batch
+  [securityHoldingCid] <-
+    submit bank do exerciseCmd batchCid Batch.Cancel with actors = Set.singleton bank
+
+  -- Sanity check
+  let ts = [(sender, securityHoldingCid)]
+  Holding.verifyOwnerOfHolding ts
+  Holding.verifyNoObservers ts
+  Some holding <- queryInterfaceContractId @Lockable.I sender
+    $ toInterfaceContractId securityHoldingCid
+  holding.lock === None
+
+-- | Cancel a batch after expiry.
+cancelLockedBatchAfterExpiry : Script ()
+cancelLockedBatchAfterExpiry = do
+  -- Allocate and approve
+  (TestParties{..}, (secret, expiry, htlcCid), (batchCid, _)) <- runAllocateAndApprove
+
+  -- Lock Batch and Instructions (such that they can't be backed out of)
+  htlcCid <- submit bank do exerciseCmd htlcCid HTLC.Lock
+
+  -- Can not cancel (as Batch is Locked and has not expired)
+  submitMustFail bank do exerciseCmd batchCid Batch.Cancel with actors = Set.singleton bank
+
+  -- Wait for expiry
+  now <- getTime
+  passTime (subTime (addRelTime expiry (hours 1)) now)
+
+  -- Cancel the batch
+  [securityHoldingCid] <-
+    submit bank do exerciseCmd batchCid Batch.Cancel with actors = Set.singleton bank
+
+  -- Sanity check
+  let ts = [(sender, securityHoldingCid)]
+  Holding.verifyOwnerOfHolding ts
+  Holding.verifyNoObservers ts
+  Some holding <- queryInterfaceContractId @Lockable.I sender
+    $ toInterfaceContractId securityHoldingCid
+  holding.lock === None
+
+-- | Settle the batch.
+settleBatch : Script ()
+settleBatch = do
+  -- Allocate and approve
+  (TestParties{..}, (secret, _, htlcCid), (batchCid, securityInstructionCid))
+    <- runAllocateAndApprove
 
   -- Lock Batch and Instructions (such that they can't be backed out of)
   htlcCid <- submit bank do
@@ -157,50 +202,25 @@ run isHappyPath = script do
     exerciseCmd securityInstructionCid Instruction.Allocate with
       actors = Set.singleton sender; allocation = Unallocated
 
-  -- Settler can't settle (as locked)
-  submitMustFail receiver do
-    exerciseCmd batchCid Batch.Settle with actors = Set.singleton receiver
+  -- Bank can't settle (as locked)
+  submitMustFail bank do
+    exerciseCmd batchCid Batch.Settle with actors = Set.singleton bank
 
-  if isHappyPath
-    then do
-      -- HAPPY PATH
-      submit cashSender do
-        exerciseCmd htlcCid HTLC.Reveal with actor = cashSender; secret
+  -- Reveal secret
+  submit receiver do exerciseCmd htlcCid HTLC.Reveal with actor = receiver; secret
 
-      [securityHoldingCid] <- submit bank do
-        exerciseCmd batchCid Batch.Settle with actors = Set.singleton bank
+  -- Settle the batch
+  [securityHoldingCid] <- submit bank do
+    exerciseCmd batchCid Batch.Settle with actors = Set.singleton bank
 
-      -- Assert state
-      let ts = [(receiver, securityHoldingCid)]
-      Holding.verifyOwnerOfHolding ts
-      Holding.verifyNoObservers ts
-      pure ()
-    else do
-      -- FAILURE PATH
-      -- cannot cancel before expiry
-      submitMultiMustFail [bank, sender, receiver] [] do
-        exerciseCmd batchCid Batch.Cancel with actors = Set.fromList [bank, sender, receiver]
+  -- Assert state
+  let ts = [(receiver, securityHoldingCid)]
+  Holding.verifyOwnerOfHolding ts
+  Holding.verifyNoObservers ts
 
-      -- wait for expiry
-      setTime $ addRelTime expiry $ hours 1
-
-      [securityHoldingCid] <- submitMulti [bank, sender, receiver] [] do
-        exerciseCmd batchCid Batch.Cancel with actors = Set.fromList [bank, sender, receiver]
-
-      -- Assert state
-      let ts = [(sender, securityHoldingCid)]
-      Holding.verifyOwnerOfHolding ts
-      Holding.verifyNoObservers ts
-      pure ()
-
-runHappyPath : Script ()
-runHappyPath = run True
-
-runFailurePath : Script ()
-runFailurePath = run False
+  pure ()
 
 setupParties : Script TestParties
 setupParties = do
-  [cb, bank, sender, receiver, cashSender, cashReceiver, settler] <-
-    createParties ["CentralBank", "Bank", "Sender", "Receiver", "CashSender", "CashReceiver", "Settler"]
-  pure TestParties with cb; bank; sender; receiver; cashSender; cashReceiver; settler
+  [bank, sender, receiver] <- createParties ["Bank", "Sender", "Receiver"]
+  pure TestParties with bank; sender; receiver


### PR DESCRIPTION
This PR relaxes the `Cancel` choice for the HTLC `Batch` with the following changes:

1. It allows the cancellation of a `Batch` that is either in the `Open` state or has expired.
2. It enables the `instructor` to cancel the `Batch` even if its `Instruction`s have been `Approved` and `Allocated`, removing the requirement to first unapprove or unallocate them.

Previously, the `Cancel` choice of the `Batch` required the HTLC to be expired, preventing cancellation while in the `Open` (and non-expired) state.