### PR TITLE
Daml Finance cleanup after release SDK 2.9.1 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,8 @@ Dependency update (patch).
 
 ### Daml.Finance.Interface.Account
 
+Dependency update (patch).
+
 ### Daml.Finance.Interface.Claims
 
 Dependency update (patch).
@@ -118,7 +120,11 @@ Dependency update (patch).
 
 ### Daml.Finance.Interface.Holding
 
+Dependency update (patch).
+
 ### Daml.Finance.Interface.Instrument.Base
+
+Dependency update (patch).
 
 ### Daml.Finance.Interface.Instrument.Bond
 
@@ -142,9 +148,15 @@ Add new AutoCallable instrument (minor).
 
 ### Daml.Finance.Interface.Instrument.Swap
 
+Dependency update (patch).
+
 ### Daml.Finance.Interface.Instrument.Token
 
+Dependency update (patch).
+
 ### Daml.Finance.Interface.Instrument.Types
+
+Dependency update (patch).
 
 ### Daml.Finance.Interface.Lifecycle
 
@@ -152,11 +164,19 @@ Update a comment (this should generally not trigger a version bump, but packell 
 
 ### Daml.Finance.Interface.Settlement
 
+Dependency update (patch).
+
 ### Daml.Finance.Interface.Types.Common
+
+Dependency update (patch).
 
 ### Daml.Finance.Interface.Types.Date
 
+Dependency update (patch).
+
 ### Daml.Finance.Interface.Util
+
+Dependency update (patch).
 
 ### Daml.Finance.Lifecycle
 

--- a/bin/update-daml-hashes
+++ b/bin/update-daml-hashes
@@ -9,7 +9,7 @@ damlVersion=$(yq .daml-version $DIR/../daml.yaml)
 
 release_exists() (
   curl -I \
-       https://github.com/digital-asset/daml/releases/tag/v$damlVersion \
+       https://github.com/digital-asset/daml/releases/tag/v$sdkVersion \
        --fail \
     &>/dev/null
 )
@@ -22,7 +22,7 @@ get_hash() (
       curl --location \
            --fail \
            --silent \
-           https://github.com/digital-asset/daml/releases/download/v${damlVersion}/daml-sdk-${sdkVersion}-${os}.tar.gz \
+           https://github.com/digital-asset/daml/releases/download/v${sdkVersion}/daml-sdk-${damlVersion}-${os}.tar.gz \
         > $out
     ;;
     private)

--- a/daml.yaml
+++ b/daml.yaml
@@ -5,8 +5,18 @@
 # to keep shell.nix in sync (CI will notice & fail)
 # You may need to comment out `daml` from the "buildInputs` list to get your
 # Nix shell to run while you update the hashes.
+# sdk-version refers to the release folder names found here:
+# https://github.com/digital-asset/daml/releases
+# For example 2.9.0-rc1 (in case of a release candidate) or 2.8.0 (for a regular release)
 sdk-version: 2.9.0-rc2
 # daml-version is not used by the daml assistant, only by the finance nix config
+# It refers to the version number in the files of the release folder.
+# For example, if you use a release candidate like:
+# https://github.com/digital-asset/daml/releases/tag/v2.9.0-rc1
+# the daml-version would be: 2.9.0-snapshot.20240619.12850.0.v0cfddd39
+# On the other hand, if you use a regular release like:
+# https://github.com/digital-asset/daml/releases/tag/v2.8.0
+# the daml-version would simply be: 2.8.0
 daml-version: 2.9.0-snapshot.20240627.12859.1.v8721b34e
 name: daml-finance
 source: src/test/daml

--- a/daml.yaml
+++ b/daml.yaml
@@ -10,7 +10,7 @@
 # For example 2.9.0-rc1 (in case of a release candidate) or 2.8.0 (for a regular release)
 sdk-version: 2.9.0-rc2
 # daml-version is not used by the daml assistant, only by the finance nix config
-# It refers to the version number in the files of the release folder.
+# It refers to the version number of the files of the release folder.
 # For example, if you use a release candidate like:
 # https://github.com/digital-asset/daml/releases/tag/v2.9.0-rc1
 # the daml-version would be: 2.9.0-snapshot.20240619.12850.0.v0cfddd39

--- a/daml.yaml
+++ b/daml.yaml
@@ -7,7 +7,7 @@
 # update the hashes. The sdk-version refers to the release folder names (or tags) found here:
 # https://github.com/digital-asset/daml/releases
 # For example 2.9.0-rc1 (in case of a release candidate) or 2.8.0 (for a regular release)
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 # daml-version is not used by the daml assistant, only by the finance nix config
 # It refers to the version number of the files of the release folder.
 # For example, if you use a release candidate like:
@@ -16,7 +16,7 @@ sdk-version: 2.9.1
 # On the other hand, if you use a regular release like:
 # https://github.com/digital-asset/daml/releases/tag/v2.8.0
 # the daml-version would simply be: 2.8.0
-daml-version: 2.9.1
+daml-version: 2.9.3
 name: daml-finance
 source: src/test/daml
 # version is independent of the actual sdk-version. It is used to create an assembly artifact here

--- a/daml.yaml
+++ b/daml.yaml
@@ -3,12 +3,11 @@
 
 # If sdk-version or daml-version is changed, please run bin/update-daml-hashes
 # to keep shell.nix in sync (CI will notice & fail)
-# You may need to comment out `daml` from the "buildInputs` list to get your
-# Nix shell to run while you update the hashes.
-# sdk-version refers to the release folder names (or tags) found here:
+# You need to comment out `daml` from the `buildInputs` list to get your Nix shell to run while you
+# update the hashes. The sdk-version refers to the release folder names (or tags) found here:
 # https://github.com/digital-asset/daml/releases
 # For example 2.9.0-rc1 (in case of a release candidate) or 2.8.0 (for a regular release)
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 # daml-version is not used by the daml assistant, only by the finance nix config
 # It refers to the version number of the files of the release folder.
 # For example, if you use a release candidate like:
@@ -17,10 +16,15 @@ sdk-version: 2.9.0-rc2
 # On the other hand, if you use a regular release like:
 # https://github.com/digital-asset/daml/releases/tag/v2.8.0
 # the daml-version would simply be: 2.8.0
-daml-version: 2.9.0-snapshot.20240627.12859.1.v8721b34e
+daml-version: 2.9.1
 name: daml-finance
 source: src/test/daml
-version: 1.4.1
+# version is independent of the actual sdk-version. It is used to create an assembly artifact here
+# https://digitalasset.jfrog.io/ui/repos/tree/General/assembly/daml-finance which is referenced by
+# docs.daml.com (in the docs/<sdk-version>/version.json files). The purpose of having an independent
+# version number is to allow the release of new assembly versions without waiting for a new SDK
+# release. For each new SDK release, we increment the minor version of the assembly.
+version: 1.5.0
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/daml.yaml
+++ b/daml.yaml
@@ -5,7 +5,7 @@
 # to keep shell.nix in sync (CI will notice & fail)
 # You may need to comment out `daml` from the "buildInputs` list to get your
 # Nix shell to run while you update the hashes.
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 # daml-version is not used by the daml assistant, only by the finance nix config
 daml-version: 2.8.0
 name: daml-finance

--- a/daml.yaml
+++ b/daml.yaml
@@ -5,7 +5,7 @@
 # to keep shell.nix in sync (CI will notice & fail)
 # You may need to comment out `daml` from the "buildInputs` list to get your
 # Nix shell to run while you update the hashes.
-# sdk-version refers to the release folder names found here:
+# sdk-version refers to the release folder names (or tags) found here:
 # https://github.com/digital-asset/daml/releases
 # For example 2.9.0-rc1 (in case of a release candidate) or 2.8.0 (for a regular release)
 sdk-version: 2.9.0-rc2

--- a/daml.yaml
+++ b/daml.yaml
@@ -7,7 +7,7 @@
 # Nix shell to run while you update the hashes.
 sdk-version: 2.9.0-rc2
 # daml-version is not used by the daml assistant, only by the finance nix config
-daml-version: 2.8.0
+daml-version: 2.9.0-snapshot.20240627.12859.1.v8721b34e
 name: daml-finance
 source: src/test/daml
 version: 1.4.1

--- a/docs/code-samples/getting-started/daml.yaml
+++ b/docs/code-samples/getting-started/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: quickstart-finance
 source: daml
 init-script: Scripts.Transfer:runTransfer

--- a/docs/code-samples/getting-started/daml.yaml
+++ b/docs/code-samples/getting-started/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: quickstart-finance
 source: daml
 init-script: Scripts.Transfer:runTransfer

--- a/docs/code-samples/getting-started/daml.yaml
+++ b/docs/code-samples/getting-started/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: quickstart-finance
 source: daml
 init-script: Scripts.Transfer:runTransfer

--- a/docs/code-samples/lifecycling/daml.yaml
+++ b/docs/code-samples/lifecycling/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: finance-lifecycling
 source: daml
 init-script: Scripts.FixedRateBond:runFixedRateBond

--- a/docs/code-samples/lifecycling/daml.yaml
+++ b/docs/code-samples/lifecycling/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: finance-lifecycling
 source: daml
 init-script: Scripts.FixedRateBond:runFixedRateBond

--- a/docs/code-samples/lifecycling/daml.yaml
+++ b/docs/code-samples/lifecycling/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: finance-lifecycling
 source: daml
 init-script: Scripts.FixedRateBond:runFixedRateBond

--- a/docs/code-samples/payoff-modeling/daml.yaml
+++ b/docs/code-samples/payoff-modeling/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: finance-payoff-modeling
 source: daml
 init-script: PayoffBuilder:runCreateAndLifecycle

--- a/docs/code-samples/payoff-modeling/daml.yaml
+++ b/docs/code-samples/payoff-modeling/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: finance-payoff-modeling
 source: daml
 init-script: PayoffBuilder:runCreateAndLifecycle

--- a/docs/code-samples/payoff-modeling/daml.yaml
+++ b/docs/code-samples/payoff-modeling/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: finance-payoff-modeling
 source: daml
 init-script: PayoffBuilder:runCreateAndLifecycle

--- a/docs/code-samples/settlement/daml.yaml
+++ b/docs/code-samples/settlement/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: finance-settlement
 source: daml
 init-script: Scripts.Transfer:runDualControlTransfer

--- a/docs/code-samples/settlement/daml.yaml
+++ b/docs/code-samples/settlement/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: finance-settlement
 source: daml
 init-script: Scripts.Transfer:runDualControlTransfer

--- a/docs/code-samples/settlement/daml.yaml
+++ b/docs/code-samples/settlement/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: finance-settlement
 source: daml
 init-script: Scripts.Transfer:runDualControlTransfer

--- a/docs/code-samples/upgrades/daml.yaml
+++ b/docs/code-samples/upgrades/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: finance-upgrades
 source: daml
 init-script: Scripts.UpgradeHolding:upgradeHolding

--- a/docs/code-samples/upgrades/daml.yaml
+++ b/docs/code-samples/upgrades/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: finance-upgrades
 source: daml
 init-script: Scripts.UpgradeHolding:upgradeHolding

--- a/docs/code-samples/upgrades/daml.yaml
+++ b/docs/code-samples/upgrades/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: finance-upgrades
 source: daml
 init-script: Scripts.UpgradeHolding:upgradeHolding

--- a/nix/daml.nix
+++ b/nix/daml.nix
@@ -15,12 +15,14 @@ let
       fi
 
       get_os() (
+        echo "Downloading SDK from GitHub..."
         curl --location \
              --fail \
-             https://github.com/digital-asset/daml/releases/download/v${damlVersion}/daml-sdk-${sdkVersion}-${os}.tar.gz \
+             https://github.com/digital-asset/daml/releases/download/v${sdkVersion}/daml-sdk-${damlVersion}-${os}.tar.gz \
           > $out
       )
       get_ee() (
+        echo "Downloading SDK from Artifactory..."
         if [ -n "''${ARTIFACTORY_PASSWORD:-}" ]; then
           curl -u $ARTIFACTORY_USERNAME:$ARTIFACTORY_PASSWORD \
                https://digitalasset.jfrog.io/artifactory/assembly/daml/${sdkVersion}/daml-sdk-${sdkVersion}-${os}.tar.gz \
@@ -49,7 +51,7 @@ in
       tar xzf $src -C daml --strip-components 1
       patchShebangs .
     '';
-    installPhase = "cd daml; DAML_HOME=$out ./install.sh --install-with-internal-version yes";
+    installPhase = "cd daml; DAML_HOME=$out ./install.sh";
     propagatedBuildInputs = [ jdk ];
     preFixup = ''
       # Set DAML_HOME automatically.

--- a/package/main/daml/ContingentClaims.Core/daml.yaml
+++ b/package/main/daml/ContingentClaims.Core/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: contingent-claims-core
 source: daml
 version: 2.0.2

--- a/package/main/daml/ContingentClaims.Core/daml.yaml
+++ b/package/main/daml/ContingentClaims.Core/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: contingent-claims-core
 source: daml
 version: 2.0.2

--- a/package/main/daml/ContingentClaims.Core/daml.yaml
+++ b/package/main/daml/ContingentClaims.Core/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: contingent-claims-core
 source: daml
 version: 2.0.2

--- a/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
+++ b/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: contingent-claims-lifecycle
 source: daml
 version: 2.0.2

--- a/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
+++ b/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: contingent-claims-lifecycle
 source: daml
 version: 2.0.2

--- a/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
+++ b/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: contingent-claims-lifecycle
 source: daml
 version: 2.0.2

--- a/package/main/daml/ContingentClaims.Valuation/daml.yaml
+++ b/package/main/daml/ContingentClaims.Valuation/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: contingent-claims-valuation
 source: daml
 version: 0.2.3

--- a/package/main/daml/ContingentClaims.Valuation/daml.yaml
+++ b/package/main/daml/ContingentClaims.Valuation/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: contingent-claims-valuation
 source: daml
 version: 0.2.3

--- a/package/main/daml/ContingentClaims.Valuation/daml.yaml
+++ b/package/main/daml/ContingentClaims.Valuation/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: contingent-claims-valuation
 source: daml
 version: 0.2.3

--- a/package/main/daml/Daml.Finance.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Account/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-account
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Account/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-account
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Account/daml.yaml
@@ -9,10 +9,10 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.0/daml-finance-interface-account-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.1/daml-finance-interface-account-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.1/daml-finance-interface-holding-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Account/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-account
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Claims/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-claims
 source: daml
 version: 2.1.1

--- a/package/main/daml/Daml.Finance.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Claims/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-claims
 source: daml
 version: 2.1.1

--- a/package/main/daml/Daml.Finance.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Claims/daml.yaml
@@ -12,12 +12,12 @@ data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/2.0.2/contingent-claims-core-2.0.2.dar
   - .lib/daml-finance/ContingentClaims.Lifecycle/2.0.2/contingent-claims-lifecycle-2.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.1/daml-finance-interface-claims-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.1/daml-finance-interface-lifecycle-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Claims/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-claims
 source: daml
 version: 2.1.1

--- a/package/main/daml/Daml.Finance.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Claims/daml.yaml
@@ -13,10 +13,10 @@ data-dependencies:
   - .lib/daml-finance/ContingentClaims.Lifecycle/2.0.2/contingent-claims-lifecycle-2.0.2.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.1/daml-finance-interface-claims-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.1/daml-finance-interface-instrument-types-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.1/daml-finance-interface-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar

--- a/package/main/daml/Daml.Finance.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Data/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-data
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Data/daml.yaml
@@ -11,9 +11,9 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Data/3.1.1/daml-finance-interface-data-3.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.1/daml-finance-interface-lifecycle-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Data/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-data
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Data/daml.yaml
@@ -12,7 +12,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Data/3.1.1/daml-finance-interface-data-3.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.1/daml-finance-interface-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Data/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-data
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Holding/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-holding
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Holding/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-holding
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Holding/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-holding
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Holding/daml.yaml
@@ -9,10 +9,10 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.0/daml-finance-interface-account-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.1/daml-finance-interface-account-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.1/daml-finance-interface-holding-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-instrument-bond
 source: daml
 version: 2.0.1

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -13,12 +13,12 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Claims/2.1.1/daml-finance-claims-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Data/3.0.1/daml-finance-data-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.1/daml-finance-interface-claims-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/2.0.1/daml-finance-interface-instrument-bond-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -15,9 +15,9 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.1/daml-finance-interface-claims-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/2.0.1/daml-finance-interface-instrument-bond-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.1/daml-finance-interface-instrument-types-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-instrument-bond
 source: daml
 version: 2.0.1

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-instrument-bond
 source: daml
 version: 2.0.1

--- a/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-instrument-equity
 source: daml
 version: 0.4.1

--- a/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-instrument-equity
 source: daml
 version: 0.4.1

--- a/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-instrument-equity
 source: daml
 version: 0.4.1

--- a/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
@@ -9,10 +9,10 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.4.1/daml-finance-interface-instrument-equity-0.4.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
@@ -11,11 +11,11 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Claims/2.1.1/daml-finance-claims-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.1/daml-finance-interface-claims-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/3.0.1/daml-finance-interface-instrument-generic-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.1/daml-finance-interface-lifecycle-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-instrument-generic
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-instrument-generic
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-instrument-generic
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-instrument-option
 source: daml
 version: 0.3.1

--- a/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
@@ -12,10 +12,10 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Claims/2.1.1/daml-finance-claims-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Data/3.0.1/daml-finance-data-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.1/daml-finance-interface-claims-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.3.1/daml-finance-interface-instrument-option-0.3.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-instrument-option
 source: daml
 version: 0.3.1

--- a/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-instrument-option
 source: daml
 version: 0.3.1

--- a/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-instrument-structuredproduct
 source: daml
 version: 0.2.0

--- a/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-instrument-structuredproduct
 source: daml
 version: 0.2.0

--- a/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
@@ -16,9 +16,9 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.3.1/daml-finance-interface-instrument-option-0.3.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.StructuredProduct/0.2.0/daml-finance-interface-instrument-structuredproduct-0.2.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.1/daml-finance-interface-instrument-types-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
@@ -13,13 +13,13 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Claims/2.1.1/daml-finance-claims-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Data/3.0.1/daml-finance-data-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.1/daml-finance-interface-claims-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.3.1/daml-finance-interface-instrument-option-0.3.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.StructuredProduct/0.2.0/daml-finance-interface-instrument-structuredproduct-0.2.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-instrument-structuredproduct
 source: daml
 version: 0.2.0

--- a/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-instrument-swap
 source: daml
 version: 0.4.1

--- a/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-instrument-swap
 source: daml
 version: 0.4.1

--- a/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
@@ -15,10 +15,10 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.1/daml-finance-interface-claims-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.4.1/daml-finance-interface-instrument-swap-0.4.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.1/daml-finance-interface-instrument-types-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.1/daml-finance-interface-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar

--- a/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
@@ -13,13 +13,13 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Claims/2.1.1/daml-finance-claims-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Data/3.0.1/daml-finance-data-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.1/daml-finance-interface-claims-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.4.0/daml-finance-interface-instrument-swap-0.4.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.4.1/daml-finance-interface-instrument-swap-0.4.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.1/daml-finance-interface-lifecycle-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options: null

--- a/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-instrument-swap
 source: daml
 version: 0.4.1

--- a/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
@@ -9,10 +9,10 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/3.0.0/daml-finance-interface-instrument-token-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/3.0.1/daml-finance-interface-instrument-token-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-instrument-token
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-instrument-token
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-instrument-token
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-interface-account
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-interface-account
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
@@ -4,13 +4,13 @@
 sdk-version: 2.9.0-rc2
 name: daml-finance-interface-account
 source: daml
-version: 3.0.0
+version: 3.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.1/daml-finance-interface-holding-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-interface-account
 source: daml
 version: 3.0.0

--- a/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
@@ -10,8 +10,8 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/2.0.2/contingent-claims-core-2.0.2.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-interface-claims
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-interface-claims
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-interface-claims
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-interface-data
 source: daml
 version: 3.1.1

--- a/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-interface-data
 source: daml
 version: 3.1.1

--- a/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
@@ -11,7 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.1/daml-finance-interface-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
@@ -10,8 +10,8 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.1/daml-finance-interface-lifecycle-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-interface-data
 source: daml
 version: 3.1.1

--- a/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-interface-holding
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-interface-holding
 source: daml
 version: 3.0.0

--- a/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-interface-holding
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
@@ -4,12 +4,12 @@
 sdk-version: 2.9.0-rc2
 name: daml-finance-interface-holding
 source: daml
-version: 3.0.0
+version: 3.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
@@ -4,13 +4,13 @@
 sdk-version: 2.9.0-rc2
 name: daml-finance-interface-instrument-base
 source: daml
-version: 3.0.0
+version: 3.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.1/daml-finance-interface-holding-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-interface-instrument-base
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-interface-instrument-base
 source: daml
 version: 3.0.0

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-interface-instrument-base
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-interface-instrument-bond
 source: daml
 version: 2.0.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
@@ -10,10 +10,10 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.1/daml-finance-interface-claims-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-interface-instrument-bond
 source: daml
 version: 2.0.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-interface-instrument-bond
 source: daml
 version: 2.0.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
@@ -11,9 +11,9 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.1/daml-finance-interface-claims-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.1/daml-finance-interface-instrument-types-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
@@ -9,9 +9,9 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.1/daml-finance-interface-lifecycle-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-interface-instrument-equity
 source: daml
 version: 0.4.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-interface-instrument-equity
 source: daml
 version: 0.4.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-interface-instrument-equity
 source: daml
 version: 0.4.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-interface-instrument-generic
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-interface-instrument-generic
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
@@ -10,8 +10,8 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.1/daml-finance-interface-claims-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-interface-instrument-generic
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
@@ -10,9 +10,9 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.1/daml-finance-interface-claims-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.1/daml-finance-interface-lifecycle-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-interface-instrument-option
 source: daml
 version: 0.3.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-interface-instrument-option
 source: daml
 version: 0.3.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-interface-instrument-option
 source: daml
 version: 0.3.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-interface-instrument-structuredproduct
 source: daml
 version: 0.2.0

--- a/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-interface-instrument-structuredproduct
 source: daml
 version: 0.2.0

--- a/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
@@ -12,7 +12,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.1/daml-finance-interface-claims-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
@@ -10,9 +10,9 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.1/daml-finance-interface-claims-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-interface-instrument-structuredproduct
 source: daml
 version: 0.2.0

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-interface-instrument-swap
 source: daml
 version: 0.4.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
@@ -4,15 +4,15 @@
 sdk-version: 2.9.0-rc2
 name: daml-finance-interface-instrument-swap
 source: daml
-version: 0.4.0
+version: 0.4.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-interface-instrument-swap
 source: daml
 version: 0.4.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
@@ -10,9 +10,9 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.1/daml-finance-interface-instrument-types-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-interface-instrument-swap
 source: daml
 version: 0.4.0

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
@@ -4,13 +4,13 @@
 sdk-version: 2.9.0-rc2
 name: daml-finance-interface-instrument-token
 source: daml
-version: 3.0.0
+version: 3.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-interface-instrument-token
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-interface-instrument-token
 source: daml
 version: 3.0.0

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-interface-instrument-token
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-interface-instrument-types
 source: daml
 version: 1.0.0

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-interface-instrument-types
 source: daml
 version: 1.0.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-interface-instrument-types
 source: daml
 version: 1.0.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
@@ -4,11 +4,11 @@
 sdk-version: 2.9.0-rc2
 name: daml-finance-interface-instrument-types
 source: daml
-version: 1.0.0
+version: 1.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-interface-lifecycle
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
@@ -9,9 +9,9 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/3.0.0/daml-finance-interface-settlement-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.1/daml-finance-interface-holding-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/3.0.1/daml-finance-interface-settlement-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-interface-lifecycle
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-interface-lifecycle
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-interface-settlement
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-interface-settlement
 source: daml
 version: 3.0.0

--- a/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
@@ -4,13 +4,13 @@
 sdk-version: 2.9.0-rc2
 name: daml-finance-interface-settlement
 source: daml
-version: 3.0.0
+version: 3.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.1/daml-finance-interface-holding-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-interface-settlement
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-interface-types-common
 source: daml
 version: 2.0.0

--- a/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-interface-types-common
 source: daml
 version: 2.0.1

--- a/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.9.0-rc2
 name: daml-finance-interface-types-common
 source: daml
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-interface-types-common
 source: daml
 version: 2.0.1

--- a/package/main/daml/Daml.Finance.Interface.Types.Date/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Date/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-interface-types-date
 source: daml
 version: 2.1.0

--- a/package/main/daml/Daml.Finance.Interface.Types.Date/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Date/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-interface-types-date
 source: daml
 version: 2.1.1

--- a/package/main/daml/Daml.Finance.Interface.Types.Date/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Date/daml.yaml
@@ -4,7 +4,7 @@
 sdk-version: 2.9.0-rc2
 name: daml-finance-interface-types-date
 source: daml
-version: 2.1.0
+version: 2.1.1
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/package/main/daml/Daml.Finance.Interface.Types.Date/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Date/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-interface-types-date
 source: daml
 version: 2.1.1

--- a/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-interface-util
 source: daml
 version: 2.1.1

--- a/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
@@ -4,11 +4,11 @@
 sdk-version: 2.9.0-rc2
 name: daml-finance-interface-util
 source: daml
-version: 2.1.0
+version: 2.1.1
 dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-interface-util
 source: daml
 version: 2.1.0

--- a/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-interface-util
 source: daml
 version: 2.1.1

--- a/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
@@ -9,13 +9,13 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.0/daml-finance-interface-account-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.1/daml-finance-interface-account-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.1/daml-finance-interface-holding-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.1/daml-finance-interface-lifecycle-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/3.0.0/daml-finance-interface-settlement-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/3.0.1/daml-finance-interface-settlement-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-lifecycle
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-lifecycle
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-lifecycle
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Settlement/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-settlement
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Settlement/daml.yaml
@@ -9,11 +9,11 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.0/daml-finance-interface-account-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/3.0.0/daml-finance-interface-settlement-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.1/daml-finance-interface-account-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.1/daml-finance-interface-holding-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/3.0.1/daml-finance-interface-settlement-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Settlement/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-settlement
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Settlement/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-settlement
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-util
 source: daml
 version: 3.1.1

--- a/package/main/daml/Daml.Finance.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-util
 source: daml
 version: 3.1.1

--- a/package/main/daml/Daml.Finance.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-util
 source: daml
 version: 3.1.1

--- a/package/main/daml/Daml.Finance.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Util/daml.yaml
@@ -10,7 +10,7 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options: null
 

--- a/package/main/daml/Daml.Finance.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Util/daml.yaml
@@ -9,8 +9,8 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options: null
 

--- a/package/test/daml/ContingentClaims.Test/daml.yaml
+++ b/package/test/daml/ContingentClaims.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: contingent-claims-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/ContingentClaims.Test/daml.yaml
+++ b/package/test/daml/ContingentClaims.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: contingent-claims-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/ContingentClaims.Test/daml.yaml
+++ b/package/test/daml/ContingentClaims.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: contingent-claims-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Account.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Account.Test/daml.yaml
@@ -12,10 +12,10 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Holding.Test/1.0.0/daml-finance-holding-test-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Holding/3.0.1/daml-finance-holding-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.0/daml-finance-interface-account-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.1/daml-finance-interface-account-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.1/daml-finance-interface-holding-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Account.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Account.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-account-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Account.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Account.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-account-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Account.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Account.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-account-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Data.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Data.Test/daml.yaml
@@ -13,7 +13,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Data/3.0.1/daml-finance-data-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Data/3.1.1/daml-finance-interface-data-3.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.1/daml-finance-interface-lifecycle-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options: null

--- a/package/test/daml/Daml.Finance.Data.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Data.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-data-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Data.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Data.Test/daml.yaml
@@ -14,7 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Data/3.1.1/daml-finance-interface-data-3.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.1/daml-finance-interface-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Data.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Data.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-data-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Data.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Data.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-data-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-holding-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-holding-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-holding-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
@@ -12,10 +12,10 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Account/3.0.1/daml-finance-account-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Holding/3.0.1/daml-finance-holding-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.0/daml-finance-interface-account-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.1/daml-finance-interface-account-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.1/daml-finance-interface-holding-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-instrument-bond-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
@@ -15,9 +15,9 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.1/daml-finance-interface-claims-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/2.0.1/daml-finance-interface-instrument-bond-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
@@ -14,9 +14,9 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Instrument.Bond/2.0.1/daml-finance-instrument-bond-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.1/daml-finance-interface-claims-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Bond/2.0.1/daml-finance-interface-instrument-bond-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.1/daml-finance-interface-instrument-types-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options: null

--- a/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-instrument-bond-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-instrument-bond-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
@@ -17,9 +17,9 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.4.1/daml-finance-interface-instrument-equity-0.4.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.3.1/daml-finance-interface-instrument-option-0.3.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.1/daml-finance-interface-lifecycle-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/3.0.0/daml-finance-interface-settlement-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/3.0.1/daml-finance-interface-settlement-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Settlement/3.0.1/daml-finance-settlement-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar

--- a/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-instrument-equity-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-instrument-equity-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-instrument-equity-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
@@ -15,15 +15,15 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Data/3.0.1/daml-finance-data-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Holding/3.0.1/daml-finance-holding-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Instrument.Generic/3.0.1/daml-finance-instrument-generic-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.0/daml-finance-interface-account-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.1/daml-finance-interface-account-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Claims/3.0.1/daml-finance-interface-claims-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.1/daml-finance-interface-holding-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Generic/3.0.1/daml-finance-interface-instrument-generic-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.1/daml-finance-interface-lifecycle-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/3.0.0/daml-finance-interface-settlement-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/3.0.1/daml-finance-interface-settlement-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Settlement/3.0.1/daml-finance-settlement-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar

--- a/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-instrument-generic-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-instrument-generic-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-instrument-generic-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
@@ -22,7 +22,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.1/daml-finance-interface-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Settlement/3.0.1/daml-finance-interface-settlement-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Settlement/3.0.1/daml-finance-settlement-3.0.1.dar

--- a/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-instrument-option-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
@@ -15,8 +15,8 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Instrument.Option/0.3.1/daml-finance-instrument-option-0.3.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Option/0.3.1/daml-finance-interface-instrument-option-0.3.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.1/daml-finance-interface-lifecycle-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-instrument-option-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-instrument-option-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-instrument-structuredproduct-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-instrument-structuredproduct-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
@@ -13,9 +13,9 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Data/3.0.1/daml-finance-data-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Instrument.StructuredProduct/0.2.0/daml-finance-instrument-structuredproduct-0.2.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.StructuredProduct/0.2.0/daml-finance-interface-instrument-structuredproduct-0.2.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
@@ -14,7 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Instrument.StructuredProduct/0.2.0/daml-finance-instrument-structuredproduct-0.2.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.StructuredProduct/0.2.0/daml-finance-interface-instrument-structuredproduct-0.2.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options: null

--- a/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-instrument-structuredproduct-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
@@ -16,10 +16,10 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Instrument.Swap/0.4.1/daml-finance-instrument-swap-0.4.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.4.1/daml-finance-interface-instrument-equity-0.4.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.4.1/daml-finance-interface-instrument-swap-0.4.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.1/daml-finance-interface-instrument-types-1.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.1/daml-finance-interface-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options: null

--- a/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-instrument-swap-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-instrument-swap-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-instrument-swap-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
@@ -15,12 +15,12 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Instrument.Equity/0.4.1/daml-finance-instrument-equity-0.4.1.dar
   - .lib/daml-finance/Daml.Finance.Instrument.Swap/0.4.1/daml-finance-instrument-swap-0.4.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Equity/0.4.1/daml-finance-interface-instrument-equity-0.4.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.4.0/daml-finance-interface-instrument-swap-0.4.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Swap/0.4.1/daml-finance-interface-instrument-swap-0.4.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Types/1.0.0/daml-finance-interface-instrument-types-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.1/daml-finance-interface-lifecycle-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options: null
 

--- a/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
@@ -12,11 +12,11 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Account/3.0.1/daml-finance-account-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Holding/3.0.1/daml-finance-holding-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.0/daml-finance-interface-account-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Settlement/3.0.0/daml-finance-interface-settlement-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.1/daml-finance-interface-account-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.1/daml-finance-interface-holding-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Settlement/3.0.1/daml-finance-interface-settlement-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Settlement/3.0.1/daml-finance-settlement-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options: null

--- a/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-settlement-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-settlement-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-settlement-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Test.Util/daml.yaml
+++ b/package/test/daml/Daml.Finance.Test.Util/daml.yaml
@@ -15,14 +15,14 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Data/3.0.1/daml-finance-data-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Holding/3.0.1/daml-finance-holding-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Instrument.Token/3.0.1/daml-finance-instrument-token-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.0/daml-finance-interface-account-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.0/daml-finance-interface-holding-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.0/daml-finance-interface-instrument-base-3.0.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/3.0.0/daml-finance-interface-instrument-token-3.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Account/3.0.1/daml-finance-interface-account-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.1/daml-finance-interface-holding-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/3.0.1/daml-finance-interface-instrument-token-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.1/daml-finance-interface-lifecycle-3.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options: null

--- a/package/test/daml/Daml.Finance.Test.Util/daml.yaml
+++ b/package/test/daml/Daml.Finance.Test.Util/daml.yaml
@@ -21,7 +21,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Token/3.0.1/daml-finance-interface-instrument-token-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.1/daml-finance-interface-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar

--- a/package/test/daml/Daml.Finance.Test.Util/daml.yaml
+++ b/package/test/daml/Daml.Finance.Test.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-test-util
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Test.Util/daml.yaml
+++ b/package/test/daml/Daml.Finance.Test.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-test-util
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Test.Util/daml.yaml
+++ b/package/test/daml/Daml.Finance.Test.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-test-util
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Util.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Util.Test/daml.yaml
@@ -11,7 +11,7 @@ dependencies:
   - daml-script
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar

--- a/package/test/daml/Daml.Finance.Util.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Util.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-finance-util-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Util.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Util.Test/daml.yaml
@@ -10,9 +10,9 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.0/daml-finance-interface-types-common-2.0.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.0/daml-finance-interface-types-date-2.1.0.dar
-  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.0/daml-finance-interface-util-2.1.0.dar
+  - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options: null

--- a/package/test/daml/Daml.Finance.Util.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Util.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.0-rc2
+sdk-version: 2.9.1
 name: daml-finance-util-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Util.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Util.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.8.0
+sdk-version: 2.9.0-rc2
 name: daml-finance-util-test
 source: daml
 version: 1.0.0

--- a/shell.nix
+++ b/shell.nix
@@ -20,7 +20,7 @@ let
                        curl_cert = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
                        os = if pkgs.stdenv.isDarwin then "macos" else "linux";
                        hashes = { linux = "1y+AixwC6+yLBk7M2igPsDy3gf+F1ZtvesFFyLQ+V84=";
-                                  macos = "kHbvAObgbV8qEMS0l+MvzZIUAdgDVDQJ/hsLl23jvXo="; };});
+                                  macos = "hZ7NQp1nu1JMn/B8kC7lsQE9p2yTd9QB3q2M5kKDgFQ="; };});
 in
 pkgs.mkShell {
   SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";

--- a/shell.nix
+++ b/shell.nix
@@ -19,8 +19,8 @@ let
                        curl = pkgs.curl;
                        curl_cert = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
                        os = if pkgs.stdenv.isDarwin then "macos" else "linux";
-                       hashes = { linux = "0E8BOpw3ojfnTCzPKno0An3YMwRjr7yo/PwbOwNb7/A=";
-                                  macos = "hZ7NQp1nu1JMn/B8kC7lsQE9p2yTd9QB3q2M5kKDgFQ="; };});
+                       hashes = { linux = "TIGQjDBnWbHXnHbBU9SqMAgfLuPOLhtnM4cpKQb6WbM=";
+                                  macos = "i/vWv8E1Zqpiay2Cg+pKhn2zPSLn6pOLXkr6O0qABug="; };});
 in
 pkgs.mkShell {
   SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";

--- a/shell.nix
+++ b/shell.nix
@@ -19,8 +19,8 @@ let
                        curl = pkgs.curl;
                        curl_cert = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
                        os = if pkgs.stdenv.isDarwin then "macos" else "linux";
-                       hashes = { linux = "TIGQjDBnWbHXnHbBU9SqMAgfLuPOLhtnM4cpKQb6WbM=";
-                                  macos = "i/vWv8E1Zqpiay2Cg+pKhn2zPSLn6pOLXkr6O0qABug="; };});
+                       hashes = { linux = "j2PzPon2rTYA4eFI4U9/O22jeJ1dRWoydvOZVvevScg=";
+                                  macos = "6gX1na0ceRxIjBfz6qOj+WP3tl+ZqzNHsZWpJDQi9NU="; };});
 in
 pkgs.mkShell {
   SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";

--- a/shell.nix
+++ b/shell.nix
@@ -19,7 +19,7 @@ let
                        curl = pkgs.curl;
                        curl_cert = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
                        os = if pkgs.stdenv.isDarwin then "macos" else "linux";
-                       hashes = { linux = "1y+AixwC6+yLBk7M2igPsDy3gf+F1ZtvesFFyLQ+V84=";
+                       hashes = { linux = "0E8BOpw3ojfnTCzPKno0An3YMwRjr7yo/PwbOwNb7/A=";
                                   macos = "hZ7NQp1nu1JMn/B8kC7lsQE9p2yTd9QB3q2M5kKDgFQ="; };});
 in
 pkgs.mkShell {


### PR DESCRIPTION
Shows that the `2.9.0-rc2` works in the Daml Finance repo. Our tests pass and no changes were required to the Daml code. Replace `sdk-version: 2.9.0-rc2` by `sdk-version: 2.9.0` (when released) or `sdk-version: 2.9.0-rc3` (if required).

Fixes https://github.com/digital-asset/daml-finance/issues/1224