### PR TITLE
Generate a new assembly and reset the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,264 +6,115 @@ This document tracks pending changes to packages. It is facilitating the write-u
 
 | Package                                    | Released | Target version |
 |--------------------------------------------|----------|----------------|
-| ContingentClaims.Core                      | 2.0.1    | 3.0.0          |
-| ContingentClaims.Lifecycle                 | 2.0.1    | 3.0.0          |
-| Daml.Finance.Account                       | 3.0.0    | 4.0.0          |
-| Daml.Finance.Claims                        | 2.1.0    | 3.0.0          |
-| Daml.Finance.Data                          | 3.0.0    | 4.0.0          |
-| Daml.Finance.Holding                       | 3.0.1    | 4.0.0          |
-| Daml.Finance.Instrument.Bond               | 2.0.0    | 3.0.0          |
-| Daml.Finance.Instrument.Generic            | 3.0.0    | 4.0.0          |
-| Daml.Finance.Instrument.Token              | 3.0.0    | 4.0.0          |
-| Daml.Finance.Interface.Account             | 3.0.0    | 4.0.0          |
-| Daml.Finance.Interface.Claims              | 3.0.0    | 4.0.0          |
-| Daml.Finance.Interface.Data                | 3.1.0    | 4.0.0          |
-| Daml.Finance.Interface.Holding             | 3.0.0    | 4.0.0          |
-| Daml.Finance.Interface.Instrument.Base     | 3.0.0    | 4.0.0          |
-| Daml.Finance.Interface.Instrument.Bond     | 2.0.0    | 3.0.0          |
-| Daml.Finance.Interface.Instrument.Generic  | 3.0.0    | 4.0.0          |
-| Daml.Finance.Interface.Instrument.Token    | 3.0.0    | 4.0.0          |
-| Daml.Finance.Interface.Instrument.Types    | 1.0.0    | 2.0.0          |
-| Daml.Finance.Interface.Lifecycle           | 3.0.0    | 4.0.0          |
-| Daml.Finance.Interface.Settlement          | 3.0.0    | 4.0.0          |
-| Daml.Finance.Interface.Types.Common        | 2.0.0    | 3.0.0          |
-| Daml.Finance.Interface.Types.Date          | 2.1.0    | 3.0.0          |
-| Daml.Finance.Interface.Util                | 2.1.0    | 3.0.0          |
-| Daml.Finance.Lifecycle                     | 3.0.0    | 4.0.0          |
-| Daml.Finance.Settlement                    | 3.0.0    | 4.0.0          |
-| Daml.Finance.Util                          | 3.1.0    | 4.0.0          |
+| ContingentClaims.Core                      | 3.0.0    |                |
+| ContingentClaims.Lifecycle                 | 3.0.0    |                |
+| Daml.Finance.Account                       | 4.0.0    |                |
+| Daml.Finance.Claims                        | 3.0.0    |                |
+| Daml.Finance.Data                          | 4.0.0    |                |
+| Daml.Finance.Holding                       | 4.0.0    |                |
+| Daml.Finance.Instrument.Bond               | 3.0.0    |                |
+| Daml.Finance.Instrument.Generic            | 4.0.0    |                |
+| Daml.Finance.Instrument.Token              | 4.0.0    |                |
+| Daml.Finance.Interface.Account             | 4.0.0    |                |
+| Daml.Finance.Interface.Claims              | 4.0.0    |                |
+| Daml.Finance.Interface.Data                | 4.0.0    |                |
+| Daml.Finance.Interface.Holding             | 4.0.0    |                |
+| Daml.Finance.Interface.Instrument.Base     | 4.0.0    |                |
+| Daml.Finance.Interface.Instrument.Bond     | 3.0.0    |                |
+| Daml.Finance.Interface.Instrument.Generic  | 4.0.0    |                |
+| Daml.Finance.Interface.Instrument.Token    | 4.0.0    |                |
+| Daml.Finance.Interface.Instrument.Types    | 2.0.0    |                |
+| Daml.Finance.Interface.Lifecycle           | 4.0.0    |                |
+| Daml.Finance.Interface.Settlement          | 4.0.0    |                |
+| Daml.Finance.Interface.Types.Common        | 3.0.0    |                |
+| Daml.Finance.Interface.Types.Date          | 3.0.0    |                |
+| Daml.Finance.Interface.Util                | 3.0.0    |                |
+| Daml.Finance.Lifecycle                     | 4.0.0    |                |
+| Daml.Finance.Settlement                    | 4.0.0    |                |
+| Daml.Finance.Util                          | 4.0.0    |                |
 
 ## Early Access Packages
 
 | Package                                             | Released | Target version |
 |-----------------------------------------------------|----------|----------------|
-| ContingentClaims.Valuation                          | 0.2.2    | 0.3.0          |
-| Daml.Finance.Instrument.Equity                      | 0.4.0    | 0.5.0          |
-| Daml.Finance.Instrument.Option                      | 0.3.0    | 0.4.0          |
-| Daml.Finance.Instrument.StructuredProduct           | 0.1.0    | 0.2.0          |
-| Daml.Finance.Instrument.Swap                        | 0.4.0    | 0.5.0          |
-| Daml.Finance.Interface.Instrument.Equity            | 0.4.0    | 0.5.0          |
-| Daml.Finance.Interface.Instrument.Option            | 0.3.0    | 0.4.0          |
-| Daml.Finance.Interface.Instrument.StructuredProduct | 0.1.0    | 0.2.0          |
-| Daml.Finance.Interface.Instrument.Swap              | 0.4.0    | 0.5.0          |
+| ContingentClaims.Valuation                          | 0.3.0    |                |
+| Daml.Finance.Instrument.Equity                      | 0.5.0    |                |
+| Daml.Finance.Instrument.Option                      | 0.4.0    |                |
+| Daml.Finance.Instrument.StructuredProduct           | 0.2.0    |                |
+| Daml.Finance.Instrument.Swap                        | 0.5.0    |                |
+| Daml.Finance.Interface.Instrument.Equity            | 0.5.0    |                |
+| Daml.Finance.Interface.Instrument.Option            | 0.4.0    |                |
+| Daml.Finance.Interface.Instrument.StructuredProduct | 0.2.0    |                |
+| Daml.Finance.Interface.Instrument.Swap              | 0.5.0    |                |
 
 ## Pending changes
 
 ### ContingentClaims.Core
 
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
-
-Bumps `daml-ctl` to `2.5.0`.
-
 ### ContingentClaims.Lifecycle
-
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
-
-Bumps `daml-ctl` to `2.5.0`.
 
 ### ContingentClaims.Valuation
 
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
-
-Bumps `daml-ctl` to `2.5.0`.
-
 ### Daml.Finance.Account
-
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
 
 ### Daml.Finance.Claims
 
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
-
 ### Daml.Finance.Data
-
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
 
 ### Daml.Finance.Holding
 
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
-
 ### Daml.Finance.Instrument.Bond
-
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
 
 ### Daml.Finance.Instrument.Equity
 
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
-
 ### Daml.Finance.Instrument.Generic
-
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
 
 ### Daml.Finance.Instrument.Option
 
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
-
 ### Daml.Finance.Instrument.StructuredProduct
-
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
-
-Add new AutoCallable instrument (minor).
 
 ### Daml.Finance.Instrument.Swap
 
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
-
 ### Daml.Finance.Instrument.Token
-
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
 
 ### Daml.Finance.Interface.Account
 
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
-
 ### Daml.Finance.Interface.Claims
-
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
 
 ### Daml.Finance.Interface.Data
 
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
-
 ### Daml.Finance.Interface.Holding
-
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
 
 ### Daml.Finance.Interface.Instrument.Base
 
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
-
 ### Daml.Finance.Interface.Instrument.Bond
-
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
 
 ### Daml.Finance.Interface.Instrument.Equity
 
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
-
 ### Daml.Finance.Interface.Instrument.Generic
-
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
 
 ### Daml.Finance.Interface.Instrument.Option
 
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
-
 ### Daml.Finance.Interface.Instrument.StructuredProduct
-
-Bump SDK to 2.10.0. LF protocol update.
-
-Add new AutoCallable instrument (minor).
 
 ### Daml.Finance.Interface.Instrument.Swap
 
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
-
 ### Daml.Finance.Interface.Instrument.Token
-
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
 
 ### Daml.Finance.Interface.Instrument.Types
 
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
-
 ### Daml.Finance.Interface.Lifecycle
-
-Bump SDK to 2.10.0. LF protocol update.
-
-Update a comment (this should generally not trigger a version bump, but packell is unhappy as I
-effectively removed a comment line, which forces the package bump).
 
 ### Daml.Finance.Interface.Settlement
 
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
-
 ### Daml.Finance.Interface.Types.Common
-
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
 
 ### Daml.Finance.Interface.Types.Date
 
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
-
 ### Daml.Finance.Interface.Util
-
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
 
 ### Daml.Finance.Lifecycle
 
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
-
 ### Daml.Finance.Settlement
 
-Bump SDK to 2.10.0. LF protocol update.
-
-Dependency update.
-
 ### Daml.Finance.Util
-
-Bump SDK to 2.10.0. LF protocol update.
-
-Only release a Semaphore lock if the provided context is recognized (patch).

--- a/daml.yaml
+++ b/daml.yaml
@@ -32,7 +32,7 @@ source: src/test/daml
 # docs.daml.com (in the docs/<sdk-version>/version.json files). The purpose of having an independent
 # version number is to allow the release of new assembly versions without waiting for a new SDK
 # release. For each new SDK release, we increment the minor version of the assembly.
-version: 1.6.0
+version: 1.6.1
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/shell.nix
+++ b/shell.nix
@@ -21,7 +21,7 @@ let
                        curl_cert = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
                        os = if pkgs.stdenv.isDarwin then "macos" else "linux";
                        osJFrog = if pkgs.stdenv.isDarwin then "macos" else "linux-intel";
-                       hashes = { linux = "ii5kHI47ZH0Pq9BrPuMmy6vmXaZtnKZ5tHq4pnqJkt8=";
+                       hashes = { linux = "JYJ6pOsJf+m3ymForJO54dVTgLS0lyXoxOA6YOck0KY=";
                                   macos = "vWilCmSv0pp46Q5Lqkil0/V8c95x+gDNvlooh3w+ibU="; };});
 in
 pkgs.mkShell {

--- a/shell.nix
+++ b/shell.nix
@@ -22,7 +22,7 @@ let
                        os = if pkgs.stdenv.isDarwin then "macos" else "linux";
                        osJFrog = if pkgs.stdenv.isDarwin then "macos" else "linux-intel";
                        hashes = { linux = "JYJ6pOsJf+m3ymForJO54dVTgLS0lyXoxOA6YOck0KY=";
-                                  macos = "vWilCmSv0pp46Q5Lqkil0/V8c95x+gDNvlooh3w+ibU="; };});
+                                  macos = "fH3ZS5h+O2w2F3oeelXBAmc2BHfhOzIaefjVvUjryWk="; };});
 in
 pkgs.mkShell {
   SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";


### PR DESCRIPTION
This is to update docs.daml.com with the new version numbers for the experimental packages.