### PR TITLE
Update to LF1.17, Support external daml-sdk tarball

### DIFF
--- a/bin/update-daml-hashes
+++ b/bin/update-daml-hashes
@@ -6,6 +6,7 @@ DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 sdkVersion=$(yq .sdk-version $DIR/../daml.yaml)
 damlVersion=$(yq .daml-version $DIR/../daml.yaml)
+tarPath=$(yq .daml-tar-path $DIR/../daml.yaml)
 
 release_exists() (
   curl -I \
@@ -36,6 +37,9 @@ get_hash() (
         exit 1
       fi
     ;;
+    local)
+      ln -sf $tarPath $out
+    ;;
   esac
   echo $(sha256sum $out | awk '{print $1}') | xxd -r -p | base64
 )
@@ -45,7 +49,11 @@ update_yaml_files() (
   find docs package -name daml.yaml -exec sed -i "s|sdk-version:.*|sdk-version: $version|" '{}' \;
 )
 
-if release_exists; then
+if [ $tarPath != "null" ]; then
+  echo "Using provided tar with sdk version $sdkVersion"
+  src=local
+  update_yaml_files $sdkVersion
+elif release_exists; then
   echo "Using daml version $damlVersion."
   src=public
   update_yaml_files $sdkVersion

--- a/daml.yaml
+++ b/daml.yaml
@@ -44,4 +44,3 @@ build-options:
   - --target=1.17
   - --warn-bad-interface-instances=yes
   - --warn-bad-exceptions=yes
-# typecheck-upgrades: true

--- a/daml.yaml
+++ b/daml.yaml
@@ -7,7 +7,7 @@
 # update the hashes. The sdk-version refers to the release folder names (or tags) found here:
 # https://github.com/digital-asset/daml/releases
 # For example 2.9.0-rc1 (in case of a release candidate) or 2.8.0 (for a regular release)
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 # daml-version is not used by the daml assistant, only by the finance nix config
 # It refers to the version number of the files of the release folder.
 # For example, if you use a release candidate like:
@@ -16,15 +16,15 @@ sdk-version: 2.9.5
 # On the other hand, if you use a regular release like:
 # https://github.com/digital-asset/daml/releases/tag/v2.8.0
 # the daml-version would simply be: 2.8.0
-daml-version: 2.9.5
+daml-version: 2.10.0-snapshot.20241023.13024.0.v2bb40b56
 # To use a custom daml, you must update the sdk-version across the project to that of the tar you have (likely 0.0.0)
 # daml-version above will be ignored
 # and uncomment the below tar path to point to your release tar.
 # You can generate this tar from the daml repo (in sdk/) using `bazel build //release:sdk-release-tarball`
-# which will generate the tar at <daml/sdk>/bazel-bin/release/sdk-release-tarball-ce.tar.gz
+# which will generate the tar at <daml>/sdk/bazel-bin/release/sdk-release-tarball-ce.tar.gz
 # Be sure to run bin/update-daml-hashes after adding or changing this path, and on rebuild
 # NOTE: This must be an absolute path to the release tarball.
-# daml-tar-path: <path-to-daml>/sdk/bazel-bin/release/sdk-release-tarball-ce.tar.gz
+# daml-tar-path: <daml>/sdk/bazel-bin/release/sdk-release-tarball-ce.tar.gz
 name: daml-finance
 source: src/test/daml
 # version is independent of the actual sdk-version. It is used to create an assembly artifact here
@@ -36,7 +36,7 @@ version: 1.5.0
 dependencies:
   - daml-prim
   - daml-stdlib
-  - daml-script
+  - daml-script-beta
 data-dependencies:
   - .lib/daml-ctl/v2.4.1/daml-ctl-2.4.1.dar
 build-options:

--- a/daml.yaml
+++ b/daml.yaml
@@ -7,7 +7,7 @@
 # update the hashes. The sdk-version refers to the release folder names (or tags) found here:
 # https://github.com/digital-asset/daml/releases
 # For example 2.9.0-rc1 (in case of a release candidate) or 2.8.0 (for a regular release)
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 # daml-version is not used by the daml assistant, only by the finance nix config
 # It refers to the version number of the files of the release folder.
 # For example, if you use a release candidate like:
@@ -16,7 +16,7 @@ sdk-version: 2.10.0-snapshot.20241030.0
 # On the other hand, if you use a regular release like:
 # https://github.com/digital-asset/daml/releases/tag/v2.8.0
 # the daml-version would simply be: 2.8.0
-daml-version: 2.10.0-snapshot.20241023.13024.0.v2bb40b56
+daml-version: 2.10.0-snapshot.20241101.13047.0.v1e6d5c93
 # To use a custom daml, you must update the sdk-version across the project to that of the tar you have (likely 0.0.0)
 # daml-version above will be ignored
 # and uncomment the below tar path to point to your release tar.
@@ -42,5 +42,5 @@ data-dependencies:
 build-options:
   - --include=src/main/daml
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions

--- a/daml.yaml
+++ b/daml.yaml
@@ -17,6 +17,14 @@ sdk-version: 2.9.5
 # https://github.com/digital-asset/daml/releases/tag/v2.8.0
 # the daml-version would simply be: 2.8.0
 daml-version: 2.9.5
+# To use a custom daml, you must update the sdk-version across the project to that of the tar you have (likely 0.0.0)
+# daml-version above will be ignored
+# and uncomment the below tar path to point to your release tar.
+# You can generate this tar from the daml repo (in sdk/) using `bazel build //release:sdk-release-tarball`
+# which will generate the tar at <daml/sdk>/bazel-bin/release/sdk-release-tarball-ce.tar.gz
+# Be sure to run bin/update-daml-hashes after adding or changing this path, and on rebuild
+# NOTE: This must be an absolute path to the release tarball.
+# daml-tar-path: <path-to-daml>/sdk/bazel-bin/release/sdk-release-tarball-ce.tar.gz
 name: daml-finance
 source: src/test/daml
 # version is independent of the actual sdk-version. It is used to create an assembly artifact here
@@ -33,6 +41,7 @@ data-dependencies:
   - .lib/daml-ctl/v2.4.1/daml-ctl-2.4.1.dar
 build-options:
   - --include=src/main/daml
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 # typecheck-upgrades: true

--- a/daml.yaml
+++ b/daml.yaml
@@ -33,3 +33,6 @@ data-dependencies:
   - .lib/daml-ctl/v2.4.1/daml-ctl-2.4.1.dar
 build-options:
   - --include=src/main/daml
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
+# typecheck-upgrades: true

--- a/docs/code-samples/getting-started/daml.yaml
+++ b/docs/code-samples/getting-started/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: quickstart-finance
 source: daml
 init-script: Scripts.Transfer:runTransfer

--- a/docs/code-samples/getting-started/daml.yaml
+++ b/docs/code-samples/getting-started/daml.yaml
@@ -3,14 +3,14 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: quickstart-finance
 source: daml
 init-script: Scripts.Transfer:runTransfer
 version: 0.0.6
 dependencies:
   - daml-prim
-  - daml-script
+  - daml-script-beta
   - daml-stdlib
 data-dependencies:
   # INTERFACE DEPENDENCIES

--- a/docs/code-samples/getting-started/daml.yaml.template
+++ b/docs/code-samples/getting-started/daml.yaml.template
@@ -8,7 +8,7 @@ init-script: Scripts.Transfer:runTransfer
 version: 0.0.6
 dependencies:
   - daml-prim
-  - daml-script
+  - daml-script-beta
   - daml-stdlib
 data-dependencies:
   # INTERFACE DEPENDENCIES

--- a/docs/code-samples/lifecycling/daml.yaml
+++ b/docs/code-samples/lifecycling/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: finance-lifecycling
 source: daml
 init-script: Scripts.FixedRateBond:runFixedRateBond

--- a/docs/code-samples/lifecycling/daml.yaml
+++ b/docs/code-samples/lifecycling/daml.yaml
@@ -3,14 +3,14 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: finance-lifecycling
 source: daml
 init-script: Scripts.FixedRateBond:runFixedRateBond
 version: 0.0.6
 dependencies:
   - daml-prim
-  - daml-script
+  - daml-script-beta
   - daml-stdlib
 data-dependencies:
   # INTERFACE DEPENDENCIES

--- a/docs/code-samples/lifecycling/daml.yaml.template
+++ b/docs/code-samples/lifecycling/daml.yaml.template
@@ -8,7 +8,7 @@ init-script: Scripts.FixedRateBond:runFixedRateBond
 version: 0.0.6
 dependencies:
   - daml-prim
-  - daml-script
+  - daml-script-beta
   - daml-stdlib
 data-dependencies:
   # INTERFACE DEPENDENCIES

--- a/docs/code-samples/payoff-modeling/daml.yaml
+++ b/docs/code-samples/payoff-modeling/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: finance-payoff-modeling
 source: daml
 init-script: PayoffBuilder:runCreateAndLifecycle

--- a/docs/code-samples/payoff-modeling/daml.yaml
+++ b/docs/code-samples/payoff-modeling/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: finance-payoff-modeling
 source: daml
 init-script: PayoffBuilder:runCreateAndLifecycle
@@ -11,7 +11,7 @@ version: 0.0.6
 dependencies:
   - daml-prim
   - daml-stdlib
-  - daml-script
+  - daml-script-beta
 data-dependencies:
   # INTERFACE DEPENDENCIES
   - .lib/daml-finance-interface-claims.dar

--- a/docs/code-samples/payoff-modeling/daml.yaml.template
+++ b/docs/code-samples/payoff-modeling/daml.yaml.template
@@ -9,7 +9,7 @@ version: 0.0.6
 dependencies:
   - daml-prim
   - daml-stdlib
-  - daml-script
+  - daml-script-beta
 data-dependencies:
   # INTERFACE DEPENDENCIES
   - .lib/daml-finance-interface-claims.dar

--- a/docs/code-samples/settlement/daml.yaml
+++ b/docs/code-samples/settlement/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: finance-settlement
 source: daml
 init-script: Scripts.Transfer:runDualControlTransfer

--- a/docs/code-samples/settlement/daml.yaml
+++ b/docs/code-samples/settlement/daml.yaml
@@ -3,14 +3,14 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: finance-settlement
 source: daml
 init-script: Scripts.Transfer:runDualControlTransfer
 version: 0.0.6
 dependencies:
   - daml-prim
-  - daml-script
+  - daml-script-beta
   - daml-stdlib
 data-dependencies:
   # INTERFACE DEPENDENCIES

--- a/docs/code-samples/settlement/daml.yaml.template
+++ b/docs/code-samples/settlement/daml.yaml.template
@@ -8,7 +8,7 @@ init-script: Scripts.Transfer:runDualControlTransfer
 version: 0.0.6
 dependencies:
   - daml-prim
-  - daml-script
+  - daml-script-beta
   - daml-stdlib
 data-dependencies:
   # INTERFACE DEPENDENCIES

--- a/docs/code-samples/upgrades/daml.yaml
+++ b/docs/code-samples/upgrades/daml.yaml
@@ -3,14 +3,14 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: finance-upgrades
 source: daml
 init-script: Scripts.UpgradeHolding:upgradeHolding
 version: 0.0.6
 dependencies:
   - daml-prim
-  - daml-script
+  - daml-script-beta
   - daml-stdlib
 data-dependencies:
   # INTERFACE DEPENDENCIES

--- a/docs/code-samples/upgrades/daml.yaml
+++ b/docs/code-samples/upgrades/daml.yaml
@@ -3,7 +3,7 @@
 
 # *** DO NOT COPY THIS FILE TO THE DAML REPO ***
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: finance-upgrades
 source: daml
 init-script: Scripts.UpgradeHolding:upgradeHolding

--- a/docs/code-samples/upgrades/daml.yaml.template
+++ b/docs/code-samples/upgrades/daml.yaml.template
@@ -8,7 +8,7 @@ init-script: Scripts.UpgradeHolding:upgradeHolding
 version: 0.0.6
 dependencies:
   - daml-prim
-  - daml-script
+  - daml-script-beta
   - daml-stdlib
 data-dependencies:
   # INTERFACE DEPENDENCIES

--- a/nix/daml.nix
+++ b/nix/daml.nix
@@ -21,7 +21,7 @@ let
           echo "No explict tar set, attempting to download"
           exit 1
         else
-          echo "Using explicit tar $tar_path $out"
+          echo "Using explicit tar"
           cp $tar_path $out
           chmod -x $out
         fi

--- a/nix/daml.nix
+++ b/nix/daml.nix
@@ -66,7 +66,7 @@ in
     installPhase = ''
       cd daml
       export DAML_HOME=$out
-      ./daml/daml install --install-assistant yes --install-with-internal-version yes $src
+      ./daml/daml install --install-assistant yes --install-with-custom-version $version $src
     '';
     propagatedBuildInputs = [ jdk ];
     preFixup = ''

--- a/package/main/daml/ContingentClaims.Core/daml.yaml
+++ b/package/main/daml/ContingentClaims.Core/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: contingent-claims-core
 source: daml
 version: 2.0.2
@@ -12,6 +12,6 @@ data-dependencies:
   - .lib/daml-ctl/v2.4.1/daml-ctl-2.4.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/ContingentClaims.Core/daml.yaml
+++ b/package/main/daml/ContingentClaims.Core/daml.yaml
@@ -10,5 +10,7 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-ctl/v2.4.1/daml-ctl-2.4.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/ContingentClaims.Core/daml.yaml
+++ b/package/main/daml/ContingentClaims.Core/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: contingent-claims-core
 source: daml
 version: 2.0.2
@@ -11,6 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-ctl/v2.4.1/daml-ctl-2.4.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
+++ b/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: contingent-claims-lifecycle
 source: daml
 version: 2.0.2
@@ -13,6 +13,6 @@ data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/2.0.2/contingent-claims-core-2.0.2.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
+++ b/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: contingent-claims-lifecycle
 source: daml
 version: 2.0.2
@@ -12,6 +12,7 @@ data-dependencies:
   - .lib/daml-ctl/v2.4.1/daml-ctl-2.4.1.dar
   - .lib/daml-finance/ContingentClaims.Core/2.0.2/contingent-claims-core-2.0.2.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
+++ b/package/main/daml/ContingentClaims.Lifecycle/daml.yaml
@@ -11,5 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-ctl/v2.4.1/daml-ctl-2.4.1.dar
   - .lib/daml-finance/ContingentClaims.Core/2.0.2/contingent-claims-core-2.0.2.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/ContingentClaims.Valuation/daml.yaml
+++ b/package/main/daml/ContingentClaims.Valuation/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: contingent-claims-valuation
 source: daml
 version: 0.2.3
@@ -13,6 +13,6 @@ data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/2.0.2/contingent-claims-core-2.0.2.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/ContingentClaims.Valuation/daml.yaml
+++ b/package/main/daml/ContingentClaims.Valuation/daml.yaml
@@ -11,5 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-ctl/v2.4.1/daml-ctl-2.4.1.dar
   - .lib/daml-finance/ContingentClaims.Core/2.0.2/contingent-claims-core-2.0.2.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/ContingentClaims.Valuation/daml.yaml
+++ b/package/main/daml/ContingentClaims.Valuation/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: contingent-claims-valuation
 source: daml
 version: 0.2.3
@@ -12,6 +12,7 @@ data-dependencies:
   - .lib/daml-ctl/v2.4.1/daml-ctl-2.4.1.dar
   - .lib/daml-finance/ContingentClaims.Core/2.0.2/contingent-claims-core-2.0.2.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Account/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-account
 source: daml
 version: 3.0.1
@@ -15,6 +15,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Account/daml.yaml
@@ -14,5 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Account/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-account
 source: daml
 version: 3.0.1
@@ -16,6 +16,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Claims/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-claims
 source: daml
 version: 2.1.1
@@ -21,6 +21,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Claims/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-claims
 source: daml
 version: 2.1.1
@@ -22,6 +22,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Claims/daml.yaml
@@ -20,5 +20,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Data/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-data
 source: daml
 version: 3.0.1
@@ -17,6 +17,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Data/daml.yaml
@@ -15,5 +15,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Data/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-data
 source: daml
 version: 3.0.1
@@ -16,6 +16,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Holding/daml.yaml
@@ -14,5 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Holding/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-holding
 source: daml
 version: 3.0.2
@@ -16,6 +16,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Holding/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-holding
 source: daml
 version: 3.0.2
@@ -15,6 +15,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-instrument-bond
 source: daml
 version: 2.0.1
@@ -21,6 +21,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -20,5 +20,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Bond/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-instrument-bond
 source: daml
 version: 2.0.1
@@ -22,6 +22,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-instrument-equity
 source: daml
 version: 0.4.1
@@ -16,6 +16,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-instrument-equity
 source: daml
 version: 0.4.1
@@ -17,6 +17,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Equity/daml.yaml
@@ -15,5 +15,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-instrument-generic
 source: daml
 version: 3.0.1
@@ -19,6 +19,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
@@ -18,5 +18,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Generic/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-instrument-generic
 source: daml
 version: 3.0.1
@@ -20,6 +20,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
@@ -18,5 +18,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-instrument-option
 source: daml
 version: 0.3.1
@@ -19,6 +19,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Option/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-instrument-option
 source: daml
 version: 0.3.1
@@ -20,6 +20,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
@@ -21,5 +21,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-instrument-structuredproduct
 source: daml
 version: 0.2.0
@@ -22,6 +22,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.StructuredProduct/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-instrument-structuredproduct
 source: daml
 version: 0.2.0
@@ -23,6 +23,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-instrument-swap
 source: daml
 version: 0.4.1
@@ -23,6 +23,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
@@ -22,5 +22,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Swap/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-instrument-swap
 source: daml
 version: 0.4.1
@@ -24,6 +24,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-instrument-token
 source: daml
 version: 3.0.1
@@ -15,6 +15,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
@@ -14,5 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Instrument.Token/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-instrument-token
 source: daml
 version: 3.0.1
@@ -16,6 +16,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-interface-account
 source: daml
 version: 3.0.1
@@ -14,6 +14,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-interface-account
 source: daml
 version: 3.0.1
@@ -13,6 +13,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Account/daml.yaml
@@ -12,5 +12,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.1/daml-finance-interface-holding-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-interface-claims
 source: daml
 version: 3.0.1
@@ -15,6 +15,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-interface-claims
 source: daml
 version: 3.0.1
@@ -14,6 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Claims/daml.yaml
@@ -13,5 +13,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-interface-data
 source: daml
 version: 3.1.1
@@ -15,6 +15,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-interface-data
 source: daml
 version: 3.1.1
@@ -14,6 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Data/daml.yaml
@@ -13,5 +13,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-interface-holding
 source: daml
 version: 3.0.1
@@ -13,6 +13,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
@@ -11,5 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Holding/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-interface-holding
 source: daml
 version: 3.0.1
@@ -12,6 +12,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-interface-instrument-base
 source: daml
 version: 3.0.1
@@ -13,6 +13,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
@@ -12,5 +12,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.1/daml-finance-interface-holding-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Base/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-interface-instrument-base
 source: daml
 version: 3.0.1
@@ -14,6 +14,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
@@ -15,5 +15,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-interface-instrument-bond
 source: daml
 version: 2.0.1
@@ -16,6 +16,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Bond/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-interface-instrument-bond
 source: daml
 version: 2.0.1
@@ -17,6 +17,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
@@ -13,5 +13,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.1/daml-finance-interface-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-interface-instrument-equity
 source: daml
 version: 0.4.1
@@ -15,6 +15,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Equity/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-interface-instrument-equity
 source: daml
 version: 0.4.1
@@ -14,6 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-interface-instrument-generic
 source: daml
 version: 3.0.1
@@ -14,6 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
@@ -13,5 +13,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Generic/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-interface-instrument-generic
 source: daml
 version: 3.0.1
@@ -15,6 +15,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-interface-instrument-option
 source: daml
 version: 0.3.1
@@ -16,6 +16,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-interface-instrument-option
 source: daml
 version: 0.3.1
@@ -15,6 +15,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Option/daml.yaml
@@ -14,5 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Lifecycle/3.0.1/daml-finance-interface-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-interface-instrument-structuredproduct
 source: daml
 version: 0.2.0
@@ -15,6 +15,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-interface-instrument-structuredproduct
 source: daml
 version: 0.2.0
@@ -16,6 +16,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.StructuredProduct/daml.yaml
@@ -14,5 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-interface-instrument-swap
 source: daml
 version: 0.4.1
@@ -16,6 +16,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-interface-instrument-swap
 source: daml
 version: 0.4.1
@@ -15,6 +15,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Swap/daml.yaml
@@ -14,5 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
@@ -12,5 +12,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Instrument.Base/3.0.1/daml-finance-interface-instrument-base-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-interface-instrument-token
 source: daml
 version: 3.0.1
@@ -13,6 +13,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Token/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-interface-instrument-token
 source: daml
 version: 3.0.1
@@ -14,6 +14,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
@@ -10,5 +10,7 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-interface-instrument-types
 source: daml
 version: 1.0.1
@@ -11,6 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Instrument.Types/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-interface-instrument-types
 source: daml
 version: 1.0.1
@@ -12,6 +12,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
@@ -13,5 +13,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Settlement/3.0.1/daml-finance-interface-settlement-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-interface-lifecycle
 source: daml
 version: 3.0.1
@@ -14,6 +14,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-interface-lifecycle
 source: daml
 version: 3.0.1
@@ -15,6 +15,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-interface-settlement
 source: daml
 version: 3.0.1
@@ -13,6 +13,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
@@ -12,5 +12,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Holding/3.0.1/daml-finance-interface-holding-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Settlement/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-interface-settlement
 source: daml
 version: 3.0.1
@@ -14,6 +14,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
@@ -9,5 +9,7 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies: null
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-interface-types-common
 source: daml
 version: 2.0.1
@@ -11,6 +11,6 @@ dependencies:
 data-dependencies: null
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Common/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-interface-types-common
 source: daml
 version: 2.0.1
@@ -10,6 +10,7 @@ dependencies:
   - daml-stdlib
 data-dependencies: null
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Types.Date/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Date/daml.yaml
@@ -9,5 +9,7 @@ dependencies:
   - daml-prim
   - daml-stdlib
 data-dependencies: null
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Types.Date/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Date/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-interface-types-date
 source: daml
 version: 2.1.1
@@ -11,6 +11,6 @@ dependencies:
 data-dependencies: null
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Interface.Types.Date/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Types.Date/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-interface-types-date
 source: daml
 version: 2.1.1
@@ -10,6 +10,7 @@ dependencies:
   - daml-stdlib
 data-dependencies: null
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-interface-util
 source: daml
 version: 2.1.1
@@ -11,6 +11,7 @@ dependencies:
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-interface-util
 source: daml
 version: 2.1.1
@@ -12,6 +12,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Interface.Util/daml.yaml
@@ -10,5 +10,7 @@ dependencies:
   - daml-stdlib
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-lifecycle
 source: daml
 version: 3.0.1
@@ -19,6 +19,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
@@ -17,5 +17,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
+++ b/package/main/daml/Daml.Finance.Lifecycle/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-lifecycle
 source: daml
 version: 3.0.1
@@ -18,6 +18,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Settlement/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-settlement
 source: daml
 version: 3.0.1
@@ -16,6 +16,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/main/daml/Daml.Finance.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Settlement/daml.yaml
@@ -15,5 +15,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Settlement/daml.yaml
+++ b/package/main/daml/Daml.Finance.Settlement/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-settlement
 source: daml
 version: 3.0.1
@@ -17,6 +17,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-util
 source: daml
 version: 3.1.1
@@ -14,6 +14,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/main/daml/Daml.Finance.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Util/daml.yaml
@@ -12,5 +12,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/main/daml/Daml.Finance.Util/daml.yaml
+++ b/package/main/daml/Daml.Finance.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-util
 source: daml
 version: 3.1.1
@@ -13,6 +13,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/test/daml/ContingentClaims.Test/daml.yaml
+++ b/package/test/daml/ContingentClaims.Test/daml.yaml
@@ -14,5 +14,7 @@ data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/2.0.2/contingent-claims-core-2.0.2.dar
   - .lib/daml-finance/ContingentClaims.Lifecycle/2.0.2/contingent-claims-lifecycle-2.0.2.dar
   - .lib/daml-finance/ContingentClaims.Valuation/0.2.3/contingent-claims-valuation-0.2.3.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/test/daml/ContingentClaims.Test/daml.yaml
+++ b/package/test/daml/ContingentClaims.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: contingent-claims-test
 source: daml
 version: 1.0.0
@@ -16,6 +16,6 @@ data-dependencies:
   - .lib/daml-finance/ContingentClaims.Valuation/0.2.3/contingent-claims-valuation-0.2.3.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/test/daml/ContingentClaims.Test/daml.yaml
+++ b/package/test/daml/ContingentClaims.Test/daml.yaml
@@ -1,20 +1,21 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: contingent-claims-test
 source: daml
 version: 1.0.0
 dependencies:
   - daml-prim
   - daml-stdlib
-  - daml-script
+  - daml-script-beta
 data-dependencies:
   - .lib/daml-ctl/v2.4.1/daml-ctl-2.4.1.dar
   - .lib/daml-finance/ContingentClaims.Core/2.0.2/contingent-claims-core-2.0.2.dar
   - .lib/daml-finance/ContingentClaims.Lifecycle/2.0.2/contingent-claims-lifecycle-2.0.2.dar
   - .lib/daml-finance/ContingentClaims.Valuation/0.2.3/contingent-claims-valuation-0.2.3.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/test/daml/Daml.Finance.Account.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Account.Test/daml.yaml
@@ -17,5 +17,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/test/daml/Daml.Finance.Account.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Account.Test/daml.yaml
@@ -1,14 +1,14 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-account-test
 source: daml
 version: 1.0.0
 dependencies:
   - daml-prim
   - daml-stdlib
-  - daml-script
+  - daml-script-beta
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Holding.Test/1.0.0/daml-finance-holding-test-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Holding/3.0.2/daml-finance-holding-3.0.2.dar
@@ -18,6 +18,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/test/daml/Daml.Finance.Account.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Account.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-account-test
 source: daml
 version: 1.0.0
@@ -19,6 +19,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/test/daml/Daml.Finance.Data.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Data.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-data-test
 source: daml
 version: 1.0.0
@@ -18,6 +18,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/test/daml/Daml.Finance.Data.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Data.Test/daml.yaml
@@ -1,14 +1,14 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-data-test
 source: daml
 version: 1.0.0
 dependencies:
   - daml-prim
   - daml-stdlib
-  - daml-script
+  - daml-script-beta
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Data/3.0.1/daml-finance-data-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Data/3.1.1/daml-finance-interface-data-3.1.1.dar
@@ -17,6 +17,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/test/daml/Daml.Finance.Data.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Data.Test/daml.yaml
@@ -16,5 +16,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
@@ -17,5 +17,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
@@ -1,14 +1,14 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-holding-test
 source: daml
 version: 1.0.0
 dependencies:
   - daml-prim
   - daml-stdlib
-  - daml-script
+  - daml-script-beta
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Account/3.0.1/daml-finance-account-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Holding/3.0.2/daml-finance-holding-3.0.2.dar
@@ -18,6 +18,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Holding.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-holding-test
 source: daml
 version: 1.0.0
@@ -19,6 +19,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-instrument-bond-test
 source: daml
 version: 1.0.0
@@ -21,6 +21,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
@@ -19,5 +19,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Bond.Test/daml.yaml
@@ -1,14 +1,14 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-instrument-bond-test
 source: daml
 version: 1.0.0
 dependencies:
   - daml-prim
   - daml-stdlib
-  - daml-script
+  - daml-script-beta
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Data/3.0.1/daml-finance-data-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Instrument.Bond/2.0.1/daml-finance-instrument-bond-2.0.1.dar
@@ -20,6 +20,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-instrument-equity-test
 source: daml
 version: 1.0.0
@@ -25,6 +25,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
@@ -1,14 +1,14 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-instrument-equity-test
 source: daml
 version: 1.0.0
 dependencies:
   - daml-prim
   - daml-stdlib
-  - daml-script
+  - daml-script-beta
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Holding/3.0.2/daml-finance-holding-3.0.2.dar
   - .lib/daml-finance/Daml.Finance.Instrument.Equity/0.4.1/daml-finance-instrument-equity-0.4.1.dar
@@ -24,6 +24,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Settlement/3.0.1/daml-finance-settlement-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Equity.Test/daml.yaml
@@ -23,5 +23,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Settlement/3.0.1/daml-finance-settlement-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-instrument-generic-test
 source: daml
 version: 1.0.0
@@ -30,6 +30,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
@@ -1,14 +1,14 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-instrument-generic-test
 source: daml
 version: 1.0.0
 dependencies:
   - daml-prim
   - daml-stdlib
-  - daml-script
+  - daml-script-beta
 data-dependencies:
   - .lib/daml-finance/ContingentClaims.Core/2.0.2/contingent-claims-core-2.0.2.dar
   - .lib/daml-finance/Daml.Finance.Claims/2.1.1/daml-finance-claims-2.1.1.dar
@@ -29,6 +29,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Generic.Test/daml.yaml
@@ -28,5 +28,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Settlement/3.0.1/daml-finance-settlement-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
@@ -18,5 +18,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-instrument-option-test
 source: daml
 version: 1.0.0
@@ -20,6 +20,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Option.Test/daml.yaml
@@ -1,14 +1,14 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-instrument-option-test
 source: daml
 version: 1.0.0
 dependencies:
   - daml-prim
   - daml-stdlib
-  - daml-script
+  - daml-script-beta
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Claims/2.1.1/daml-finance-claims-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Data/3.0.1/daml-finance-data-3.0.1.dar
@@ -19,6 +19,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
@@ -17,5 +17,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
@@ -1,14 +1,14 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-instrument-structuredproduct-test
 source: daml
 version: 1.0.0
 dependencies:
   - daml-prim
   - daml-stdlib
-  - daml-script
+  - daml-script-beta
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Data/3.0.1/daml-finance-data-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Instrument.StructuredProduct/0.2.0/daml-finance-instrument-structuredproduct-0.2.0.dar
@@ -18,6 +18,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.StructuredProduct.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-instrument-structuredproduct-test
 source: daml
 version: 1.0.0
@@ -19,6 +19,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-instrument-swap-test
 source: daml
 version: 1.0.0
@@ -24,6 +24,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
@@ -22,5 +22,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Instrument.Swap.Test/daml.yaml
@@ -1,14 +1,14 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-instrument-swap-test
 source: daml
 version: 1.0.0
 dependencies:
   - daml-prim
   - daml-stdlib
-  - daml-script
+  - daml-script-beta
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Data/3.0.1/daml-finance-data-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Instrument.Equity.Test/1.0.0/daml-finance-instrument-equity-test-1.0.0.dar
@@ -23,6 +23,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
@@ -19,5 +19,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Settlement/3.0.1/daml-finance-settlement-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
@@ -1,14 +1,14 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-settlement-test
 source: daml
 version: 1.0.0
 dependencies:
   - daml-prim
   - daml-stdlib
-  - daml-script
+  - daml-script-beta
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Account/3.0.1/daml-finance-account-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Holding/3.0.2/daml-finance-holding-3.0.2.dar
@@ -20,6 +20,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Settlement/3.0.1/daml-finance-settlement-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Settlement.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-settlement-test
 source: daml
 version: 1.0.0
@@ -21,6 +21,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/test/daml/Daml.Finance.Test.Util/daml.yaml
+++ b/package/test/daml/Daml.Finance.Test.Util/daml.yaml
@@ -25,5 +25,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/test/daml/Daml.Finance.Test.Util/daml.yaml
+++ b/package/test/daml/Daml.Finance.Test.Util/daml.yaml
@@ -1,14 +1,14 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-test-util
 source: daml
 version: 1.0.0
 dependencies:
   - daml-prim
   - daml-stdlib
-  - daml-script
+  - daml-script-beta
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Account/3.0.1/daml-finance-account-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Claims/2.1.1/daml-finance-claims-2.1.1.dar
@@ -26,6 +26,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Lifecycle/3.0.1/daml-finance-lifecycle-3.0.1.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/test/daml/Daml.Finance.Test.Util/daml.yaml
+++ b/package/test/daml/Daml.Finance.Test.Util/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-test-util
 source: daml
 version: 1.0.0
@@ -27,6 +27,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/package/test/daml/Daml.Finance.Util.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Util.Test/daml.yaml
@@ -1,14 +1,14 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.9.5
+sdk-version: 2.10.0-snapshot.20241030.0
 name: daml-finance-util-test
 source: daml
 version: 1.0.0
 dependencies:
   - daml-prim
   - daml-stdlib
-  - daml-script
+  - daml-script-beta
 data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Types.Common/2.0.1/daml-finance-interface-types-common-2.0.1.dar
   - .lib/daml-finance/Daml.Finance.Interface.Types.Date/2.1.1/daml-finance-interface-types-date-2.1.1.dar
@@ -16,6 +16,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
-  - --target=1.16
+  - --target=1.17
   - --warn-bad-interface-instances=yes
+  - --warn-bad-exceptions=yes
 

--- a/package/test/daml/Daml.Finance.Util.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Util.Test/daml.yaml
@@ -15,5 +15,7 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Interface.Util/2.1.1/daml-finance-interface-util-2.1.1.dar
   - .lib/daml-finance/Daml.Finance.Test.Util/1.0.0/daml-finance-test-util-1.0.0.dar
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
-build-options: null
+build-options:
+  - --target=1.16
+  - --warn-bad-interface-instances=yes
 

--- a/package/test/daml/Daml.Finance.Util.Test/daml.yaml
+++ b/package/test/daml/Daml.Finance.Util.Test/daml.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 2.10.0-snapshot.20241030.0
+sdk-version: 2.10.0-snapshot.20241106.0
 name: daml-finance-util-test
 source: daml
 version: 1.0.0
@@ -17,6 +17,6 @@ data-dependencies:
   - .lib/daml-finance/Daml.Finance.Util/3.1.1/daml-finance-util-3.1.1.dar
 build-options:
   - --target=1.17
-  - --warn-bad-interface-instances=yes
-  - --warn-bad-exceptions=yes
+  - -Wno-upgrade-interfaces
+  - -Wno-upgrade-exceptions
 

--- a/shell.nix
+++ b/shell.nix
@@ -21,8 +21,8 @@ let
                        curl_cert = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
                        os = if pkgs.stdenv.isDarwin then "macos" else "linux";
                        osJFrog = if pkgs.stdenv.isDarwin then "macos" else "linux-intel";
-                       hashes = { linux = "JTcmMYHMvc5jV7Wj47gpUXH+Eeb72Da3txjAipDy1vY=";
-                                  macos = "EL90brSEorJGG1FSxgwf55EiJSo9kWMus3Hd398hMFg="; };});
+                       hashes = { linux = "uoS+WkUO61tJ9hou7BQ7Sm8fL+WBEZxtRZv8DXr71r4=";
+                                  macos = "x9QqQ/5vUintTJpn/4KOmFxDzd3AlKRF5sXUBicbi4Y="; };});
 in
 pkgs.mkShell {
   SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";

--- a/shell.nix
+++ b/shell.nix
@@ -21,8 +21,8 @@ let
                        curl_cert = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
                        os = if pkgs.stdenv.isDarwin then "macos" else "linux";
                        osJFrog = if pkgs.stdenv.isDarwin then "macos" else "linux-intel";
-                       hashes = { linux = "uoS+WkUO61tJ9hou7BQ7Sm8fL+WBEZxtRZv8DXr71r4=";
-                                  macos = "x9QqQ/5vUintTJpn/4KOmFxDzd3AlKRF5sXUBicbi4Y="; };});
+                       hashes = { linux = "SM26LFj43g4TFba1EpLFazaEdvDFOufvMPrbGPYYP0o=";
+                                  macos = "wdXq5PVge6pyf3FuW+winRhMM7707Lg0b4cr4L8+nE4="; };});
 in
 pkgs.mkShell {
   SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";

--- a/shell.nix
+++ b/shell.nix
@@ -16,6 +16,7 @@ let
                        jdk = pkgs.openjdk11_headless;
                        sdkVersion = damlYaml.sdk-version;
                        damlVersion = damlYaml.daml-version;
+                       tarPath = damlYaml.daml-tar-path or null;
                        curl = pkgs.curl;
                        curl_cert = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
                        os = if pkgs.stdenv.isDarwin then "macos" else "linux";


### PR DESCRIPTION
This PR adds support for an external daml-sdk tarball (i.e. generated by the daml repo as 0.0.0), via an optional field in the root daml.yaml

It also updates every package to LF1.17, enables the correct flags, and moves to daml-script-beta.

This work has uncovered a bug in daml-script and daml-script-beta, which were fixed by [this daml pr](https://github.com/digital-asset/daml/pull/20216)
This PR uses a snapshot that includes that fix.