### PR TITLE
Add version targets to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,46 +6,46 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 | Package                                    | Released version   | Target version |
 |--------------------------------------------|--------------------|----------------|
-| ContingentClaims.Core                      | 2.0.1              |                |
-| ContingentClaims.Lifecycle                 | 2.0.1              |                |
-| Daml.Finance.Account                       | 3.0.0              |                |
-| Daml.Finance.Claims                        | 2.1.0              |                |
-| Daml.Finance.Data                          | 3.0.0              |                |
-| Daml.Finance.Holding                       | 3.0.0              |                |
-| Daml.Finance.Instrument.Bond               | 2.0.0              |                |
-| Daml.Finance.Instrument.Generic            | 3.0.0              |                |
-| Daml.Finance.Instrument.Token              | 3.0.0              |                |
-| Daml.Finance.Interface.Account             | 3.0.0              |                |
-| Daml.Finance.Interface.Claims              | 3.0.0              |                |
-| Daml.Finance.Interface.Data                | 3.1.0              |                |
-| Daml.Finance.Interface.Holding             | 3.0.0              |                |
-| Daml.Finance.Interface.Instrument.Base     | 3.0.0              |                |
-| Daml.Finance.Interface.Instrument.Bond     | 2.0.0              |                |
-| Daml.Finance.Interface.Instrument.Generic  | 3.0.0              |                |
-| Daml.Finance.Interface.Instrument.Token    | 3.0.0              |                |
-| Daml.Finance.Interface.Instrument.Types    | 1.0.0              |                |
-| Daml.Finance.Interface.Lifecycle           | 3.0.0              |                |
-| Daml.Finance.Interface.Settlement          | 3.0.0              |                |
-| Daml.Finance.Interface.Types.Common        | 2.0.0              |                |
-| Daml.Finance.Interface.Types.Date          | 2.1.0              |                |
-| Daml.Finance.Interface.Util                | 2.1.0              |                |
-| Daml.Finance.Lifecycle                     | 3.0.0              |                |
-| Daml.Finance.Settlement                    | 3.0.0              |                |
-| Daml.Finance.Util                          | 3.1.0              |                |
+| ContingentClaims.Core                      | 2.0.1              | 2.0.2          |
+| ContingentClaims.Lifecycle                 | 2.0.1              | 2.0.2          |
+| Daml.Finance.Account                       | 3.0.0              | 3.0.1          |
+| Daml.Finance.Claims                        | 2.1.0              | 2.1.1          |
+| Daml.Finance.Data                          | 3.0.0              | 3.0.1          |
+| Daml.Finance.Holding                       | 3.0.0              | 3.0.1          |
+| Daml.Finance.Instrument.Bond               | 2.0.0              | 2.0.1          |
+| Daml.Finance.Instrument.Generic            | 3.0.0              | 3.0.1          |
+| Daml.Finance.Instrument.Token              | 3.0.0              | 3.0.1          |
+| Daml.Finance.Interface.Account             | 3.0.0              | 3.0.1          |
+| Daml.Finance.Interface.Claims              | 3.0.0              | 3.0.1          |
+| Daml.Finance.Interface.Data                | 3.1.0              | 3.1.1          |
+| Daml.Finance.Interface.Holding             | 3.0.0              | 3.0.1          |
+| Daml.Finance.Interface.Instrument.Base     | 3.0.0              | 3.0.1          |
+| Daml.Finance.Interface.Instrument.Bond     | 2.0.0              | 2.0.1          |
+| Daml.Finance.Interface.Instrument.Generic  | 3.0.0              | 3.0.1          |
+| Daml.Finance.Interface.Instrument.Token    | 3.0.0              | 3.0.1          |
+| Daml.Finance.Interface.Instrument.Types    | 1.0.0              | 1.0.1          |
+| Daml.Finance.Interface.Lifecycle           | 3.0.0              | 3.0.1          |
+| Daml.Finance.Interface.Settlement          | 3.0.0              | 3.0.1          |
+| Daml.Finance.Interface.Types.Common        | 2.0.0              | 2.0.1          |
+| Daml.Finance.Interface.Types.Date          | 2.1.0              | 2.1.1          |
+| Daml.Finance.Interface.Util                | 2.1.0              | 2.1.1          |
+| Daml.Finance.Lifecycle                     | 3.0.0              | 3.0.1          |
+| Daml.Finance.Settlement                    | 3.0.0              | 3.0.1          |
+| Daml.Finance.Util                          | 3.1.0              | 3.1.1          |
 
 ## Early Access Packages
 
 | Package                                             | Released version   | Target version |
 |-----------------------------------------------------|--------------------|----------------|
-| ContingentClaims.Valuation                          | 0.2.2              |                |
-| Daml.Finance.Instrument.Equity                      | 0.4.0              |                |
-| Daml.Finance.Instrument.Option                      | 0.3.0              |                |
-| Daml.Finance.Instrument.StructuredProduct           | 0.1.0              |                |
-| Daml.Finance.Instrument.Swap                        | 0.4.0              |                |
-| Daml.Finance.Interface.Instrument.Equity            | 0.4.0              |                |
-| Daml.Finance.Interface.Instrument.Option            | 0.3.0              |                |
-| Daml.Finance.Interface.Instrument.StructuredProduct | 0.1.0              |                |
-| Daml.Finance.Interface.Instrument.Swap              | 0.4.0              |                |
+| ContingentClaims.Valuation                          | 0.2.2              | 0.2.3          |
+| Daml.Finance.Instrument.Equity                      | 0.4.0              | 0.4.1          |
+| Daml.Finance.Instrument.Option                      | 0.3.0              | 0.3.1          |
+| Daml.Finance.Instrument.StructuredProduct           | 0.1.0              | 0.2.0          |
+| Daml.Finance.Instrument.Swap                        | 0.4.0              | 0.4.1          |
+| Daml.Finance.Interface.Instrument.Equity            | 0.4.0              | 0.4.1          |
+| Daml.Finance.Interface.Instrument.Option            | 0.3.0              | 0.3.1          |
+| Daml.Finance.Interface.Instrument.StructuredProduct | 0.1.0              | 0.2.0          |
+| Daml.Finance.Interface.Instrument.Swap              | 0.4.0              | 0.4.1          |
 
 ## Pending changes
 


### PR DESCRIPTION
This PR:
- Makes use of `daml-ctl-2.4.1`
- Updates the target versions in the changelog