### PR TITLE
Update docs instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,6 @@ validate-generated-docs: doc-code
 .PHONY: sphinx-build-generated-docs
 sphinx-build-generated-docs:
 	sphinx-build -M html ./docs/generated ./docs/.preview -c ./docs/sphinx-config -E
-	find ./docs/.preview -type f -follow -exec chmod 0444 {} +
 
 .PHONY: sphinx-preview-generated-docs
 sphinx-preview-generated-docs:

--- a/Makefile
+++ b/Makefile
@@ -70,11 +70,11 @@ test-all: test test-packages
 clean-all: clean clean-packages clean-docs
 
 .PHONY: generate-docs
-generate-docs:
+generate-docs: doc-code
 	./docs/scripts/generate-docs.sh
 
 .PHONY: validate-generated-docs
-validate-generated-docs:
+validate-generated-docs: doc-code
 	./docs/scripts/validate-generated-docs.sh
 
 .PHONY: sphinx-build-generated-docs

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,4 +15,8 @@ the docs via an `assembly` artifact.
 
 4. `make generate-docs` to create auto-generated docs and combine them with manual docs in `docs/generated`.
 
+For preview:
 
+1. `make sphinx-build-generated-docs`
+2. `make sphinx-preview-generated-docs`
+3. Visit http://localhost:8000/

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,31 +11,8 @@ the docs via an `assembly` artifact.
 
 2. `make build-all` to build the Daml Finance `dar`s.
 
-3. `make ci-docs` to build the `rst` documentation of the code.
+3. Write manually-written docs in `docs/source`.
 
-## Publishing to docs.daml.com
+4. `make generate-docs` to create auto-generated docs and combine them with manual docs in `docs/generated`.
 
-In order to update the assembly package used on the main documentation website at
-[docs.daml.com](http://docs.daml.com), we need to execute the following steps:
 
-1. Update the `version` in [daml.yaml](../daml.yaml). Merge this new version into main.
-2. Create a branch beginning with `assembly` or `Assembly`. This must be an
-   empty branch without any commits in it. Otherwise, the assembly tag will be incorrect.
-   You can create a remote branch in the
-   [GitHub GUI](https://github.com/digital-asset/daml-finance/branches).
-3. Log into [CircleCi](https://app.circleci.com/) and navigate to the Daml-Finance
-   [pipeline](https://app.circleci.com/pipelines/github/digital-asset/daml-finance).
-4. Navigate to the branch that you created in step 2 with the CircleCi workflow `assembly`.
-5. Once CircleCI has successfully built both `build` and `docs` steps, an approval step named
-   `hold` will be enabled - select the step and press `Approve`.
-6. The next step named `assembly` will start processing. This step:
-   1. Runs the script `docs/scripts/build-assembly.sh` which:
-      1. Takes the build output at `docs/build/daml-finance-rst` and the `src` directory and places
-         it into a folder at `docs/.assembly` with the expected directory structure.
-      2. Updates the directory paths.
-   2. Creates a tarball file.
-   3. Uploads this tarball to Artifactory (Note - if the target Daml SDK version already exists for
-      Daml-Finance, this step will fail with a 403 http error code).
-7. In the docs.daml.com [repo](https://github.com/digital-asset/docs.daml.com), follow the
-   instructions in the [README](https://github.com/digital-asset/docs.daml.com/blob/main/README.md)
-   to update the `daml-finance` version.


### PR DESCRIPTION
1. Remove outdated docs instructions
2. Added `doc-code` to doc-related tasks in Makefile
3. Removed the logic of making preview files read-only, because of the following error:

```
PermissionError: [Errno 13] Permission denied: '/Users/pulewicz/digital-asset/daml-finance/docs/.preview/doctrees/concepts/asset-model.doctree'
```