### PR TITLE
Bump version for updated docs

### DIFF
--- a/daml.yaml
+++ b/daml.yaml
@@ -32,7 +32,7 @@ source: src/test/daml
 # docs.daml.com (in the docs/<sdk-version>/version.json files). The purpose of having an independent
 # version number is to allow the release of new assembly versions without waiting for a new SDK
 # release. For each new SDK release, we increment the minor version of the assembly.
-version: 1.6.0
+version: 1.6.1
 dependencies:
   - daml-prim
   - daml-stdlib


### PR DESCRIPTION
This is to update docs.daml.com with the new version numbers for the experimental packages.