### PR TITLE
Token Standard Example with two-tier cash settlement

### DIFF
--- a/src/main/daml/Daml/Finance/Holding/V4/BaseHolding.daml
+++ b/src/main/daml/Daml/Finance/Holding/V4/BaseHolding.daml
@@ -11,6 +11,8 @@ import Daml.Finance.Interface.Util.V3.Disclosure qualified as Disclosure (I, Vie
 import Daml.Finance.Interface.Util.V3.Lockable qualified as Lockable (I, Lock(..), View(..), getLockers)
 import Daml.Finance.Util.V4.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 import Daml.Finance.Util.V4.Lockable (acquireImpl, isValidLock, releaseImpl)
+import Daml.Finance.Holding.V4.Util (lockableHoldingToStandardsHolding)
+import Splice.Api.Token.HoldingV1 qualified as HoldingV1 (Holding) 
 
 -- | Type synonym for `BaseHolding`.
 type T = BaseHolding
@@ -51,3 +53,6 @@ template BaseHolding
 
     interface instance Holding.I for BaseHolding where
       view = Holding.View with instrument; account; amount
+
+    interface instance HoldingV1.Holding for BaseHolding where
+      view = lockableHoldingToStandardsHolding this

--- a/src/main/daml/Daml/Finance/Holding/V4/Fungible.daml
+++ b/src/main/daml/Daml/Finance/Holding/V4/Fungible.daml
@@ -13,6 +13,8 @@ import Daml.Finance.Interface.Util.V3.Disclosure qualified as Disclosure (I, Vie
 import Daml.Finance.Interface.Util.V3.Lockable qualified as Lockable (I, Lock(..), View(..), getLockers)
 import Daml.Finance.Util.V4.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 import Daml.Finance.Util.V4.Lockable (acquireImpl, isValidLock, releaseImpl)
+import Daml.Finance.Holding.V4.Util (lockableHoldingToStandardsHolding)
+import Splice.Api.Token.HoldingV1 qualified as HoldingV1 (Holding) 
 
 -- | Type synonym for `Fungible`.
 type T = Fungible
@@ -58,3 +60,6 @@ template Fungible
       view = Fungible.View with modifiers = singleton account.owner
       split = splitImpl (toInterface @Fungible.I this) (\amount -> this with amount)
       merge = mergeImpl (toInterface @Fungible.I this) (.amount) (\amount -> this with amount)
+
+    interface instance HoldingV1.Holding for Fungible where
+      view = lockableHoldingToStandardsHolding this

--- a/src/main/daml/Daml/Finance/Holding/V4/Transferable.daml
+++ b/src/main/daml/Daml/Finance/Holding/V4/Transferable.daml
@@ -13,6 +13,8 @@ import Daml.Finance.Interface.Util.V3.Disclosure qualified as Disclosure (I, Vie
 import Daml.Finance.Interface.Util.V3.Lockable qualified as Lockable (I, Lock(..), View(..), getLockers)
 import Daml.Finance.Util.V4.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 import Daml.Finance.Util.V4.Lockable (acquireImpl, isValidLock, releaseImpl)
+import Daml.Finance.Holding.V4.Util (lockableHoldingToStandardsHolding)
+import Splice.Api.Token.HoldingV1 qualified as HoldingV1 (Holding) 
 
 -- | Type synonym for `Transferable`.
 type T = Transferable
@@ -57,3 +59,6 @@ template Transferable
     interface instance Transferable.I for Transferable where
       view = Transferable.View {}
       transfer = transferImpl $ toInterface this
+
+    interface instance HoldingV1.Holding for Transferable where
+      view = lockableHoldingToStandardsHolding this

--- a/src/main/daml/Daml/Finance/Holding/V4/TransferableFungible.daml
+++ b/src/main/daml/Daml/Finance/Holding/V4/TransferableFungible.daml
@@ -14,6 +14,8 @@ import Daml.Finance.Interface.Util.V3.Disclosure qualified as Disclosure (I, Vie
 import Daml.Finance.Interface.Util.V3.Lockable qualified as Lockable (I, Lock(..), View(..), getLockers)
 import Daml.Finance.Util.V4.Disclosure (addObserversImpl, removeObserversImpl, setObserversImpl)
 import Daml.Finance.Util.V4.Lockable (acquireImpl, isValidLock, releaseImpl)
+import Daml.Finance.Holding.V4.Util (lockableHoldingToStandardsHolding)
+import Splice.Api.Token.HoldingV1 qualified as HoldingV1 (Holding) 
 
 -- | Type synonym for `TransferableFungible`.
 type T = TransferableFungible
@@ -65,3 +67,6 @@ template TransferableFungible
       view = Fungible.View with modifiers = singleton account.owner
       split = splitImpl (toInterface @Fungible.I this) (\amount -> this with amount)
       merge = mergeImpl (toInterface @Fungible.I this) (.amount) (\amount -> this with amount)
+
+    interface instance HoldingV1.Holding for TransferableFungible where
+      view = lockableHoldingToStandardsHolding this

--- a/src/main/daml/Daml/Finance/Holding/V4/Util.daml
+++ b/src/main/daml/Daml/Finance/Holding/V4/Util.daml
@@ -5,7 +5,7 @@ module Daml.Finance.Holding.V4.Util where
 
 import DA.Action (foldlA)
 import DA.Foldable qualified as F (all)
-import DA.Set (fromList, isSubsetOf)
+import DA.Set (toList, fromList, isSubsetOf)
 import DA.Traversable qualified as T (forA)
 import Daml.Finance.Interface.Account.V4.Account qualified as Account (Credit(..), Debit(..), I, R, exerciseInterfaceByKey)
 import Daml.Finance.Interface.Account.V4.Util (fetchAccount)
@@ -14,7 +14,11 @@ import Daml.Finance.Interface.Holding.V4.Holding qualified as Holding (I)
 import Daml.Finance.Interface.Holding.V4.Transferable qualified as Transferable (I, Transfer(..))
 import Daml.Finance.Interface.Util.V3.Common (qty, verify)
 import Daml.Finance.Interface.Util.V3.InterfaceKey (fetchInterfaceByKey)
-import Daml.Finance.Interface.Util.V3.Lockable qualified as Lockable (mustNotBeLocked)
+import Daml.Finance.Interface.Util.V3.Lockable qualified as Lockable (I, mustNotBeLocked)
+import Splice.Api.Token.HoldingV1 qualified as HoldingV1 (HoldingView(..), Lock(..)) 
+import Splice.Api.Token.MetadataV1 qualified as MetadataV1 (Metadata(..)) 
+import Daml.Finance.Instrument.Util (instrumentKeyToInstrumentId)
+import DA.TextMap qualified as TextMap (fromList)
 
 -- | Default implementation of `transfer` for the `Transferable` interface.
 transferImpl : Transferable.I -> ContractId Transferable.I -> Transferable.Transfer
@@ -107,3 +111,26 @@ getRestAmount amounts currentAmount = do
     <> ", currentAmount=" <> show currentAmount
   let rest = currentAmount - splitAmountSum
   pure $ if rest == 0.0 then None else Some rest
+
+-- Convert a lockable holding to a standards holding
+lockableHoldingToStandardsHolding : forall t . (Template t, HasToInterface t Lockable.I, HasToInterface t Holding.I) =>
+  t -> HoldingV1.HoldingView
+lockableHoldingToStandardsHolding x =
+  HoldingV1.HoldingView with 
+    owner = account.owner
+    instrumentId = instrumentKeyToInstrumentId instrument
+    amount = amount
+    lock = fmap (\l -> HoldingV1.Lock with
+        holders = toList l.lockers
+        expiresAt = None
+        expiresAfter = None
+        context = Some (show l.context) -- Cound be more sophisticated here.
+      ) lock
+    meta = MetadataV1.Metadata with values = TextMap.fromList [("account", show account)] -- Could be more sophisticated here.
+  where
+    holding = view (toInterface @Holding.I x)
+    account = holding.account
+    instrument = holding.instrument
+    amount = holding.amount
+    lockable = view (toInterface @Lockable.I x)
+    lock = lockable.lock

--- a/src/main/daml/Daml/Finance/Instrument/Util.daml
+++ b/src/main/daml/Daml/Finance/Instrument/Util.daml
@@ -1,0 +1,9 @@
+module Daml.Finance.Instrument.Util where
+
+import Splice.Api.Token.HoldingV1 qualified as HoldingV1 (InstrumentId(..)) 
+import Daml.Finance.Interface.Types.Common.V3.Types
+
+instrumentKeyToInstrumentId : InstrumentKey -> HoldingV1.InstrumentId
+instrumentKeyToInstrumentId instrument = HoldingV1.InstrumentId with
+    admin = instrument.depository
+    id = show instrument.id -- Could be more sophisticated here.

--- a/src/main/daml/Daml/Finance/Settlement/V4/Batch.daml
+++ b/src/main/daml/Daml/Finance/Settlement/V4/Batch.daml
@@ -16,6 +16,10 @@ import Daml.Finance.Interface.Settlement.V4.Types (Allocation(..), Approval(..),
 import Daml.Finance.Interface.Types.Common.V3.Types (Id(..), Parties)
 import Daml.Finance.Settlement.V4.Instruction (Instruction(..), mustAuthorizeHelper)
 
+import Splice.Api.Token.AllocationV1 qualified as AllocationV1
+import Splice.Api.Token.MetadataV1
+import Splice.Api.Token.HoldingV1 qualified as HoldingV1
+
 -- | Type synonym for `Batch`.
 type T = Batch
 
@@ -120,6 +124,49 @@ orderPassThroughChains routedStepsWithInstructions =
           PassThroughFrom _ -> pure (ordered, used)
           _ -> pure (ordered', used')
     ) ([], mempty) routedStepsWithInstructions
+
+-- Wrapper for Batch to turn it into a standards Allocation.
+template BatchAllocation
+  with
+    batchCid : ContractId Batch.I
+    allocation : AllocationV1.AllocationSpecification
+    holdingCids : [ContractId HoldingV1.Holding]
+    meta : Metadata
+  where
+    signatory allocation.transferLeg.sender
+    observer allocation.settlement.executor
+
+    interface instance AllocationV1.Allocation for BatchAllocation where
+      view = AllocationV1.AllocationView with ..
+
+      allocation_executeTransferImpl self args = do
+        -- We should be doing some validations here that the batch matches the allocation specification
+        -- and that the holdings match.
+        batch <- fetch batchCid
+        new_holdings <- exercise batchCid Batch.Settle with actors = Set.singleton allocation.transferLeg.sender
+        receiverHoldingCids <- foldlA (\acc (holding_cid, rs) -> do
+            if rs.receiver == allocation.transferLeg.receiver
+              then return $ (coerceInterfaceContractId @HoldingV1.Holding holding_cid)::acc
+              else return acc
+          )
+          []
+          (zip new_holdings (view batch).routedSteps)
+          
+        return AllocationV1.Allocation_ExecuteTransferResult with
+          senderHoldingCids = []
+          receiverHoldingCids
+          meta = emptyMetadata
+
+      allocation_cancelImpl self args = do 
+        return AllocationV1.Allocation_CancelResult with
+          senderHoldingCids = holdingCids
+          meta = emptyMetadata
+      allocation_withdrawImpl self args = do 
+        return AllocationV1.Allocation_WithdrawResult with
+          senderHoldingCids = holdingCids
+          meta = emptyMetadata
+
+
 
 -- | HIDE
 -- Follows the pass-through chain and collects the corresponding instructions in an ordered list.

--- a/src/main/daml/Splice/Api/Token/AllocationInstructionV1.daml
+++ b/src/main/daml/Splice/Api/Token/AllocationInstructionV1.daml
@@ -1,0 +1,175 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- | Interfaces to enable wallets to instruct the registry to create allocations.
+module Splice.Api.Token.AllocationInstructionV1 where
+
+import DA.Map qualified as Map
+
+import Splice.Api.Token.MetadataV1
+import Splice.Api.Token.HoldingV1
+import Splice.Api.Token.AllocationV1
+
+
+-- AllocationInstruction
+------------------------
+
+-- | View for `AllocationInstruction`.
+data AllocationInstructionView = AllocationInstructionView with
+    originalInstructionCid : Optional (ContractId AllocationInstruction)
+      -- ^ The contract id of the original allocation instruction contract.
+      -- Used by the wallet to track the lineage of allocation instructions through multiple steps.
+      --
+      -- Only set if the registry evolves the allocation instruction in multiple steps.
+    allocation : AllocationSpecification
+      -- ^ The allocation that this instruction should create.
+    pendingActions : Map.Map Party Text
+      -- ^ The pending actions to be taken by different actors to create the allocation.
+      --
+      -- ^ This field can by used to report on the progress of registry specific
+      -- workflows that are required to prepare the allocation.
+    requestedAt : Time
+      -- ^ The time at which the allocation was requested.
+    inputHoldingCids : [ContractId Holding]
+      -- ^ The holdings to be used to fund the allocation.
+      --
+      -- MAY be empty for registries that do not represent their holdings on-ledger.
+    meta : Metadata
+      -- ^ Additional metadata specific to the allocation instruction, used for
+      -- extensibility; e.g., more detailed status information.
+  deriving (Show, Eq)
+
+-- | An interface for tracking the status of an allocation instruction,
+-- i.e., a request to a registry app to create an allocation.
+--
+-- Registries MAY evolve the allocation instruction in multiple steps. They SHOULD
+-- do so using only the choices on this interface, so that wallets can reliably
+-- parse the transaction history and determine whether the creation of the allocation ultimately
+-- succeeded or failed.
+interface AllocationInstruction where
+  viewtype AllocationInstructionView
+
+  allocationInstruction_withdrawImpl : ContractId AllocationInstruction -> AllocationInstruction_Withdraw -> Update AllocationInstructionResult
+  allocationInstruction_updateImpl : ContractId AllocationInstruction -> AllocationInstruction_Update -> Update AllocationInstructionResult
+
+  choice AllocationInstruction_Withdraw : AllocationInstructionResult
+    -- ^ Withdraw the allocation instruction as the sender.
+    with
+      extraArgs : ExtraArgs
+        -- ^ Additional context required in order to exercise the choice.
+    controller (view this).allocation.transferLeg.sender
+    do allocationInstruction_withdrawImpl this self arg
+
+  choice AllocationInstruction_Update : AllocationInstructionResult
+    -- ^ Update the state of the allocation instruction. Used by the registry to
+    -- execute registry internal workflow steps that advance the state of the
+    -- allocation instruction. A reason may be communicated via the metadata.
+    with
+      extraActors : [Party]
+        -- ^ Extra actors authorizing the update. Implementations MUST check that
+        -- this field contains the expected actors for the specific update.
+      extraArgs : ExtraArgs
+        -- ^ Additional context required in order to exercise the choice.
+    controller (view this).allocation.transferLeg.instrumentId.admin, extraActors
+    do allocationInstruction_updateImpl this self arg
+
+
+-- AllocationFactory
+--------------------
+
+-- | View for `AllocationFactory`.
+data AllocationFactoryView = AllocationFactoryView with
+    admin : Party
+      -- ^ The party representing the registry app that administers the instruments
+      -- for which this allocation factory can be used.
+    meta : Metadata
+      -- ^ Additional metadata specific to the allocation factory, used for extensibility.
+  deriving (Show, Eq)
+
+-- | Contracts implementing `AllocationFactory` are retrieved from the registry app and are
+-- used by the wallet to create allocation instructions (or allocations directly).
+interface AllocationFactory where
+  viewtype AllocationFactoryView
+
+  allocationFactory_allocateImpl : ContractId AllocationFactory -> AllocationFactory_Allocate -> Update AllocationInstructionResult
+  allocationFactory_publicFetchImpl : ContractId AllocationFactory -> AllocationFactory_PublicFetch -> Update AllocationFactoryView
+
+  nonconsuming choice AllocationFactory_Allocate : AllocationInstructionResult
+    -- ^ Generic choice for the sender's wallet to request the allocation of
+    -- assets to a specific leg of a settlement. It depends on the registry
+    -- whether this results in the allocation being created directly
+    -- or in an allocation instruction being created instead.
+    with
+      expectedAdmin : Party
+        -- ^ The expected admin party issuing the factory. Implementations MUST validate that this matches
+        -- the admin of the factory.
+        -- Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against
+        -- their own participant. That way they can ensure that it is safe to exercise a choice
+        -- on a factory contract acquired from an untrusted source *provided*
+        -- all vetted Daml packages only contain interface implementations
+        -- that check the expected admin party.
+      allocation : AllocationSpecification
+        -- ^ The allocation which should be created.
+      requestedAt : Time
+        -- ^ The time at which the allocation was requested.
+      inputHoldingCids : [ContractId Holding]
+        -- ^ The holdings that SHOULD be used to fund the allocation.
+        --
+        -- MAY be empty for registries that do not represent their holdings on-ledger; or
+        -- for registries that support automatic selection of holdings for allocations.
+        --
+        -- If specified, then the successful allocation MUST archive all of these holdings, so
+        -- that the execution of the allocation conflicts with any other allocations
+        -- using these holdings. Thereby allowing that the sender can use
+        -- deliberate contention on holdings to prevent duplicate allocations.
+      extraArgs : ExtraArgs
+        -- ^ Additional choice arguments.
+    controller allocation.transferLeg.sender
+    do allocationFactory_allocateImpl this self arg
+
+  nonconsuming choice AllocationFactory_PublicFetch : AllocationFactoryView
+    with
+      expectedAdmin : Party
+        -- ^ The expected admin party issuing the factory. Implementations MUST validate that this matches
+        -- the admin of the factory.
+        -- Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against
+        -- their own participant. That way they can ensure that it is safe to exercise a choice
+        -- on a factory contract acquired from an untrusted source *provided*
+        -- all vetted Daml packages only contain interface implementations
+        -- that check the expected admin party.
+      actor : Party
+    controller actor
+    do allocationFactory_publicFetchImpl this self arg
+
+
+-- Result type
+--------------
+
+-- | The result of instructing an allocation or advancing the state of an allocation instruction.
+data AllocationInstructionResult = AllocationInstructionResult with
+    output : AllocationInstructionResult_Output
+     -- ^ The output of the step.
+    senderChangeCids : [ContractId Holding]
+      -- ^ New holdings owned by the sender created to return "change". Can be used
+      -- by callers to batch creating or updating multiple allocation instructions
+      -- in a single Daml transaction.
+    meta : Metadata
+      -- ^ Additional metadata specific to the allocation instruction, used for extensibility; e.g., fees charged.
+  deriving (Show, Eq)
+
+-- | The output of instructing an allocation or advancing the state of an allocation instruction.
+data AllocationInstructionResult_Output
+  = AllocationInstructionResult_Pending
+      -- ^ Use this result to communicate that the creation of the allocation is pending further steps.
+      with
+        allocationInstructionCid : ContractId AllocationInstruction
+          -- ^ Contract id of the allocation instruction representing the pending state.
+  | AllocationInstructionResult_Completed
+      -- ^ Use this result to communicate that the allocation was created.
+      with
+        allocationCid : ContractId Allocation
+          -- ^ The newly created allocation.
+  | AllocationInstructionResult_Failed
+      -- ^ Use this result to communicate that the creation of the allocation did not succeed and
+      -- all holdings reserved for funding the allocation have been released.
+  deriving (Show, Eq)

--- a/src/main/daml/Splice/Api/Token/AllocationRequestV1.daml
+++ b/src/main/daml/Splice/Api/Token/AllocationRequestV1.daml
@@ -1,0 +1,65 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- | This module defines the interface for an `AllocationRequest`, which is an interface that can
+-- be implemented by an app to request specific allocations from their users
+-- for the purpose of settling a DvP or a payment as part of an app's workflow.
+module Splice.Api.Token.AllocationRequestV1 where
+
+import DA.TextMap (TextMap)
+
+import Splice.Api.Token.MetadataV1
+import Splice.Api.Token.AllocationV1
+
+-- | A request by an app for allocations to be created to enable the execution of a settlement.
+--
+-- Apps are free to use a single request spanning all senders or one request per sender.
+interface AllocationRequest where
+  viewtype AllocationRequestView
+
+  allocationRequest_RejectImpl
+    : ContractId AllocationRequest -> AllocationRequest_Reject -> Update ChoiceExecutionMetadata
+  allocationRequest_WithdrawImpl
+    : ContractId AllocationRequest -> AllocationRequest_Withdraw -> Update ChoiceExecutionMetadata
+
+  choice AllocationRequest_Reject : ChoiceExecutionMetadata
+    -- ^ Reject an allocation request.
+    --
+    -- Implementations SHOULD allow any sender of a transfer leg to reject the allocation request,
+    -- and thereby signal that they are definitely not going to create a matching allocation for the settlement.
+    with
+      actor : Party -- ^ The party rejecting the allocation request.
+      extraArgs : ExtraArgs
+        -- ^ Additional context required in order to exercise the choice.
+    controller actor
+    do allocationRequest_RejectImpl this self arg
+
+  choice AllocationRequest_Withdraw : ChoiceExecutionMetadata
+    -- ^ Withdraw an allocation request as the executor.
+    --
+    -- Used by executors to withdraw the allocation request if they are unable to execute it;
+    -- e.g., because a trade has been cancelled.
+    with
+      extraArgs : ExtraArgs
+        -- ^ Additional context required in order to exercise the choice.
+    controller (view this).settlement.executor
+    do allocationRequest_WithdrawImpl this self arg
+
+
+-- | View of `AllocationRequest`.
+--
+-- Implementations SHOULD make sure that at least all senders of the transfer legs
+-- are observers of the implementing contract, so that their wallet can show
+-- the request to them.
+data AllocationRequestView = AllocationRequestView with
+    settlement : SettlementInfo
+      -- ^ Settlement for which the assets are requested to be allocated.
+    transferLegs : TextMap TransferLeg
+      -- ^ Transfer legs that are requested to be allocated for the execution of the settlement
+      -- keyed by their identifier.
+      --
+      -- This may or may not be a complete list of transfer legs that are part of the settlement,
+      -- depending on the confidentiality requirements of the app.
+    meta : Metadata
+      -- ^ Additional metadata specific to the allocation request, used for extensibility.
+  deriving (Show, Eq)

--- a/src/main/daml/Splice/Api/Token/AllocationV1.daml
+++ b/src/main/daml/Splice/Api/Token/AllocationV1.daml
@@ -1,0 +1,178 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- | This module defines the `Allocation` interface and supporting types.
+--
+-- Contracts implementing the `Allocation` interface represent a reservation of
+-- assets to transfer them as part of an atomic on-ledger settlement requested
+-- by an app.
+module Splice.Api.Token.AllocationV1 where
+
+import Splice.Api.Token.MetadataV1
+import Splice.Api.Token.HoldingV1 (Holding, InstrumentId)
+
+-- | A generic type to refer to data defined within an app.
+
+-- The interpretation of such a reference is app specific, but SHOULD be unambiguous within the context of the app.
+data Reference = Reference with
+    id : Text
+      -- ^ The key that identifies the data. Can be set to the empty string if the contract-id is provided and is sufficient.
+    cid : Optional AnyContractId
+      -- ^ Optional contract-id to use for referring to contracts.
+      --
+      -- This field is there for technical reasons, as contract-ids cannot be converted to text from within Daml,
+      -- which is due to their full textual representation being only known after transactions have been prepared.
+  deriving (Show, Eq)
+
+-- | The minimal set of information about a settlement that an app would like to execute.
+data SettlementInfo = SettlementInfo
+  with
+    executor : Party
+      -- ^ The party that is responsible for executing the settlement.
+    settlementRef : Reference
+      -- ^ Reference to the settlement that app would like to execute.
+    requestedAt : Time
+      -- ^ When the settlement was requested. Provided for display and debugging purposes,
+      -- but SHOULD be in the past.
+    allocateBefore : Time
+      -- ^ Until when (exclusive) the senders are given time to allocate their assets.
+      -- This field has a particular relevance with respect to instrument versioning / corporate
+      -- actions, in that the settlement pertains to the instrument version resulting from the
+      -- processing of all corporate actions falling strictly before the `allocateBefore` time.
+    settleBefore : Time
+      -- ^ Until when (exclusive) the executor is given time to execute the settlement.
+      --
+      -- SHOULD be strictly after `allocateBefore`.
+    meta : Metadata
+      -- ^ Additional metadata about the settlement, used for extensibility.
+  deriving (Show, Eq)
+
+-- | A specification of a transfer of holdings between two parties for the
+-- purpose of a settlement, which often requires the atomic execution of multiple legs.
+data TransferLeg = TransferLeg with
+    sender : Party
+      -- ^ The sender of the transfer.
+    receiver : Party
+      -- ^ The receiver of the transfer.
+    amount : Decimal
+      -- ^ The amount to transfer.
+    instrumentId : InstrumentId
+      -- ^ The instrument identifier.
+    meta : Metadata
+      -- ^ Additional metadata about the transfer leg, used for extensibility.
+  deriving (Eq, Ord, Show)
+
+-- | The specification of an allocation of assets to a specific leg of a settlement.
+--
+-- In contrast to an `AllocationView` this just specifies what should be allocated,
+-- but not the holdings that are backing the allocation.
+data AllocationSpecification = AllocationSpecification with
+    settlement : SettlementInfo
+      -- ^ The settlement for whose execution the assets are being allocated.
+    transferLegId : Text
+      -- ^ A unique identifer for the transfer leg within the settlement.
+    transferLeg : TransferLeg
+      -- ^ The transfer for which the assets are being allocated.
+  deriving (Show, Eq)
+
+-- | View of a funded allocation of assets to a specific leg of a settlement.
+data AllocationView = AllocationView with
+    allocation : AllocationSpecification
+      -- ^ The settlement for whose execution the assets are being allocated.
+    holdingCids : [ContractId Holding]
+      -- ^ The holdings that are backing this allocation.
+      --
+      -- Provided so that that wallets can correlate the allocation with the
+      -- holdings.
+      --
+      -- MAY be empty for registries that do not represent their holdings on-ledger.
+    meta : Metadata
+      -- ^ Additional metadata specific to the allocation, used for extensibility.
+  deriving (Show, Eq)
+
+
+-- Allocation
+------------------------
+
+-- | Convenience function to refer to the union of sender, receiver, and
+-- executor of the settlement, which jointly control the execution of the
+-- allocation.
+allocationControllers : AllocationView -> [Party]
+allocationControllers AllocationView{..} =
+  [allocation.settlement.executor, allocation.transferLeg.sender, allocation.transferLeg.receiver]
+
+-- | A contract representing an allocation of some amount of aasset holdings to
+-- a specific leg of a settlement.
+interface Allocation where
+  viewtype AllocationView
+
+  allocation_executeTransferImpl : ContractId Allocation -> Allocation_ExecuteTransfer -> Update Allocation_ExecuteTransferResult
+  allocation_cancelImpl : ContractId Allocation -> Allocation_Cancel -> Update Allocation_CancelResult
+  allocation_withdrawImpl : ContractId Allocation -> Allocation_Withdraw -> Update Allocation_WithdrawResult
+
+  choice Allocation_ExecuteTransfer : Allocation_ExecuteTransferResult
+    -- ^ Execute the transfer of the allocated assets. Intended to be used to execute the settlement.
+    -- This choice SHOULD succeed provided the `settlement.settleBefore` deadline has not yet passed.
+    with
+      extraArgs : ExtraArgs
+        -- ^ Additional context required in order to exercise the choice.
+    controller allocationControllers (view this)
+    do allocation_executeTransferImpl this self arg
+
+  choice Allocation_Cancel : Allocation_CancelResult
+    -- ^ Cancel the allocation. Requires authorization from sender, receiver, and
+    -- executor.
+    --
+    -- Typically this authorization is granted by sender and receiver to the
+    -- executor as part of the contract coordinating the settlement, so that
+    -- that the executor can release the allocated assets early in case the
+    -- settlement is aborted or it has definitely failed.
+    with
+      extraArgs : ExtraArgs
+        -- ^ Additional context required in order to exercise the choice.
+    controller allocationControllers (view this)
+    do allocation_cancelImpl this self arg
+
+  choice Allocation_Withdraw : Allocation_WithdrawResult
+    -- ^ Withdraw the allocated assets. Used by the sender to withdraw the assets before settlement
+    -- was completed. This SHOULD not fail settlement if the sender has still time to allocate the
+    -- assets again; i.e., the `settlement.allocateBefore` deadline has not yet passed.
+    with
+      extraArgs : ExtraArgs
+        -- ^ Additional context required in order to exercise the choice.
+    controller (view this).allocation.transferLeg.sender
+    do allocation_withdrawImpl this self arg
+
+
+-- Result types
+---------------
+
+-- | The result of the `Allocation_ExecuteTransfer` choice.
+data Allocation_ExecuteTransferResult = Allocation_ExecuteTransferResult
+  with
+    senderHoldingCids : [ContractId Holding]
+      -- ^ The holdings that were created for the sender. Can be used to return
+      -- "change" to the sender if required.
+    receiverHoldingCids : [ContractId Holding]
+      -- ^ The holdings that were created for the receiver.
+    meta : Metadata
+      -- ^ Additional metadata specific to the transfer instruction, used for extensibility.
+  deriving (Show, Eq)
+
+-- | The result of the `Allocation_Cancel` choice.
+data Allocation_CancelResult = Allocation_CancelResult
+  with
+    senderHoldingCids : [ContractId Holding]
+      -- ^ The holdings that were released back to the sender.
+    meta : Metadata
+      -- ^ Additional metadata specific to the allocation, used for extensibility.
+  deriving (Show, Eq)
+
+-- | The result of the `Allocation_Withdraw` choice.
+data Allocation_WithdrawResult = Allocation_WithdrawResult
+  with
+    senderHoldingCids : [ContractId Holding]
+      -- ^ The holdings that were released back to the sender.
+    meta : Metadata
+      -- ^ Additional metadata specific to the allocation, used for extensibility.
+  deriving (Show, Eq)

--- a/src/main/daml/Splice/Api/Token/BurnMintV1.daml
+++ b/src/main/daml/Splice/Api/Token/BurnMintV1.daml
@@ -1,0 +1,101 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- | An interface for registries to expose burn/mint operations in a generic way
+-- for bridges to use them, and for wallets to parse their use.
+module Splice.Api.Token.BurnMintV1 where
+
+import Splice.Api.Token.MetadataV1
+import Splice.Api.Token.HoldingV1
+
+-- | A factory for generic burn/mint operations.
+interface BurnMintFactory where
+  viewtype BurnMintFactoryView
+
+  burnMintFactory_burnMintImpl : ContractId BurnMintFactory -> BurnMintFactory_BurnMint -> Update BurnMintFactory_BurnMintResult
+  burnMintFactory_publicFetchImpl : ContractId BurnMintFactory -> BurnMintFactory_PublicFetch -> Update BurnMintFactoryView
+
+  nonconsuming choice BurnMintFactory_BurnMint : BurnMintFactory_BurnMintResult
+    -- ^ Burn the holdings in `inputHoldingCids` and create holdings with the
+    -- owners and amounts specified in outputs.
+    --
+    -- Note that this is jointly authorized by the admin and the `extraActors`.
+    -- The `admin` thus controls all calls to this choice, and some implementations might
+    -- required `extraActors` to be present, e.g., the owners of the minted and burnt holdings.
+    --
+    -- Implementations are free to restrict the implementation of this choice
+    -- including failing on all inputs or not implementing this interface at all.
+    with
+      expectedAdmin : Party
+       -- ^ The expected `admin` party issuing the factory. Implementations MUST validate that this matches
+        -- the admin of the factory.
+        -- Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against
+        -- their own participant. That way they can ensure that it is safe to exercise a choice
+        -- on a factory contract acquired from an untrusted source *provided*
+        -- all vetted Daml packages only contain interface implementations
+        -- that check the expected admin party.
+      instrumentId : InstrumentId
+        -- ^ The instrument id of the holdings.
+        -- All holdings in `inputHoldingCids` as well as the resulting output holdings MUST
+        -- have this instrument id.
+      inputHoldingCids : [ContractId Holding]
+        -- ^ The holdings that should be burnt.
+        -- All holdings in `inputHoldingCids` MUST be archived by this choice.
+        -- Implementations MAY enforce additional restrictions such as all `inputHoldingCids`
+        -- belonging to the same owner.
+      outputs : [BurnMintOutput]
+        -- ^ The holdings that should be created. The choice MUST create new holdings with the given amounts.
+      extraActors : [Party]
+        -- ^ Extra actors, the full actors required are the admin + extraActors. This is often the owners of inputHoldingCids and outputs
+        -- but we allow different sets of actors to support token implementations with different authorization setups.
+      extraArgs : ExtraArgs
+        -- ^ Additional context. Implementations SHOULD include a `splice.lfdecentralizedtrust.org/reason`
+        -- key in the metadata to provide a human readable description for explain why the
+        -- `BurnMintFactory_BurnMint` choice was called, so that generic wallets can display it to the user.
+    controller (view this).admin :: extraActors
+    do burnMintFactory_burnMintImpl this self arg
+
+  nonconsuming choice BurnMintFactory_PublicFetch : BurnMintFactoryView
+    with
+      expectedAdmin : Party
+        -- ^ The expected admin party issuing the factory. Implementations MUST validate that this matches
+        -- the admin of the factory.
+        -- Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against
+        -- their own participant. That way they can ensure that it is safe to exercise a choice
+        -- on a factory contract acquired from an untrusted source *provided*
+        -- all vetted Daml packages only contain interface implementations
+        -- that check the expected admin party.
+      actor : Party
+        -- ^ The party fetching the data.
+    controller actor
+    do burnMintFactory_publicFetchImpl this self arg
+
+-- | The specification of a holding to create as part of the burn/mint operation.
+data BurnMintOutput = BurnMintOutput
+  with
+    owner : Party
+      -- ^ The owner of the holding to create.
+    amount : Decimal
+      -- ^ The amount of the holding to create.
+    context : ChoiceContext
+      -- ^ Context specific to this output which can be used to support locking
+      -- or other registry-specific features.
+  deriving (Show, Eq)
+
+-- | The result of calling the `BurnMintFactory_BurnMint` choice.
+data BurnMintFactory_BurnMintResult = BurnMintFactory_BurnMintResult
+  with
+    outputCids : [ContractId Holding]
+      -- ^ The holdings created by the choice.
+      -- Must contain exactly the outputs specified in the choice argument in the same order.
+  deriving (Show, Eq)
+
+-- | The view of a `BurnMintFactory`.
+data BurnMintFactoryView = BurnMintFactoryView
+   with
+     admin : Party
+       -- ^ The party representing the registry app that administers the instruments
+       -- for which this burnt-mint factory can be used.
+     meta : Metadata
+       -- ^ Additional metadata specific to the burn-mint factory, used for extensibility.
+   deriving (Show, Eq)

--- a/src/main/daml/Splice/Api/Token/HoldingV1.daml
+++ b/src/main/daml/Splice/Api/Token/HoldingV1.daml
@@ -1,0 +1,64 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- | Types and interfaces for retrieving an investor's holdings.
+module Splice.Api.Token.HoldingV1 where
+
+import DA.Time (RelTime)
+
+import Splice.Api.Token.MetadataV1
+
+-- | A globally unique identifier for instruments.
+data InstrumentId = InstrumentId
+  with
+    admin : Party
+      -- ^ The party representing the registry app that administers the instrument.
+    id : Text
+      -- ^ The identifier used for the instrument by the instrument admin.
+      --
+      -- This identifier MUST be unique and unambiguous per instrument admin.
+  deriving (Eq, Ord, Show)
+
+-- | Details of a lock.
+data Lock = Lock
+  with
+    holders : [Party]
+      -- ^ Unique list of parties which are locking the contract.
+      -- (Represented as a list, as that has the better JSON encoding.)
+    expiresAt : Optional Time
+      -- ^ Absolute, inclusive deadline as of which the lock expires.
+    expiresAfter : Optional RelTime
+      -- ^ Duration after which the created lock expires. Measured relative
+      -- to the ledger time that the locked holding contract was created.
+      --
+      -- If both `expiresAt` and `expiresAfter` are set, the lock expires at
+      -- the earlier of the two times.
+    context : Optional Text
+      -- ^ Short, human-readable description of the context of the lock.
+      -- Used by wallets to enable users to understand the reason for the lock.
+      --
+      -- Note that the visibility of the content in this field might be wider
+      -- than the visibility of the contracts in the context. You should thus
+      -- carefully decide what information is safe to put in the lock context.
+  deriving (Eq, Ord, Show)
+
+-- | Holding interface.
+interface Holding where viewtype HoldingView
+
+-- | View for `Holding`.
+data HoldingView = HoldingView
+  with
+    owner : Party
+      -- ^ Owner of the holding.
+    instrumentId : InstrumentId
+      -- ^ Instrument being held.
+    amount : Decimal
+      -- ^ Size of the holding.
+    lock : Optional Lock
+      -- ^ Lock on the holding.
+      --
+      -- Registries SHOULD allow holdings with expired locks as inputs to
+      -- transfers to enable a combined unlocking + use choice.
+    meta : Metadata
+      -- ^ Metadata.
+  deriving (Eq, Show)

--- a/src/main/daml/Splice/Api/Token/MetadataV1.daml
+++ b/src/main/daml/Splice/Api/Token/MetadataV1.daml
@@ -1,0 +1,90 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- | Types and interfaces for retrieving metadata about tokens.
+module Splice.Api.Token.MetadataV1 where
+
+import DA.TextMap as TextMap
+import DA.Time (RelTime)
+
+-- | A generic representation of serializable Daml values.
+--
+-- Used to pass arbitrary data across interface boundaries. For example to pass
+-- data from an an app backend to an interface choice implementation.
+data AnyValue =
+    AV_Text Text
+  | AV_Int Int
+  | AV_Decimal Decimal
+  | AV_Bool Bool
+  | AV_Date Date
+  | AV_Time Time
+  | AV_RelTime RelTime
+  | AV_Party Party
+  | AV_ContractId AnyContractId
+  | AV_List [AnyValue]
+  | AV_Map (TextMap.TextMap AnyValue)
+  deriving (Show, Eq)
+
+-- | Interface used to represent arbitrary contracts.
+-- Note that this is not expected to be implemented by any template,
+-- so it should only be used in the form `ContractId AnyContract` and through `coerceContractId`
+-- but not through any of the interface functions like `fetchFromInterface` that check whether the template actually implements the interface.
+interface AnyContract where viewtype AnyContractView
+
+-- | Not used. See the `AnyContract` interface for more information.
+data AnyContractView = AnyContractView {}
+
+-- | A reference to some contract id. Use `coerceContractId` to convert from and to this type.
+type AnyContractId = ContractId AnyContract
+
+-- | A type for passing extra data from an app's backends to the choices of that app
+-- exercised in commands submitted by app users.
+data ChoiceContext = ChoiceContext with
+    values : TextMap AnyValue
+      -- ^ The values passed in by the app backend to the choice.
+      -- The keys are considered internal to the app and should not be read by
+      -- third-party code.
+  deriving (Show, Eq)
+
+-- | Empty choice context.
+emptyChoiceContext : ChoiceContext
+emptyChoiceContext = ChoiceContext TextMap.empty
+
+-- | Machine-readable metadata intended for communicating additional information
+-- using well-known keys between systems. This is mainly used to allow for the post-hoc
+-- expansion of the information associated with contracts and choice arguments and results.
+--
+-- Modeled after by k8s support for annotations: <https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/>.
+--
+-- Implementors SHOULD follow the same conventions for allocating keys as used by k8s; i.e.,
+-- they SHOULD be prefixed using the DNS name of the app defining the key.
+--
+-- Implementors SHOULD keep metadata small, as on-ledger data is costly.
+data Metadata = Metadata with
+    values : TextMap Text
+      -- ^ Key-value pairs of metadata entries.
+  deriving (Eq,Ord, Show)
+
+-- | Empty metadata.
+emptyMetadata : Metadata
+emptyMetadata = Metadata with values = mempty
+
+-- | A common type for passing both the choice context and the metadata to a choice.
+data ExtraArgs = ExtraArgs with
+    context : ChoiceContext
+      -- ^ Extra arguments to be passed to the implementation of an interface choice.
+      -- These are provided via an off-ledger API by the app implementing the interface.
+    meta : Metadata
+      -- ^ Additional metadata to pass in.
+      --
+      -- In contrast to the `extraArgs`, these are provided by the caller of the choice.
+      -- The expectation is that the meaning of metadata fields will be agreed on
+      -- in later standards, or on a case-by-case basis between the caller and the
+      -- implementer of the interface.
+  deriving (Show, Eq)
+
+-- | A generic result for choices that do not need to return specific data.
+data ChoiceExecutionMetadata = ChoiceExecutionMetadata with
+    meta : Metadata
+      -- ^ Additional metadata specific to the result of exercising the choice, used for extensibility.
+  deriving (Show, Eq)

--- a/src/main/daml/Splice/Api/Token/TransferInstructionV1.daml
+++ b/src/main/daml/Splice/Api/Token/TransferInstructionV1.daml
@@ -1,0 +1,224 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- | Instruct transfers of holdings between parties.
+module Splice.Api.Token.TransferInstructionV1 where
+
+import qualified DA.Map as Map
+
+import Splice.Api.Token.MetadataV1
+import Splice.Api.Token.HoldingV1
+
+-- | A specification of a transfer of holdings between two parties.
+data Transfer = Transfer with
+    sender : Party
+      -- ^ The sender of the transfer.
+    receiver : Party
+      -- ^ The receiver of the transfer.
+    amount : Decimal
+      -- ^ The amount to transfer.
+    instrumentId : InstrumentId
+      -- ^ The instrument identifier.
+    requestedAt : Time
+      -- ^ Wallet provided timestamp when the transfer was requested.
+      -- MUST be in the past when instructing the transfer.
+    executeBefore : Time
+      -- ^ Until when (exclusive) the transfer may be executed. MUST be in the
+      -- future when instructing the transfer.
+      --
+      -- Registries SHOULD NOT execute the transfer instruction after this time,
+      -- so that senders can retry creating a new transfer instruction after this time.
+    inputHoldingCids : [ContractId Holding]
+      -- ^ The holding contracts that should be used to fund the transfer.
+      --
+      -- MAY be empty if the registry supports automatic selection of holdings for transfers
+      -- or does not represent holdings on-ledger.
+      --
+      -- If specified, then the transfer MUST archive all of these holdings, so
+      -- that the execution of the transfer conflicts with any other transfers
+      -- using these holdings. Thereby allowing that the sender can use
+      -- deliberate contention on holdings to prevent duplicate transfers.
+    meta : Metadata
+      -- ^ Metadata.
+  deriving (Show, Eq)
+
+-- | The result of instructing a transfer or advancing the state of a transfer instruction.
+data TransferInstructionResult = TransferInstructionResult with
+    output : TransferInstructionResult_Output
+     -- ^ The output of the step.
+    senderChangeCids : [ContractId Holding]
+      -- ^ New holdings owned by the sender created to return "change". Can be used
+      -- by callers to batch creating or updating multiple transfer instructions
+      -- in a single Daml transaction.
+    meta : Metadata
+      -- ^ Additional metadata specific to the transfer instruction, used for extensibility; e.g., fees charged.
+  deriving (Show, Eq)
+
+-- | The output of instructing a transfer or advancing the state of a transfer instruction.
+data TransferInstructionResult_Output
+  = TransferInstructionResult_Pending
+      -- ^ Use this result to communicate that the transfer is pending further steps.
+      with
+        transferInstructionCid : ContractId TransferInstruction
+          -- ^ Contract id of the transfer instruction representing the pending state.
+  | TransferInstructionResult_Completed
+      -- ^ Use this result to communicate that the transfer succeeded and the receiver
+      -- has received their holdings.
+      with
+        receiverHoldingCids : [ContractId Holding]
+          -- ^ The newly created holdings owned by the receiver as part of successfully
+          -- completing the transfer.
+  | TransferInstructionResult_Failed
+      -- ^ Use this result to communicate that the transfer did not succeed and all holdings (minus fees)
+      -- have been returned to the sender.
+  deriving (Show, Eq)
+
+
+-- TransferInstruction
+------------------------
+
+-- | Status of a transfer instruction.
+data TransferInstructionStatus
+  = TransferPendingReceiverAcceptance
+      -- ^ The transfer is pending acceptance by the receiver.
+  | TransferPendingInternalWorkflow
+      -- ^ The transfer is pending actions to be taken as part of registry internal workflows.
+      with
+        pendingActions : Map.Map Party Text
+          -- ^ The actions that a party could take to advance the transfer.
+          --
+          -- This field can by used to inform wallet users whether they need to take an action or not.
+  deriving (Show, Eq)
+
+-- | View for `TransferInstruction`.
+data TransferInstructionView = TransferInstructionView with
+    originalInstructionCid : Optional (ContractId TransferInstruction)
+      -- ^ The contract id of the original transfer instruction contract.
+      -- Used by the wallet to track the lineage of transfer instructions through multiple steps.
+      --
+      -- Only set if the registry evolves the transfer instruction in multiple steps.
+    transfer : Transfer
+      -- ^ The transfer specified by the transfer instruction.
+    status : TransferInstructionStatus
+      -- ^ The status of the transfer instruction.
+    meta : Metadata
+      -- ^ Additional metadata specific to the transfer instruction, used for extensibility; e.g., more detailed status information.
+  deriving (Show, Eq)
+
+-- | An interface for tracking the status of a transfer instruction,
+-- i.e., a request to a registry app to execute a transfer.
+--
+-- Registries MAY evolve the transfer instruction in multiple steps. They SHOULD
+-- do so using only the choices on this interface, so that wallets can reliably
+-- parse the transaction history and determine whether the instruction ultimately
+-- succeeded or failed.
+interface TransferInstruction where
+  viewtype TransferInstructionView
+
+  transferInstruction_acceptImpl : ContractId TransferInstruction -> TransferInstruction_Accept -> Update TransferInstructionResult
+  transferInstruction_rejectImpl : ContractId TransferInstruction -> TransferInstruction_Reject -> Update TransferInstructionResult
+  transferInstruction_withdrawImpl : ContractId TransferInstruction -> TransferInstruction_Withdraw -> Update TransferInstructionResult
+  transferInstruction_updateImpl : ContractId TransferInstruction -> TransferInstruction_Update -> Update TransferInstructionResult
+
+  choice TransferInstruction_Accept : TransferInstructionResult
+    -- ^ Accept the transfer as the receiver.
+    --
+    -- This choice is only available if the instruction is in
+    -- `TransferPendingReceiverAcceptance` state.
+    --
+    -- Note that while implementations will typically return `TransferInstructionResult_Completed`,
+    -- this is not guaranteed. The result of the choice is implementation-specific and MAY
+    -- be any of the three possible results.
+    with
+      extraArgs : ExtraArgs
+        -- ^ Additional context required in order to exercise the choice.
+    controller (view this).transfer.receiver
+    do transferInstruction_acceptImpl this self arg
+
+  choice TransferInstruction_Reject : TransferInstructionResult
+    -- ^ Reject the transfer as the receiver.
+    --
+    -- This choice is only available if the instruction is in
+    -- `TransferPendingReceiverAcceptance` state.
+    with
+      extraArgs : ExtraArgs
+        -- ^ Additional context required in order to exercise the choice.
+    controller (view this).transfer.receiver
+    do transferInstruction_rejectImpl this self arg
+
+  choice TransferInstruction_Withdraw : TransferInstructionResult
+    -- ^ Withdraw the transfer instruction as the sender.
+    with
+      extraArgs : ExtraArgs
+        -- ^ Additional context required in order to exercise the choice.
+    controller (view this).transfer.sender
+    do transferInstruction_withdrawImpl this self arg
+
+  choice TransferInstruction_Update : TransferInstructionResult
+    -- ^ Update the state of the transfer instruction. Used by the registry to
+    -- execute registry internal workflow steps that advance the state of the
+    -- transfer instruction. A reason may be communicated via the metadata.
+    with
+      extraActors : [Party]
+        -- ^ Extra actors authorizing the update. Implementations MUST check that
+        -- this field contains the expected actors for the specific update.
+      extraArgs : ExtraArgs
+        -- ^ Additional context required in order to exercise the choice.
+    controller (view this).transfer.instrumentId.admin, extraActors
+    do transferInstruction_updateImpl this self arg
+
+
+-- Transfer Factory
+-------------------
+
+-- | A factory contract to instruct transfers of holdings between parties.
+interface TransferFactory where
+  viewtype TransferFactoryView
+
+  transferFactory_transferImpl : ContractId TransferFactory -> TransferFactory_Transfer -> Update TransferInstructionResult
+  transferFactory_publicFetchImpl : ContractId TransferFactory -> TransferFactory_PublicFetch -> Update TransferFactoryView
+
+  nonconsuming choice TransferFactory_Transfer : TransferInstructionResult
+    -- ^ Instruct the registry to execute a transfer.
+    -- Implementations MUST ensure that this choice fails if `transfer.executeBefore` is in the past.
+    with
+      expectedAdmin : Party
+        -- ^ The expected admin party issuing the factory. Implementations MUST validate that this matches
+        -- the admin of the factory.
+        -- Callers SHOULD ensure they get `expectedAdmin` from a trusted source, e.g., a read against
+        -- their own participant. That way they can ensure that it is safe to exercise a choice
+        -- on a factory contract acquired from an untrusted source *provided*
+        -- all vetted Daml packages only contain interface implementations
+        -- that check the expected admin party.
+      transfer : Transfer
+        -- ^ The transfer to execute.
+      extraArgs : ExtraArgs
+        -- ^ The extra arguments to pass to the transfer implementation.
+    controller transfer.sender
+    do transferFactory_transferImpl this self arg
+
+  nonconsuming choice TransferFactory_PublicFetch : TransferFactoryView
+    -- ^ Fetch the view of the factory contract.
+    with
+      expectedAdmin : Party
+        -- ^ The expected admin party issuing the factory. Implementations MUST validate that this matches
+        -- the admin of the factory.
+        -- Callers SHOULD ensure they get `expectedAdmin` from a trusted source, e.g., a read against
+        -- their own participant. That way they can ensure that it is safe to exercise a choice
+        -- on a factory contract acquired from an untrusted source *provided*
+        -- all vetted Daml packages only contain interface implementations
+        -- that check the expected admin party.
+      actor : Party
+        -- ^ The party fetching the contract.
+    controller actor
+    do transferFactory_publicFetchImpl this self arg
+
+-- | View for `TransferFactory`.
+data TransferFactoryView = TransferFactoryView
+  with
+    admin : Party
+      -- ^ The party representing the registry app that administers the instruments for
+      -- which this transfer factory can be used.
+    meta : Metadata
+      -- ^ Additional metadata specific to the transfer factory, used for extensibility.
+  deriving (Show, Eq)

--- a/src/test/daml/Daml/Finance/Settlement/Test/StandardsBasedBatchWithIntermediaries.daml
+++ b/src/test/daml/Daml/Finance/Settlement/Test/StandardsBasedBatchWithIntermediaries.daml
@@ -1,0 +1,355 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Daml.Finance.Settlement.Test.StandardsBasedBatchWithIntermediaries where
+
+import DA.Date (addDays, toDateUTC)
+import DA.Map qualified as Map (fromList)
+import DA.Set qualified as Set (fromList, singleton, empty)
+import DA.Time (hours, addRelTime, time)
+import DA.TextMap qualified as TextMap
+import Daml.Finance.Holding.V4.Factory qualified as Holding (Factory(..))
+import Daml.Finance.Instrument.Util (instrumentKeyToInstrumentId)
+import Daml.Finance.Interface.Holding.V4.Holding qualified as Holding (I)
+import Daml.Finance.Interface.Settlement.V4.Batch qualified as Batch (Settle(..))
+import Daml.Finance.Interface.Settlement.V4.Factory qualified as SettlementFactory (I, Instruct(..))
+import Daml.Finance.Interface.Settlement.V4.Instruction qualified as Instruction (Allocate(..), Approve(..))
+import Daml.Finance.Interface.Settlement.V4.RouteProvider qualified as RouteProvider (Discover(..), I)
+import Daml.Finance.Interface.Settlement.V4.Types (Allocation(..), Approval(..), Step(..))
+import Daml.Finance.Interface.Types.Common.V3.Types (HoldingStandard(..), Id(..))
+import Daml.Finance.Interface.Util.V3.Common (qty)
+import Daml.Finance.Settlement.V4.Factory qualified as Settlement (Factory(..))
+import Daml.Finance.Settlement.V4.Hierarchy (Hierarchy(..))
+import Daml.Finance.Settlement.V4.Batch (BatchAllocation(..))
+import Daml.Finance.Settlement.V4.RouteProvider.IntermediatedStatic (IntermediatedStatic(..))
+import Daml.Finance.Test.Util.Account qualified as Account (ControlledBy(..), createAccount, createFactory, credit)
+import Daml.Finance.Test.Util.Common (createParties)
+import Daml.Finance.Test.Util.Holding qualified as Holding (verifyNoObservers, verifyOwnerOfHolding)
+import Daml.Finance.Test.Util.HoldingDuplicates.Factory qualified as HoldingV2 (Factory(..))
+import Daml.Finance.Test.Util.HoldingFactory (createHoldingFactory)
+import Daml.Finance.Test.Util.Instrument qualified as Instrument (originate)
+import Daml.Script
+
+import Splice.Api.Token.AllocationV1 qualified as AllocationV1
+import Splice.Api.Token.AllocationRequestV1
+import Splice.Api.Token.HoldingV1 qualified as HoldingV1 (Holding(..))
+import Splice.Api.Token.MetadataV1 (emptyMetadata, emptyChoiceContext, ExtraArgs(..))
+import Splice.Testing.Apps.TradingApp
+import Splice.Testing.TokenStandard.WalletClient qualified as WalletClient
+import DA.Assert ((===))
+import DA.Optional (fromSome)
+
+-- | Parties involved in the test script.
+data TestParties = TestParties
+  with
+    buyer : Party
+      -- ^ Receives the equity instrument in exchange for cash.
+    seller : Party
+      -- ^ Seller of the equity instrument. Receives cash in exchange for units of equity.
+    bank : Party
+      -- ^ Custodian of the issuer's cash holdings.
+    cb : Party
+      -- ^ Depository and issuer of the cash instrument. Custodian of the cash holdings of Bank 1
+      --   and Bank 2.
+    csd : Party
+      -- ^ Depository of the equity instrument. Custodian of the equity holdings of Bank 1 and
+      --   Issuer.
+    issuer : Party
+      -- ^ Issuer of the equity instrument. Receives cash in exchange for units of equity.
+    publicParty : Party
+      -- ^ The public party. Every party can readAs the public party.
+
+-- DvP via a mock OTC trading app integrated via Canton Netwok Tooken Standards.
+-- The Buyer transfers cash to Seller in exchange for an equity instrument (detained by issuer at
+-- depository).
+-- Seller transfers equity to Buyer in exchange for cash.
+-- +------------------------------------------------------+
+-- | Accounts                                             |
+-- +-----------------------------+------------------------+
+-- | structure:                  | used for:              |
+-- +-----------------------------+------------------------+
+-- |       Central Bank          |                        |
+-- |         /      \            | central bank money     |
+-- |      Buyer     Bank         |                        |
+-- |                /            | commercial bank money  |
+-- |      Buyer   Seller         |                        |
+-- |          \   /              | securities             |
+-- | Central Security Depository |                        |
+-- +-----------------------------+------------------------+
+run : Script ()
+run = script do
+  ----
+  ---- Use registry app code to issue some assets.
+  ---- No use of standards here.
+  ----
+
+  -- Create parties
+  TestParties{..} <- setupParties
+  let pp = [("PublicParty", Set.singleton publicParty)]
+
+  -- Setup security accounts at CB (utilising non-fungible holdings)
+  -- Create account factory
+  csdAccountFactoryCid <- toInterfaceContractId <$> Account.createFactory csd []
+  -- Create holding factory
+  csdHoldingFactory <- createHoldingFactory
+    Holding.Factory with
+      provider = csd; id = Id "Holding Factory @ CSD"; observers = Map.fromList pp
+  -- Create accounts
+  [buyerSecurityAccount, sellerSecurityAccount] <- mapA (Account.createAccount "Security Account" []
+    csdAccountFactoryCid csdHoldingFactory [] Account.Owner csd) [buyer, seller]
+
+  -- Setup cash accounts at CB (utilising fungible holdings)
+  -- Create account factory
+  cbAccountFactoryCid <- toInterfaceContractId <$> Account.createFactory cb []
+  -- Create holding factory
+  cbHoldingFactory <- createHoldingFactory
+    Holding.Factory with
+      provider = cb; id = Id "Holding Factory @ CB"; observers = Map.fromList pp
+  -- Create accounts
+  [buyerCashAccount, bankCashAccount] <- mapA (Account.createAccount "Cash Account" []
+    cbAccountFactoryCid cbHoldingFactory [] Account.Owner cb) [buyer, bank]
+
+  -- Setup cash accounts at Bank
+  -- Create account factory
+  bankAccountFactoryCid <- toInterfaceContractId <$> Account.createFactory bank []
+  -- Create holding factory
+  bankHoldingFactory <-
+    createHoldingFactory
+      HoldingV2.Factory with
+        provider = bank; id = Id "HoldingV2 Factory @ Bank"; observers = Map.fromList pp
+  -- Create accounts
+  [sellerCashAccount] <- mapA (Account.createAccount "Cash Account" [] bankAccountFactoryCid
+    bankHoldingFactory [] Account.Owner bank) [seller]
+
+  -- Distribute assets
+  now <- getTime
+  equityInstrument <-
+    Instrument.originate csd issuer "AAPL" TransferableFungible "Apple Inc." [] now
+  equityHoldingCid <- Account.credit [] equityInstrument 1_000.0 sellerSecurityAccount
+  cashInstrument <- Instrument.originate cb cb "USD" TransferableFungible "United States Dollar"
+    [] now
+  buyerCashHoldingCid <- Account.credit [] cashInstrument 200_000.0 buyerCashAccount
+
+  ----
+  ---- OVER TO TRADING APP
+  ---- Buyer and Seller agree a trade.
+  ----
+
+  trading_provider <- allocateParty "trading_provider"
+
+  let cashId = instrumentKeyToInstrumentId cashInstrument
+  let cashLeg = AllocationV1.TransferLeg with
+        sender = buyer
+        receiver = seller
+        amount = 200_000.0
+        instrumentId = cashId
+        meta = emptyMetadata
+  let equityId = instrumentKeyToInstrumentId equityInstrument
+  let equityLeg = AllocationV1.TransferLeg with
+        sender = seller
+        receiver = buyer
+        amount = 1_000.0
+        instrumentId = equityId
+        meta = emptyMetadata
+
+   -- buyer proposes trade with seller
+  proposalCid <- submit buyer $ createCmd OTCTradeProposal with
+    venue = trading_provider
+    tradeCid = None
+    transferLegs = TextMap.fromList [("cash", cashLeg), ("equity", equityLeg)]
+    approvers = [buyer]
+
+  -- seller accepts
+  proposalCid <- submit seller $ exerciseCmd proposalCid OTCTradeProposal_Accept with
+    approver = seller
+
+  -- provider initiates settlement
+  now <- getTime
+  let settleBefore = now `addRelTime` hours 2
+  otcTradeCid <- submit trading_provider $
+    exerciseCmd proposalCid OTCTradeProposal_InitiateSettlement with
+      prepareUntil = now `addRelTime` hours 1
+      settleBefore
+
+  Some otcTrade <- queryContractId trading_provider otcTradeCid
+
+  -- Seller sees the allocation request in her wallet
+  [sellerAlloc] <- WalletClient.listRequestedAllocations seller equityId
+  sellerAlloc.transferLeg.amount === 1_000.0
+
+  -- Buyer sees the allocation request in her wallet
+  [buyerAlloc] <- WalletClient.listRequestedAllocations buyer cashId
+  buyerAlloc.transferLeg.amount === 200_000.0
+
+  ---- BACK TO REGISTRY APPS
+  ---- Buyer and seller independently create allocations.
+
+  -- Buyer
+  -- Buyer creates the allocation self-service, as in the original example.
+
+  -- Settlement steps
+  let
+    steps =
+      [ Step with sender = buyer; receiver = seller; quantity = qty 200_000.0 cashInstrument
+      ]
+    settlementTime = settleBefore
+
+  -- Discover settlement routes (by first creating a route provider with intermediaries from Buyer
+  -- to Seller)
+  let
+    paths = Map.fromList
+      [ ("USD", Hierarchy with rootCustodian = cb; pathsToRootCustodian = [[buyer], [seller, bank]])
+      ]
+  routeProviderCid <- toInterfaceContractId @RouteProvider.I <$> submit buyer do
+    createCmd IntermediatedStatic with provider = buyer; paths; observers = mempty
+  routedSteps <- submit buyer do
+    exerciseCmd routeProviderCid RouteProvider.Discover with
+      discoverors = Set.singleton buyer; contextId = None; steps
+
+  -- Instruct settlement
+  settlementFactoryCid <- toInterfaceContractId @SettlementFactory.I <$> submit buyer do
+    createCmd Settlement.Factory with provider = buyer; observers = mempty
+  (cashBatchCid, [cashInstruction1Cid, cashInstruction2Cid]) <-
+    submitMulti [buyer] [] do
+      exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
+        instructor = buyer
+        consenters = Set.empty
+        settlers = Set.fromList [buyer, trading_provider]
+        id = Id "APPL 1000@200.0USD"; description = "Cash Leg"; contextId = None; routedSteps
+        settlementTime = Some settlementTime
+
+  -- Allocate instructions
+  (cashInstruction1Cid, _) <- submit buyer do
+    exerciseCmd cashInstruction1Cid
+      Instruction.Allocate with
+        actors = Set.singleton buyer; allocation = Pledge buyerCashHoldingCid
+  (cashInstruction2Cid, _) <-  submit bank do
+    exerciseCmd cashInstruction2Cid
+      Instruction.Allocate with actors = Set.singleton bank; allocation = CreditReceiver
+
+  -- Approve instructions
+  cashInstruction1Cid <- submit bank do
+    exerciseCmd cashInstruction1Cid
+      Instruction.Approve with actors = Set.singleton bank; approval = TakeDelivery bankCashAccount
+  cashInstruction2Cid <- submit seller do
+    exerciseCmd cashInstruction2Cid
+      Instruction.Approve with
+        actors = Set.singleton seller; approval = TakeDelivery sellerCashAccount
+
+  -- Create a BatchAllocation
+  cashAllocation <- submit buyer do
+    createCmd BatchAllocation with
+      batchCid = cashBatchCid
+      allocation = buyerAlloc
+      holdingCids = [coerceInterfaceContractId @HoldingV1.Holding buyerCashHoldingCid]
+      meta = emptyMetadata
+
+  -- Seller
+  -- Unlike in the original example, the seller independently creates their allocation.
+
+  -- Settlement steps
+  let
+    steps =
+      [ Step with sender = seller; receiver = buyer; quantity = qty 1_000.0 equityInstrument
+      ]
+    settlementTime = settleBefore
+
+  -- Discover settlement routes (by first creating a route provider with intermediaries from Buyer
+  -- to Seller)
+  let
+    paths = Map.fromList
+      [ ("AAPL", Hierarchy with rootCustodian = csd; pathsToRootCustodian = [[seller], [buyer]])
+      ]
+  routeProviderCid <- toInterfaceContractId @RouteProvider.I <$> submit seller do
+    createCmd IntermediatedStatic with provider = seller; paths; observers = mempty
+  routedSteps <- submit seller do
+    exerciseCmd routeProviderCid RouteProvider.Discover with
+      discoverors = Set.singleton seller; contextId = None; steps
+
+  -- Instruct settlement
+  settlementFactoryCid <- toInterfaceContractId @SettlementFactory.I <$> submit seller do
+    createCmd Settlement.Factory with provider = seller; observers = mempty
+  (equityBatchCid, [equityInstructionCid]) <-
+    submitMulti [seller] [] do
+      exerciseCmd settlementFactoryCid SettlementFactory.Instruct with
+        instructor = seller
+        consenters = Set.empty
+        settlers = Set.fromList [seller, trading_provider]
+        id = Id "APPL 1000@200.0USD"; description = "Equity Leg"; contextId = None; routedSteps
+        settlementTime = Some settlementTime
+
+  -- Allocate instructions
+  (equityInstructionCid, _) <- submit seller do
+    exerciseCmd equityInstructionCid
+      Instruction.Allocate with actors = Set.singleton seller; allocation = Pledge equityHoldingCid
+
+  -- Approve instructions
+  equityInstructionCid <- submit buyer do
+    exerciseCmd equityInstructionCid
+      Instruction.Approve with
+        actors = Set.singleton buyer; approval = TakeDelivery buyerSecurityAccount
+
+  -- Create a BatchAllocation
+  cashAllocation <- submit seller do
+    createCmd BatchAllocation with
+      batchCid = equityBatchCid
+      allocation = sellerAlloc
+      holdingCids = [coerceInterfaceContractId @HoldingV1.Holding equityHoldingCid]
+      meta = emptyMetadata
+
+  -- BACK TO STANDARDS
+  -- Now do settlement via OTC trade.
+
+  -- assume the time given to prepare has passed
+  passTime (hours 1)
+
+  -- provider runs automation that completes the settlement
+  let otcTradeRef = (view $ toInterface @AllocationRequest otcTrade).settlement.settlementRef
+  allocations <- appBackendListAllocations trading_provider otcTradeRef
+  TextMap.size allocations === 2
+
+  let allocationsWithContext = fmap (\(allocCid, _) -> (allocCid, ExtraArgs with context = emptyChoiceContext; meta = emptyMetadata)) allocations
+  results <- submitMulti [trading_provider] [publicParty] do
+    exerciseCmd otcTradeCid OTCTrade_Settle with
+      allocationsWithContext
+
+
+  -- AssertState as in the original example
+  -- Need to do a bit of unwrapping / coercion to go back from standards
+  -- to Daml Finance.
+
+  let
+    cashHoldings = (fromSome $ TextMap.lookup "cash" results).receiverHoldingCids
+    equityHoldings = (fromSome $ TextMap.lookup "equity" results).receiverHoldingCids
+  bankHoldings <- queryInterface @Holding.I bank
+  let
+    [(bankCashHoldingCid, _)] = filter (\(cid, Some holding) -> holding.account.owner == bank) bankHoldings
+    [sellerCashHoldingCid] = fmap (coerceInterfaceContractId @Holding.I) cashHoldings
+    [equityHoldingCid] = fmap (coerceInterfaceContractId @Holding.I) equityHoldings
+
+  let ts = [(buyer, equityHoldingCid), (bank, bankCashHoldingCid), (seller, sellerCashHoldingCid)]
+  Holding.verifyOwnerOfHolding ts
+  Holding.verifyNoObservers ts
+
+  pure ()
+
+setupParties : Script TestParties
+setupParties = do
+  [buyer, seller, cb, csd, bank, issuer, publicParty] <- createParties
+    ["Buyer", "Seller", "CentralBank", "CentralSecurityDepository", "Bank", "Issuer", "PublicParty"]
+  pure TestParties with buyer; seller; cb; csd; bank; issuer; publicParty
+
+
+-- utilities
+------------
+
+-- | List all allocations matching a particular settlement reference, sorted by their tradeLeg id.
+-- This function would be run on the trading app provider's backend as part of an automation loop.
+appBackendListAllocations : Party -> AllocationV1.Reference -> Script (TextMap.TextMap (ContractId AllocationV1.Allocation, AllocationV1.AllocationView))
+appBackendListAllocations p ref = do
+  allocs <- queryInterface @AllocationV1.Allocation p
+  let matchingAllocs = do
+        (cid, Some fundedAllocation) <- allocs
+        guard (fundedAllocation.allocation.settlement.settlementRef == ref)
+        pure (fundedAllocation.allocation.transferLegId, (cid, fundedAllocation))
+  pure $ TextMap.fromList matchingAllocs

--- a/src/test/daml/Splice/Testing/Apps/TradingApp.daml
+++ b/src/test/daml/Splice/Testing/Apps/TradingApp.daml
@@ -1,0 +1,205 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- | An example of how to build an OTC trading app for multi-leg standard token trades.
+--
+-- Used as part of the testing infrastructure to test the DvP workflows based on the token standard.
+module Splice.Testing.Apps.TradingApp where
+
+import DA.Foldable qualified as F
+import DA.Optional (fromOptional, fromSomeNote)
+import DA.Set as Set
+import DA.TextMap as TextMap
+import DA.Traversable qualified as Traversable
+
+import Splice.Api.Token.MetadataV1 as Api.Token.MetadataV1
+import Splice.Api.Token.AllocationV1 as Api.Token.AllocationV1
+import Splice.Api.Token.AllocationRequestV1
+
+
+template OTCTradeProposal with
+    venue : Party
+    tradeCid : Optional (ContractId OTCTradeProposal) -- Tracking-id for the trade being proposed. Set to None for new trades.
+    transferLegs : TextMap Api.Token.AllocationV1.TransferLeg
+    approvers : [Party] -- ^ Parties that have approved the proposal
+  where
+    signatory approvers
+    observer venue, tradingParties transferLegs
+
+    -- This is test code, so we don't care about the contention here.
+    -- Moreover, likely the number of trading parties is going to be low anyways.
+    choice OTCTradeProposal_Accept : ContractId OTCTradeProposal
+      with
+        approver : Party
+      controller approver
+      do
+        let newApprovers = approver :: approvers
+        let traders = tradingParties transferLegs
+        require "Approver is a trading party" (approver `Set.member` traders)
+        require "Approver is new" (approver `notElem` approvers)
+        create this with
+          approvers = newApprovers
+          tradeCid = Some (fromOptional self tradeCid)
+
+    choice OTCTradeProposal_Reject : ()
+      with
+        trader : Party
+      controller trader
+      do require "Trader is a trading party" (trader `Set.member` tradingParties transferLegs)
+
+    choice OTCTradeProposal_InitiateSettlement : ContractId OTCTrade
+      with
+        prepareUntil : Time
+        settleBefore : Time
+      controller venue
+      do
+        require "All trading parties have approved" (Set.fromList approvers == tradingParties transferLegs)
+        now <- getTime
+        require "Preparation time has not passed" (now < prepareUntil)
+        require "Preparation time before settlement time" (prepareUntil < settleBefore)
+        create OTCTrade with
+          venue
+          transferLegs
+          tradeCid = fromOptional self tradeCid
+          createdAt = now
+          prepareUntil
+          settleBefore
+
+tradeAllocations
+  : SettlementInfo -> TextMap Api.Token.AllocationV1.TransferLeg
+  -> TextMap AllocationSpecification
+tradeAllocations settlementInfo transferLegs =
+  TextMap.fromList $ do
+    (transferLegId, transferLeg) <- TextMap.toList transferLegs
+    let spec = AllocationSpecification with
+          settlement = settlementInfo
+          transferLegId
+          transferLeg
+    pure (transferLegId, spec)
+
+template OTCTrade
+  with
+    venue : Party
+    transferLegs : TextMap Api.Token.AllocationV1.TransferLeg
+    tradeCid : ContractId OTCTradeProposal
+    createdAt : Time
+    prepareUntil : Time
+    settleBefore : Time
+  where
+    signatory venue, tradingParties transferLegs
+
+    choice OTCTrade_Settle : TextMap Allocation_ExecuteTransferResult
+      with
+        allocationsWithContext : TextMap (ContractId Allocation, ExtraArgs)
+      controller venue
+      do
+        -- check timing constraints
+        now <- getTime
+        require "Settlement deadline has not passed" (now < settleBefore)
+        -- validate and execute transferLegs
+        let settlementInfo = SettlementInfo with
+              executor = venue
+              requestedAt = createdAt
+              settlementRef = makeTradeRef tradeCid
+              allocateBefore = prepareUntil
+              settleBefore
+              meta = emptyMetadata
+        let expectedAllocations = tradeAllocations settlementInfo transferLegs
+        let mergedMaps = zipTextMaps allocationsWithContext expectedAllocations
+        forTextMapWithKey mergedMaps \legId (optAllocWithContext,  optExpectedAlloc) -> do
+          let (allocCid, extraArgs) = fromSomeNote ("Allocation cid and extra arg is missing for leg " <> legId) optAllocWithContext
+          let expectedAlloc = fromSomeNote ("Allocation with context provided for unexpected leg " <> legId) optExpectedAlloc
+          -- fetch and validate the allocation instruction
+          instr <- fetch @Allocation allocCid
+          let instrView = view @Allocation instr
+          require "Allocation matches expected allocation" (instrView.allocation == expectedAlloc)
+          exercise allocCid (Allocation_ExecuteTransfer extraArgs)
+
+
+    -- NOTE: this choice is an approximation to what a real app would do.
+    -- As it stands, the venue can't cancel allocations that come right after
+    -- the first cancellation.  A better approach would be to leave a marker
+    -- contract in place until the `settleBefore` time, so that the venue
+    -- retains the ability to cancel the allocations that are created.
+    choice OTCTrade_Cancel : TextMap (Optional Allocation_CancelResult)
+      with
+        allocationsWithContext : TextMap (ContractId Allocation, ExtraArgs)
+      controller venue
+      do
+        -- validate and cancel transferLegs
+        let settlementInfo = SettlementInfo with
+              executor = venue
+              requestedAt = createdAt
+              settlementRef = makeTradeRef tradeCid
+              allocateBefore = prepareUntil
+              settleBefore
+              meta = emptyMetadata
+        let expectedAllocations = tradeAllocations settlementInfo transferLegs
+        let mergedMaps = zipTextMaps allocationsWithContext expectedAllocations
+          -- fetch and validate the allocation instruction
+        forTextMapWithKey mergedMaps \legId (optAllocWithContext,  optExpectedAlloc) ->
+          -- skip the leg if there is no matching allocation to cancel
+          Traversable.forA optAllocWithContext $ \(allocCid, extraArgs) -> do
+            -- fetch and validate the allocation instruction
+            let expectedAlloc = fromSomeNote ("Allocation with context provided for unexpected leg " <> legId) optExpectedAlloc
+            instr <- fetch @Allocation allocCid
+            let instrView = view @Allocation instr
+            require "Allocation matches expected allocation" (instrView.allocation == expectedAlloc)
+            exercise allocCid (Allocation_Cancel extraArgs)
+
+
+    interface instance AllocationRequest for OTCTrade where
+      view = AllocationRequestView with
+        settlement = SettlementInfo with
+          executor = venue
+          requestedAt = createdAt
+          settlementRef = makeTradeRef tradeCid
+          allocateBefore = prepareUntil
+          settleBefore
+          meta = emptyMetadata
+        transferLegs
+        meta = emptyMetadata
+
+      allocationRequest_RejectImpl _self AllocationRequest_Reject{..} = do
+        -- Note: this corresponds to signalling early that one is going to fail to deliver one's assets.
+        -- A real trading app will likely demand punitive charges for this.
+        require "Actor is a sender" (F.any (\leg -> actor == leg.sender) transferLegs)
+        pure ChoiceExecutionMetadata with meta = emptyMetadata
+
+      allocationRequest_WithdrawImpl _self _extraArgs =
+        -- just archiving the trade is enough
+        pure ChoiceExecutionMetadata with meta = emptyMetadata
+
+
+tradingParties : TextMap Api.Token.AllocationV1.TransferLeg -> Set.Set Party
+tradingParties = F.foldl (\acc t -> Set.insert t.sender (Set.insert t.receiver acc)) Set.empty
+
+-- | Check whether a required condition is true. If it's not, abort the
+-- transaction with a message saying that the requirement was not met.
+require : CanAssert m => Text -> Bool -> m ()
+require msg invariant =
+  assertMsg ("The requirement '" <> msg <> "' was not met.") invariant
+
+makeTradeRef : ContractId OTCTradeProposal -> Api.Token.AllocationV1.Reference
+makeTradeRef tradeCid = Api.Token.AllocationV1.Reference with
+  id = "OTCTradeProposal" -- set to the name of the template to simplify debugging
+  cid = Some (coerceContractId tradeCid)
+
+
+-- Additional text map utilities
+--------------------------------
+
+zipTextMaps : TextMap a -> TextMap b -> TextMap (Optional a, Optional b)
+zipTextMaps m1 m2 =
+  TextMap.merge
+    (\_ v1 -> Some (Some v1, None))
+    (\_ v2 -> Some (None, Some v2))
+    (\_ v1 v2 -> Some (Some v1, Some v2))
+    m1
+    m2
+
+forTextMapWithKey : Applicative f => TextMap a -> (Text -> a -> f b) -> f (TextMap b)
+forTextMapWithKey m f =
+    TextMap.fromList <$> mapA f' (TextMap.toList m)
+  where
+    f' (k, v) = (k,) <$> f k v

--- a/src/test/daml/Splice/Testing/TokenStandard/WalletClient.daml
+++ b/src/test/daml/Splice/Testing/TokenStandard/WalletClient.daml
@@ -1,0 +1,133 @@
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- | Daml script test utilities for simulating the actions of wallet client
+-- based on the token standard.
+--
+-- NOTE: there are likely more functions that could/should be added to this module. PRs welcome.
+module Splice.Testing.TokenStandard.WalletClient
+  (
+    -- * Reading/checking holdings
+    listHoldings,
+    listHoldingCids,
+    listLockedHoldings,
+
+    checkHoldingWithAmountExists,
+    checkBalanceBounds,
+    checkBalance,
+    checkBalanceApprox,
+    checkHolding,
+    checkHoldingBounds,
+    checkHoldingApprox,
+
+    -- * Reading transfer instructions
+    listTransferOffers,
+
+    -- * Reading allocations
+    listRequestedAllocations,
+
+  ) where
+
+import DA.Action (unless)
+import DA.Optional (isSome)
+import DA.TextMap qualified as TextMap
+
+import Splice.Api.Token.AllocationV1 as Api.Token.AllocationV1
+import Splice.Api.Token.TransferInstructionV1
+import Splice.Api.Token.AllocationRequestV1
+import Splice.Api.Token.HoldingV1 as Api.Token.HoldingV1
+
+import Daml.Script
+
+-- | List the hodlings of a party of a specific instrument.
+listHoldings : Party -> InstrumentId -> Script [(ContractId Holding, HoldingView)]
+listHoldings p instrumentId = do
+  holdings <- queryInterface @Holding p
+  let instrumendHoldings = do
+        (cid, Some holding) <- holdings
+        guard (holding.instrumentId == instrumentId)
+        guard (holding.owner == p)
+        pure (cid, holding)
+  pure instrumendHoldings
+
+listLockedHoldings : Party -> InstrumentId -> Script [(ContractId Holding, HoldingView)]
+listLockedHoldings p instrumentId =
+  filter (\(_, holding) -> isSome (holding.lock)) <$> listHoldings p instrumentId
+
+-- | List the cids of the hodlings of a party of a specific instrument.
+listHoldingCids : Party -> InstrumentId -> Script [ContractId Holding]
+listHoldingCids p instrumentId = (map fst) <$> listHoldings p instrumentId
+
+-- | Check that a holding with a specific amount exists for the given owner.
+checkHoldingWithAmountExists : Party -> InstrumentId -> Decimal -> Script ()
+checkHoldingWithAmountExists p instrumentId amount = do
+  holdings <- map snd <$> listHoldings p instrumentId
+  unless (any (\holding -> holding.amount == amount) holdings) $
+    fail (show p <> " is missing holding of value " <> show amount <> " in " <> show holdings)
+
+-- | Check the bounds on a party's total balance of all holdings of the given instrument.
+checkBalanceBounds : Party -> InstrumentId -> (Decimal, Decimal) -> Script ()
+checkBalanceBounds p instrumentId (lb, ub) = do
+  holdings <- listHoldings p instrumentId
+  let total = sum $ map (._2.amount) holdings
+  unless (total >= lb && total <= ub) $ fail $
+    "Wallet " <> show p <> ": balance of " <> show total <> " for " <> show instrumentId <>
+    " is not within the expected range [" <> show lb <> ", " <> show ub <> "]"
+
+-- | Check the exact value of on an individual holding's amount.
+checkHolding : Party -> ContractId Holding -> Decimal -> Script ()
+checkHolding p holdingCid amount = checkHoldingBounds p holdingCid (amount, amount)
+
+-- | Check the bounds on an individual holding's amount.
+checkHoldingBounds : Party -> ContractId Holding -> (Decimal, Decimal) -> Script ()
+checkHoldingBounds p holdingCid (lb, ub) = do
+  holdingO <- queryInterfaceContractId p holdingCid
+  debug holdingO
+  let holding = case holdingO of
+        None -> error $ "Holding " <> show holdingCid <> " was not found"
+        Some holding -> holding
+  unless (holding.amount >= lb && holding.amount <= ub) $ fail $
+    "Holding " <> show holding <>
+    " is not within the expected range [" <> show lb <> ", " <> show ub <> "]"
+
+-- | Check the approximate value (+/- 1.0) a party's total balance of all holdings of the given instrument.
+checkBalanceApprox : Party -> InstrumentId -> Decimal -> Script ()
+checkBalanceApprox p instrumentId approximateBalance =
+  checkBalanceBounds p instrumentId (approximateBalance - 1.0, approximateBalance + 1.0)
+
+-- | Check the approximate (+/- 1.0) amount of an individual holding.
+checkHoldingApprox : Party -> ContractId Holding -> Decimal -> Script ()
+checkHoldingApprox p holdingCid approximateAmount = checkHoldingBounds p holdingCid (approximateAmount - 1.0, approximateAmount + 1.0)
+
+-- | Check the exact value a party's total balance of all holdings of the given instrument.
+checkBalance : Party -> InstrumentId -> Decimal -> Script ()
+checkBalance p instrumentId balance =
+  checkBalanceBounds p instrumentId (balance, balance)
+
+-- | List pending transfer offers (as sender or receiver)
+listTransferOffers : Party -> InstrumentId -> Script [(ContractId TransferInstruction, TransferInstructionView)]
+listTransferOffers p instrumentId = do
+  instrs <- queryInterface @TransferInstruction p
+  let pendingOffers = do
+        (cid, Some instr) <- instrs
+        guard (instr.transfer.instrumentId == instrumentId)
+        guard (instr.status == TransferPendingReceiverAcceptance)
+        guard (p == instr.transfer.sender || p == instr.transfer.receiver)
+        pure (cid, instr)
+  pure pendingOffers
+
+-- | List all allocations requested from the owner for a specific instrument.
+listRequestedAllocations : Party -> InstrumentId -> Script [AllocationSpecification]
+listRequestedAllocations p instrumentId = do
+  reqs <- queryInterface @AllocationRequest p
+  trace reqs $ pure ()
+  let amuletAllocs = do
+        (_reqCid, Some req) <- reqs
+        (tfId, tf) <- TextMap.toList req.transferLegs
+        guard (tf.instrumentId == instrumentId)
+        guard (p == tf.sender)
+        pure AllocationSpecification with
+          settlement = req.settlement
+          transferLegId = tfId
+          transferLeg = tf
+  pure amuletAllocs


### PR DESCRIPTION
- Copied and pasted token standard and OTC Trade example app in the "Splice" folders.
- Implemented standards holding on all the Daml Finance holdings (basically mapping DF.Holding.I + DF.Lockable.I to CN20.Holding)
- Implemented a `BatchAllocation` that wraps a `Batch.I` into a Standards `Allocation`.
- Rewrote the `BatchWithIntermediaries` test to not use a single DF settlement, but to
  - Agree DvP via OTC trade
  - Construct cash and equities settlement batches separately
  - Wrap them up as allocations
  - Settle atomically via OTC trade

All very happy path and PoC grade. The BatchAllocation misses a whole bunch of validations, for example.
I didn't bother to implement AllocationInstructions or similar - this is purely showing how to settle Daml Finance assets in a trading app built against the standards.






