### PR TITLE
Test Daml Finance with SDK 2.9.5

### DIFF
--- a/bin/update-daml-hashes
+++ b/bin/update-daml-hashes
@@ -29,7 +29,7 @@ get_hash() (
       if [ -n "''${ARTIFACTORY_PASSWORD:-}" ]; then
         curl -u $ARTIFACTORY_USERNAME:$ARTIFACTORY_PASSWORD \
              --silent \
-             https://digitalasset.jfrog.io/artifactory/assembly/daml/${sdkVersion}/daml-sdk-${sdkVersion}-${os}.tar.gz \
+             https://digitalasset.jfrog.io/artifactory/assembly/daml/${sdkVersion}/daml-sdk-${sdkVersion}-${os/linux/linux-intel}.tar.gz \
           > $out
       else
         echo "ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD must be set." >&2

--- a/daml.yaml
+++ b/daml.yaml
@@ -7,7 +7,7 @@
 # update the hashes. The sdk-version refers to the release folder names (or tags) found here:
 # https://github.com/digital-asset/daml/releases
 # For example 2.9.0-rc1 (in case of a release candidate) or 2.8.0 (for a regular release)
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 # daml-version is not used by the daml assistant, only by the finance nix config
 # It refers to the version number of the files of the release folder.
 # For example, if you use a release candidate like:
@@ -16,7 +16,7 @@ sdk-version: 2.9.4
 # On the other hand, if you use a regular release like:
 # https://github.com/digital-asset/daml/releases/tag/v2.8.0
 # the daml-version would simply be: 2.8.0
-daml-version: 2.9.4
+daml-version: 2.9.5
 name: daml-finance
 source: src/test/daml
 # version is independent of the actual sdk-version. It is used to create an assembly artifact here

--- a/docs/code-samples/getting-started/daml.yaml
+++ b/docs/code-samples/getting-started/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: quickstart-finance
 source: daml
 init-script: Scripts.Transfer:runTransfer

--- a/docs/code-samples/lifecycling/daml.yaml
+++ b/docs/code-samples/lifecycling/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: finance-lifecycling
 source: daml
 init-script: Scripts.FixedRateBond:runFixedRateBond

--- a/docs/code-samples/payoff-modeling/daml.yaml
+++ b/docs/code-samples/payoff-modeling/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: finance-payoff-modeling
 source: daml
 init-script: PayoffBuilder:runCreateAndLifecycle

--- a/docs/code-samples/settlement/daml.yaml
+++ b/docs/code-samples/settlement/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: finance-settlement
 source: daml
 init-script: Scripts.Transfer:runDualControlTransfer

--- a/docs/code-samples/upgrades/daml.yaml
+++ b/docs/code-samples/upgrades/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: finance-upgrades
 source: daml
 init-script: Scripts.UpgradeHolding:upgradeHolding

--- a/nix/daml.nix
+++ b/nix/daml.nix
@@ -1,4 +1,4 @@
-{ stdenv, jdk, curl, curl_cert, sdkVersion, damlVersion, os, hashes }:
+{ stdenv, jdk, curl, curl_cert, sdkVersion, damlVersion, os, osJFrog, hashes }:
 let
   tarball = stdenv.mkDerivation {
     pname = "daml-tarball";
@@ -25,7 +25,7 @@ let
         echo "Downloading SDK from Artifactory..."
         if [ -n "''${ARTIFACTORY_PASSWORD:-}" ]; then
           curl -u $ARTIFACTORY_USERNAME:$ARTIFACTORY_PASSWORD \
-               https://digitalasset.jfrog.io/artifactory/assembly/daml/${sdkVersion}/daml-sdk-${sdkVersion}-${os}.tar.gz \
+               https://digitalasset.jfrog.io/artifactory/assembly/daml/${sdkVersion}/daml-sdk-${sdkVersion}-${osJFrog}.tar.gz \
             > $out
         else
           echo "ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD must be set." >&2
@@ -51,7 +51,11 @@ in
       tar xzf $src -C daml --strip-components 1
       patchShebangs .
     '';
-    installPhase = "cd daml; DAML_HOME=$out ./install.sh";
+    installPhase = ''
+      cd daml
+      export DAML_HOME=$out
+      ./daml/daml install --install-assistant yes --install-with-internal-version yes $src
+    '';
     propagatedBuildInputs = [ jdk ];
     preFixup = ''
       # Set DAML_HOME automatically.

--- a/package/main/daml/ContingentClaims.Core/daml.yaml
+++ b/package/main/daml/ContingentClaims.Core/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: contingent-claims-core
 source: daml
 version: 2.0.2

--- a/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
+++ b/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: contingent-claims-lifecycle
 source: daml
 version: 2.0.2

--- a/package/main/daml/ContingentClaims.Valuation/daml.yaml
+++ b/package/main/daml/ContingentClaims.Valuation/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: contingent-claims-valuation
 source: daml
 version: 0.2.3

--- a/package/main/daml/Daml.Finance.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Account/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-account
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Claims/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-claims
 source: daml
 version: 2.1.1

--- a/package/main/daml/Daml.Finance.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Data/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-data
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Holding/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-holding
 source: daml
 version: 3.0.2

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-instrument-bond
 source: daml
 version: 2.0.1

--- a/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-instrument-equity
 source: daml
 version: 0.4.1

--- a/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-instrument-generic
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-instrument-option
 source: daml
 version: 0.3.1

--- a/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-instrument-structuredproduct
 source: daml
 version: 0.2.0

--- a/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-instrument-swap
 source: daml
 version: 0.4.1

--- a/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-instrument-token
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-interface-account
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-interface-claims
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-interface-data
 source: daml
 version: 3.1.1

--- a/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-interface-holding
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-interface-instrument-base
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-interface-instrument-bond
 source: daml
 version: 2.0.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-interface-instrument-equity
 source: daml
 version: 0.4.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-interface-instrument-generic
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-interface-instrument-option
 source: daml
 version: 0.3.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-interface-instrument-structuredproduct
 source: daml
 version: 0.2.0

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-interface-instrument-swap
 source: daml
 version: 0.4.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-interface-instrument-token
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-interface-instrument-types
 source: daml
 version: 1.0.1

--- a/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-interface-lifecycle
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-interface-settlement
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-interface-types-common
 source: daml
 version: 2.0.1

--- a/package/main/daml/Daml.Finance.Interface.Types.Date/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Date/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-interface-types-date
 source: daml
 version: 2.1.1

--- a/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-interface-util
 source: daml
 version: 2.1.1

--- a/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-lifecycle
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Settlement/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-settlement
 source: daml
 version: 3.0.1

--- a/package/main/daml/Daml.Finance.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-util
 source: daml
 version: 3.1.1

--- a/package/test/daml/ContingentClaims.Test/daml.yaml
+++ b/package/test/daml/ContingentClaims.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: contingent-claims-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Account.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Account.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-account-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Data.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Data.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-data-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-holding-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-instrument-bond-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-instrument-equity-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-instrument-generic-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-instrument-option-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-instrument-structuredproduct-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-instrument-swap-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-settlement-test
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Test.Util/daml.yaml
+++ b/package/test/daml/Daml.Finance.Test.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-test-util
 source: daml
 version: 1.0.0

--- a/package/test/daml/Daml.Finance.Util.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Util.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.4
+sdk-version: 2.9.5
 name: daml-finance-util-test
 source: daml
 version: 1.0.0

--- a/shell.nix
+++ b/shell.nix
@@ -19,8 +19,9 @@ let
                        curl = pkgs.curl;
                        curl_cert = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
                        os = if pkgs.stdenv.isDarwin then "macos" else "linux";
-                       hashes = { linux = "tx9x681U4ZDB12nnZihGu/tJiACRFV4Kq8ZxeSC7ihA=";
-                                  macos = "mVUT1ZSjUMl57L6Qsd9f6nEpwtxHhJjXYijKEWQi4N4="; };});
+                       osJFrog = if pkgs.stdenv.isDarwin then "macos" else "linux-intel";
+                       hashes = { linux = "JTcmMYHMvc5jV7Wj47gpUXH+Eeb72Da3txjAipDy1vY=";
+                                  macos = "EL90brSEorJGG1FSxgwf55EiJSo9kWMus3Hd398hMFg="; };});
 in
 pkgs.mkShell {
   SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";


### PR DESCRIPTION
Tests to build DF using SDK snapshot release 2.9.5.

Updates the `daml.nix` script:

1. Use `daml install --install-assistant yes --install-with-internal-version yes "daml-sdk.tar.gz"` instead of using the `install.sh` script (provided in the gz file).
2. Use `-intel` suffix for `linux` when downloaded from JFrog

Updates the `updat-daml-hashes` script to use the right suffix for JFrog.